### PR TITLE
Decouple CMS from Hugo by introducing build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Directory: `/src/static-website/`
 
 - See [docs/environment_variables.md](docs/environment_variables.md) for an overview of all environment variables that can be set in the `.env` file.
 - See [docs/roles_and_permissions.md](docs/roles_and_permissions.md) for an overview of all roles and permissions and the location where they are configured.
+- See [docs/static_website_hugo.md](docs/static_website_hugo.md) for detailed information about the Hugo static website publishing system.
 
 ## Getting started
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -119,8 +119,11 @@ The following environment variables are used to configure the application in `sr
 
 **STATIC:**
 
-- `STATIC_WEBSITE_BASE_URL`
-- `STATIC_WEBSITE_BUILD_AFTER_HOOK`
+- `STATIC_WEBSITE_BASE_URL` - Base URL for the static website
+- `STATIC_WEBSITE_BUILD_SCRIPT` - Path to build script (default: `<project-root>/static-website/build.sh`)
+- `STATIC_WEBSITE_THEME` - Hugo theme to use (default: `rijkshuisstijl`)
+- `HUGO_OUTPUT_DIR` - Where build script writes output (default: `./public` in build script)
+- `STATIC_WEBSITE_BUILD_AFTER_HOOK` - **DEPRECATED:** Use build script for post-build actions
 
 **QUEUE:**
 

--- a/docs/static_website_hugo.md
+++ b/docs/static_website_hugo.md
@@ -1,0 +1,203 @@
+# Static Website Publishing with Hugo
+
+## Overview
+
+The OpenVWR system automatically generates and publishes a static website using [Hugo](https://gohugo.io/). The CMS contains the source data for processing records (verwerkingen), which are converted to static HTML files for public access.
+
+## Architecture
+
+The static website publishing process consists of three chained jobs that execute sequentially:
+
+1. **ContentGeneratorJob** - Generates Hugo-compatible content files (JSON/Markdown) from CMS data
+2. **HugoWebsiteGeneratorJob** - Runs Hugo to build static HTML from the content files
+3. **StaticWebsiteCheckJob** - Verifies the deployment succeeded
+
+These jobs are orchestrated by `BuildHandler.php:24` and triggered automatically when relevant data changes in the CMS.
+
+## How It Works
+
+### Step 1: Content Generation
+
+The CMS data is converted to Hugo-compatible formats:
+- Content files are written to the `static-content/` folder
+- Files are managed through `HugoFilesystem.php`
+- Supports both JSON and Markdown formats
+
+### Step 2: Hugo Build Process
+
+The CMS calls the build script `src/static-website/build.sh` with the following parameters:
+
+```bash
+./build.sh <content-path> <base-url> [theme]
+```
+
+The build script determines where to write output files (via `HUGO_OUTPUT_DIR` env var or defaults to `./public`), then executes Hugo:
+
+```bash
+hugo -c <content-path> -d <destination-path> -b <base-url> -t <theme> --cleanDestinationDir
+```
+
+**Script Parameters:**
+1. Content directory path (from CMS content storage)
+2. Base URL for the site (from `STATIC_WEBSITE_BASE_URL`)
+3. Theme to use (from `STATIC_WEBSITE_THEME`, default: `rijkshuisstijl`)
+
+**Note:** The destination path is determined by the build script itself, not passed from the CMS. This can be configured via the `HUGO_OUTPUT_DIR` environment variable in the build script's environment.
+
+**Hugo Project Structure:**
+- Location: `/src/static-website/`
+- Build script: `build.sh`
+- Configuration: `hugo.yaml`
+- Theme: `themes/rijkshuisstijl/` (default)
+- Assets: `assets/css/hugo-pagination.scss`
+
+### Step 3: Deployment Check
+
+After the build completes:
+- The build script can optionally perform post-build actions (deployment, optimization, etc.)
+- **Deprecated**: Legacy hook command can still execute (configured via `STATIC_WEBSITE_BUILD_AFTER_HOOK`)
+- Deployment verification jobs are scheduled at intervals: 1, 2, 3, 5, and 10 minutes
+- Health checks verify the site is accessible at the configured URL
+
+## Configuration
+
+### Environment Variables
+
+**Required:**
+- `STATIC_WEBSITE_BASE_URL` - Base URL for the static website (e.g., `https://example.com`)
+
+**Optional:**
+- `STATIC_WEBSITE_BUILD_SCRIPT` - Path to the build script (default: `<project-root>/static-website/build.sh`)
+- `STATIC_WEBSITE_THEME` - Theme to use for the static website (default: `rijkshuisstijl`)
+- `STATIC_WEBSITE_CHECK_BASE_URL` - URL to check for deployment verification (defaults to `STATIC_WEBSITE_BASE_URL`)
+- `STATIC_WEBSITE_CHECK_PROXY` - Proxy to use for deployment checks
+- `STATIC_WEBSITE_GENERATOR` - Generator to use (default: `hugo`, options: `hugo`, `fake`)
+- `STATIC_WEBSITE_FILESYSTEM` - Filesystem driver to use (default: `hugo`, options: `hugo`, `fake`)
+- `FILESYSTEM_STATIC_WEBSITE_ROOT` - Root directory for static website files (default: `storage/app/static-website`)
+
+**Deprecated:**
+- `STATIC_WEBSITE_BUILD_AFTER_HOOK` - Command to run after successful build. Use the build script for post-build actions instead.
+
+### Config File
+
+The static website is configured in `src/cms/config/static-website.php`:
+
+```php
+return [
+    'static_website_generator' => env('STATIC_WEBSITE_GENERATOR', 'hugo'),
+    'hugo_filesystem_disk' => 'static-website',
+    'hugo_content_folder' => 'static-content',
+    'static_website_folder' => 'static-website',
+    'build_script_path' => env('STATIC_WEBSITE_BUILD_SCRIPT', base_path('static-website/build.sh')),
+    'theme' => env('STATIC_WEBSITE_THEME', 'rijkshuisstijl'),
+    'base_url' => env('STATIC_WEBSITE_BASE_URL'),
+    'plan-check-job-delays' => [1, 2, 3, 5, 10], // minutes
+];
+```
+
+## Manual Rebuild
+
+To manually trigger a static website rebuild:
+
+```bash
+php artisan static-website:refresh
+```
+
+This command should be run:
+- After deployment to production
+- When content changes aren't automatically detected
+- After configuration changes
+
+## System Requirements
+
+**Hugo Requirements:**
+- Hugo **extended** version 0.121.1 or higher
+- Installation: https://gohugo.io/installation/
+
+**Dart Sass Requirements:**
+- Dart Sass version 1.69.5 or higher
+- Installation: https://sass-lang.com/install/
+
+Both tools must be available in the system PATH for the build process to work.
+
+## Deployment Workflow
+
+### Automatic Deployment
+
+1. Content changes in CMS trigger a rebuild event
+2. `BuildHandler` chains the three jobs
+3. Content is generated from database
+4. Hugo builds static HTML files
+5. Post-build hook executes (if configured)
+6. Deployment checks verify accessibility
+
+### Customizing the Build Script
+
+The build script at `src/static-website/build.sh` can be customized to add post-build actions:
+
+```bash
+#!/bin/bash
+set -e
+
+# ... (Hugo build happens here) ...
+
+# Add your custom post-build steps:
+# - Copy files to a web server
+# - Sync to CDN/cloud storage
+# - Trigger cache invalidation
+# - Run additional deployment scripts
+
+# Example: Deploy to remote server
+# rsync -av "${DESTINATION_PATH}/" user@webserver:/var/www/html/
+
+# Example: Upload to S3
+# aws s3 sync "${DESTINATION_PATH}/" s3://my-bucket/ --delete
+
+exit 0
+```
+
+Alternatively, you can create your own build script and set `STATIC_WEBSITE_BUILD_SCRIPT` to point to it.
+
+## File Locations
+
+**Hugo Project:**
+- Source: `/src/static-website/`
+- Config: `/src/static-website/hugo.yaml`
+- Theme: `/src/static-website/themes/rijkshuisstijl/`
+
+**Generated Content:**
+- Content files: `storage/app/static-content/`
+- Built website: `storage/app/static-website/`
+
+**CMS Code:**
+- Job: `src/cms/app/Jobs/StaticWebsite/HugoWebsiteGeneratorJob.php`
+- Generator: `src/cms/app/Services/StaticWebsite/HugoStaticWebsiteGenerator.php`
+- Filesystem: `src/cms/app/Services/StaticWebsite/HugoFilesystem.php`
+- Build Handler: `src/cms/app/Listeners/StaticWebsite/BuildHandler.php`
+
+## Troubleshooting
+
+### Build Failures
+
+If the Hugo build fails:
+1. Check Hugo is installed and accessible: `hugo version`
+2. Check Dart Sass is installed: `sass --version`
+3. Review logs in Laravel log files
+4. Verify `STATIC_WEBSITE_BASE_URL` is set correctly
+5. Check file permissions on content and destination directories
+
+### Deployment Verification Issues
+
+If deployment checks fail:
+- Verify the website is accessible at `STATIC_WEBSITE_CHECK_BASE_URL`
+- Check proxy configuration if using `STATIC_WEBSITE_CHECK_PROXY`
+- Review scheduled job logs for check results
+
+### Queue Workers
+
+The build process runs through Laravel queues. Ensure queue workers are running:
+```bash
+php artisan queue:work --queue=high,default,low
+```
+
+Remember to restart workers after deployments to load new code.

