### PR TITLE
ci: point CODEOWNERS at @sourcehaven-bv/maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,8 @@
-* @minvws/rdo-dataprocessing-codeowners
-# Last match takes precedence
-.github/CODEOWNERS @minvws/irealisatie-operations
+# Default reviewers for every change. GitHub auto-requests this team on each PR
+# (the PR author is skipped). Manage membership at:
+# https://github.com/orgs/sourcehaven-bv/teams/maintainers
+#
+# Previous owners referenced @minvws teams, which cannot resolve as code owners
+# in a sourcehaven-bv repo (a team can only own repos in its own org), so that
+# CODEOWNERS was non-functional.
+* @sourcehaven-bv/maintainers


### PR DESCRIPTION
Replaces the existing CODEOWNERS (which referenced `@minvws` teams) with `@sourcehaven-bv/maintainers`.

The previous `@minvws/*` owners cannot resolve as code owners in a sourcehaven-bv repo — a team can only own repos in its own org — so that file was effectively non-functional. This makes CODEOWNERS actually request a valid reviewer team (vloothuis + tschmits). No branch-protection changes.

If the @minvws ownership was intentional (e.g. an upstream sync obligation), close this and let me know.