--- a/src/cms/app/Providers/StaticWebsiteServiceProvider.php
+++ b/src/cms/app/Providers/StaticWebsiteServiceProvider.php
@@ -59,14 +59,14 @@ class StaticWebsiteServiceProvider extends ServiceProvider
             ->needs('$baseUrl')
             ->giveConfig('static-website.base_url');
         $this->app->when(HugoStaticWebsiteGenerator::class)
-            ->needs('$hugoProjectPath')
-            ->giveConfig('static-website.hugo_project_path');
-        $this->app->when(HugoStaticWebsiteGenerator::class)
             ->needs('$hugoContentFolder')
             ->giveConfig('static-website.hugo_content_folder');
         $this->app->when(HugoStaticWebsiteGenerator::class)
-            ->needs('$staticWebsiteFolder')
-            ->giveConfig('static-website.static_website_folder');
+            ->needs('$buildScriptPath')
+            ->giveConfig('static-website.build_script_path');
+        $this->app->when(HugoStaticWebsiteGenerator::class)
+            ->needs('$theme')
+            ->giveConfig('static-website.theme');
 
         $this->app->when(AfterBuildHandler::class)
             ->needs('$afterBuildHook')

--- a/src/cms/app/Services/StaticWebsite/HugoStaticWebsiteGenerator.php
+++ b/src/cms/app/Services/StaticWebsite/HugoStaticWebsiteGenerator.php
@@ -20,8 +20,8 @@ class HugoStaticWebsiteGenerator implements StaticWebsiteGenerator
         private readonly LoggerInterface $logger,
         private readonly string $baseUrl,
         private readonly string $hugoContentFolder,
-        private readonly string $hugoProjectPath,
-        private readonly string $staticWebsiteFolder,
+        private readonly string $buildScriptPath,
+        private readonly string $theme,
     ) {
     }
 
@@ -31,17 +31,16 @@ class HugoStaticWebsiteGenerator implements StaticWebsiteGenerator
     public function generate(): void
     {
         $sourcePath = $this->filesystem->path($this->hugoContentFolder);
-        $destinationPath = $this->filesystem->path($this->staticWebsiteFolder);
 
         AdminLog::log('Generating static website files', [
             'baseUrl' => $this->baseUrl,
-            'hugoProjectPath' => $this->hugoProjectPath,
+            'buildScriptPath' => $this->buildScriptPath,
+            'theme' => $this->theme,
             'sourcePath' => $sourcePath,
-            'destinationPath' => $destinationPath,
         ]);
 
         try {
-            $this->generateStaticWebsite($sourcePath, $destinationPath);
+            $this->generateStaticWebsite($sourcePath);
         } catch (ProcessFailedException $processFailedException) {
             $message = sprintf('build process failed: %s', $processFailedException->getMessage());
             $this->logger->error($message, ['output' => $processFailedException->result->output()]);
@@ -52,20 +51,37 @@ class HugoStaticWebsiteGenerator implements StaticWebsiteGenerator
         AfterBuildEvent::dispatch();
     }
 
-    private function generateStaticWebsite(string $sourcePath, string $destinationPath): void
+    private function generateStaticWebsite(string $sourcePath): void
     {
-        $hugoCommand = sprintf(
-            'hugo -c %s -d %s -b %s -t rijkshuisstijl --cleanDestinationDir',
-            $sourcePath,
-            $destinationPath,
-            $this->baseUrl,
+        // Validate build script exists and is executable
+        if (!file_exists($this->buildScriptPath)) {
+            throw new BuildException(sprintf('Build script not found: %s', $this->buildScriptPath));
+        }
+
+        if (!is_executable($this->buildScriptPath)) {
+            throw new BuildException(sprintf('Build script is not executable: %s', $this->buildScriptPath));
+        }
+
+        // Build command with properly escaped arguments
+        // Note: destination path is determined by the build script itself
+        $command = sprintf(
+            '%s %s %s %s',
+            escapeshellarg($this->buildScriptPath),
+            escapeshellarg($sourcePath),
+            escapeshellarg($this->baseUrl),
+            escapeshellarg($this->theme)
         );
 
-        $result = Process::path($this->hugoProjectPath)
-            ->run($hugoCommand)
+        $this->logger->debug('Executing build script', [
+            'buildScript' => $this->buildScriptPath,
+            'command' => $command,
+        ]);
+
+        $result = Process::path(dirname($this->buildScriptPath))
+            ->run($command)
             ->throw();
 
-        $this->logger->debug('Generating static website files: Success!', [
+        $this->logger->debug('Build script executed successfully', [
             'output' => $result->output(),
         ]);
     }

--- a/src/cms/config/static-website.php
+++ b/src/cms/config/static-website.php
@@ -15,19 +15,25 @@ return [
     // the folder on the disk, used for static-content
     'hugo_content_folder' => 'static-content',
 
-    // the folder on the disk, used for the static website
-    'static_website_folder' => 'static-website',
+    // Path to the build script that generates the static website
+    // The build script determines where output files are written
+    'build_script_path' => env('STATIC_WEBSITE_BUILD_SCRIPT', base_path('static-website/build.sh')),
 
-    // This is where the hugo executable, config and templates are stored that are used to generate the static website
-    'hugo_project_path' => base_path('static-website'),
+    // Theme to use for the static website
+    'theme' => env('STATIC_WEBSITE_THEME', 'rijkshuisstijl'),
 
     // the base url for the static website
     'base_url' => env('STATIC_WEBSITE_BASE_URL'),
     'check_base_url' => env('STATIC_WEBSITE_CHECK_BASE_URL', env('STATIC_WEBSITE_BASE_URL')),
     'check_proxy' => env('STATIC_WEBSITE_CHECK_PROXY'),
 
+    // DEPRECATED: Use build script for post-build actions instead
     // the command to be executed after a successful build of the website
     'build_after_hook' => env('STATIC_WEBSITE_BUILD_AFTER_HOOK'),
+
+    // DEPRECATED: Build script determines the project path
+    // This is where the hugo executable, config and templates are stored that are used to generate the static website
+    'hugo_project_path' => base_path('static-website'),
 
     // plan jobs to check deployments after x minutes
     'plan-check-job-delays' => [1, 2, 3, 5, 10],

--- a/src/cms/tests/Feature/Services/StaticWebsite/HugoStaticWebsiteGeneratorTest.php
+++ b/src/cms/tests/Feature/Services/StaticWebsite/HugoStaticWebsiteGeneratorTest.php
@@ -10,17 +10,19 @@ use Illuminate\Support\Facades\Storage;
 use Symfony\Component\Console\Command\Command;
 use Tests\Helpers\ConfigTestHelper;
 
-it('can run the hugo command', function (): void {
+it('can run the build script', function (): void {
     $filesystemDiskStaticWebsiteRoot = fake()->slug(1);
     $sourceFolder = fake()->slug(1);
-    $destinationFolder = fake()->slug(1);
     $baseUrl = fake()->url();
+    $buildScriptPath = base_path('static-website/build.sh');
+    $theme = 'rijkshuisstijl';
 
     ConfigTestHelper::set('filesystems.disks.static-website.root', $filesystemDiskStaticWebsiteRoot);
     ConfigTestHelper::set('static-website.hugo_content_folder', $sourceFolder);
-    ConfigTestHelper::set('static-website.static_website_folder', $destinationFolder);
     ConfigTestHelper::set('static-website.hugo_filesystem_disk', 'static-website');
     ConfigTestHelper::set('static-website.base_url', $baseUrl);
+    ConfigTestHelper::set('static-website.build_script_path', $buildScriptPath);
+    ConfigTestHelper::set('static-website.theme', $theme);
 
     $process = Process::fake();
 
@@ -29,15 +31,18 @@ it('can run the hugo command', function (): void {
     $process->assertRan(
         static function (PendingProcess $pendingProcess) use (
             $sourceFolder,
-            $destinationFolder,
             $baseUrl,
+            $buildScriptPath,
+            $theme,
         ): bool {
-            return $pendingProcess->command === sprintf(
-                'hugo -c %s -d %s -b %s -t rijkshuisstijl --cleanDestinationDir',
-                Storage::disk('static-website')->path($sourceFolder),
-                Storage::disk('static-website')->path($destinationFolder),
-                $baseUrl,
+            $expectedCommand = sprintf(
+                '%s %s %s %s',
+                escapeshellarg($buildScriptPath),
+                escapeshellarg(Storage::disk('static-website')->path($sourceFolder)),
+                escapeshellarg($baseUrl),
+                escapeshellarg($theme)
             );
+            return $pendingProcess->command === $expectedCommand;
         },
     );
 });

--- a/src/static-website/build.sh
+++ b/src/static-website/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+set -e
+
+# Static Website Build Script
+# This script is called by the CMS to build the static website using Hugo.
+# It decouples the CMS from the specific static site generator implementation.
+
+CONTENT_PATH="${1}"
+BASE_URL="${2}"
+THEME="${3:-rijkshuisstijl}"
+
+# Validate required parameters
+if [ -z "${CONTENT_PATH}" ] || [ -z "${BASE_URL}" ]; then
+    echo "Error: Missing required parameters"
+    echo "Usage: $0 <content-path> <base-url> [theme]"
+    exit 1
+fi
+
+# Get the directory where this script is located (the Hugo project root)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Destination is determined by the build script, not the CMS
+# This can be configured via environment variable or hardcoded
+DESTINATION_PATH="${HUGO_OUTPUT_DIR:-${SCRIPT_DIR}/public}"
+
+echo "Building static website with Hugo..."
+echo "  Content path: ${CONTENT_PATH}"
+echo "  Destination: ${DESTINATION_PATH}"
+echo "  Base URL: ${BASE_URL}"
+echo "  Theme: ${THEME}"
+echo "  Hugo project: ${SCRIPT_DIR}"
+
+# Run Hugo build from the Hugo project directory
+cd "${SCRIPT_DIR}"
+
+hugo -c "${CONTENT_PATH}" \
+     -d "${DESTINATION_PATH}" \
+     -b "${BASE_URL}" \
+     -t "${THEME}" \
+     --cleanDestinationDir
+
+echo "Static website built successfully"
+
+# Optional: Add post-build steps here
+# Examples:
+# - Optimization (minification, image compression)
+# - Deployment (rsync, S3 sync, etc.)
+# - Cache invalidation
+# - Health checks
+# - Custom hooks
+
+# If you need to run additional commands after the build, add them here
+# For example:
+# if [ -n "${POST_BUILD_COMMAND}" ]; then
+#     echo "Running post-build command: ${POST_BUILD_COMMAND}"
+#     eval "${POST_BUILD_COMMAND}"
+# fi
+
+exit 0


### PR DESCRIPTION
This change removes the explicit Hugo dependency from the CMS by introducing a build script interface that the CMS calls instead of directly invoking Hugo commands.
