### PR TITLE
feat: --name/--email/--organisation flags on user:create-admin

### DIFF
--- a/src/cms/app/Console/Commands/UserCreateAdmin.php
+++ b/src/cms/app/Console/Commands/UserCreateAdmin.php
@@ -22,12 +22,21 @@ use const FILTER_VALIDATE_EMAIL;
 
 class UserCreateAdmin extends Command
 {
-    protected $signature = 'user:create-admin';
+    protected $signature = 'user:create-admin
+        {--name= : Name for the new admin (skips the prompt when set)}
+        {--email= : Email for the new admin (skips the prompt when set)}
+        {--organisation= : Organisation name to create or reuse (skips the prompt when set)}';
     protected $description = 'Create a new admin user';
 
     public function handle(): int
     {
-        $inputData = $this->getInputData();
+        try {
+            $inputData = $this->getInputData();
+        } catch (Throwable $throwable) {
+            $this->output->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
 
         try {
             $organisation = $this->createOrGetOrganisation($inputData['organisation']);
@@ -44,26 +53,71 @@ class UserCreateAdmin extends Command
     }
 
     /**
+     * Collect inputs, preferring CLI flags for unattended use (Ansible /
+     * bootstrap scripts). Any flag left out falls back to the interactive
+     * prompt so `php artisan user:create-admin` on a support shell keeps
+     * behaving as before.
+     *
      * @return array{'name': string, 'email': string, 'organisation': string}
      */
     private function getInputData(): array
     {
         return [
-            'name' => text(label: 'Name', default: 'admin', required: true),
-            'email' => text(
-                label: 'Email address',
-                default: 'admin@example.com',
-                required: true,
-                validate: function (string $email): ?string {
-                    return match (true) {
-                        $this->isInvalidEmail($email) => 'The email address must be valid.',
-                        $this->userWithEmailExists($email) => 'A user with this email address already exists',
-                        default => null,
-                    };
-                },
-            ),
-            'organisation' => text(label: 'Organisation', default: 'Example Organization', required: true),
+            'name' => $this->resolveName(),
+            'email' => $this->resolveEmail(),
+            'organisation' => $this->resolveOrganisation(),
         ];
+    }
+
+    private function resolveName(): string
+    {
+        $name = $this->option('name');
+        if (is_string($name) && $name !== '') {
+            return $name;
+        }
+
+        return text(label: 'Name', default: 'admin', required: true);
+    }
+
+    private function resolveEmail(): string
+    {
+        $email = $this->option('email');
+        if (is_string($email) && $email !== '') {
+            // Non-interactive path: same validation as the prompt, but as
+            // an exception so the command exits FAILURE instead of
+            // re-prompting into a closed stdin.
+            if ($this->isInvalidEmail($email)) {
+                throw new Exception('The email address must be valid.');
+            }
+            if ($this->userWithEmailExists($email)) {
+                throw new Exception('A user with this email address already exists');
+            }
+
+            return $email;
+        }
+
+        return text(
+            label: 'Email address',
+            default: 'admin@example.com',
+            required: true,
+            validate: function (string $email): ?string {
+                return match (true) {
+                    $this->isInvalidEmail($email) => 'The email address must be valid.',
+                    $this->userWithEmailExists($email) => 'A user with this email address already exists',
+                    default => null,
+                };
+            },
+        );
+    }
+
+    private function resolveOrganisation(): string
+    {
+        $organisation = $this->option('organisation');
+        if (is_string($organisation) && $organisation !== '') {
+            return $organisation;
+        }
+
+        return text(label: 'Organisation', default: 'Example Organization', required: true);
     }
 
     private function isInvalidEmail(string $email): bool

--- a/src/cms/app/Console/Commands/UserCreateAdmin.php
+++ b/src/cms/app/Console/Commands/UserCreateAdmin.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Str;
 use Throwable;
 
 use function filter_var;
+use function is_string;
 use function Laravel\Prompts\text;
 
 use const FILTER_VALIDATE_EMAIL;

--- a/src/cms/tests/Feature/Console/Commands/UserCreateAdminTest.php
+++ b/src/cms/tests/Feature/Console/Commands/UserCreateAdminTest.php
@@ -71,3 +71,67 @@ it('handles an error correctly', function (): void {
         ->expectsQuestion('Organisation', $organisation->name)
         ->assertFailed();
 });
+
+it('can make an admin user from CLI flags (non-interactive)', function (): void {
+    $name = fake()->userName();
+    $email = fake()->safeEmail();
+    $organisationName = fake()->company();
+
+    $this->artisan('user:create-admin', [
+        '--name' => $name,
+        '--email' => $email,
+        '--organisation' => $organisationName,
+    ])
+        ->assertSuccessful();
+
+    $user = User::query()
+        ->where('name', $name)
+        ->where('email', $email)
+        ->firstOrFail();
+
+    $organisation = Organisation::query()
+        ->where('name', $organisationName)
+        ->firstOrFail();
+
+    expect($user->organisations()->first()->id)
+        ->toBe($organisation->id);
+});
+
+it('rejects invalid email in non-interactive mode', function (): void {
+    $this->artisan('user:create-admin', [
+        '--name' => 'Admin',
+        '--email' => 'not-an-email',
+        '--organisation' => fake()->company(),
+    ])
+        ->assertFailed();
+});
+
+it('rejects duplicate email in non-interactive mode', function (): void {
+    $existing = User::factory()->create();
+
+    $this->artisan('user:create-admin', [
+        '--name' => 'Admin',
+        '--email' => $existing->email,
+        '--organisation' => fake()->company(),
+    ])
+        ->assertFailed();
+});
+
+it('allows mixing flags with prompts (partial CLI input)', function (): void {
+    // Only --email passed; name + organisation still prompted. Lets an
+    // operator on a shell pre-fill a value from clipboard without
+    // giving up the prompt safety net.
+    $name = fake()->userName();
+    $email = fake()->safeEmail();
+    $organisationName = fake()->company();
+
+    $this->artisan('user:create-admin', ['--email' => $email])
+        ->expectsQuestion('Name', $name)
+        ->expectsQuestion('Organisation', $organisationName)
+        ->assertSuccessful();
+
+    User::query()
+        ->where('name', $name)
+        ->where('email', $email)
+        ->firstOrFail();
+});


### PR DESCRIPTION
## Summary
Adds optional CLI flags to `user:create-admin` so it can run unattended (Ansible / bootstrap scripts) while keeping the current interactive behaviour when the flags are omitted.

## Why
Provisioning the first admin on a new tenant is the moment where the app has no users yet — so it can't be done through the Filament UI. Today the only path is an SSH session that pipes text into the prompts, which is fragile.

Downstream: the devops-tailscale repo (PR sourcehaven-bv/devops#85) currently ships its own duplicate bootstrap script that pokes at `App\Models\User` directly. Once this lands, that PR can be replaced with a one-liner that calls `php artisan user:create-admin --name=... --email=... --organisation=...`, and the app remains the single source of truth for what "an admin user" means (role assignment, organisation attach, entity number counters, …).

## Change
- `user:create-admin` signature grows three optional flags: `--name`, `--email`, `--organisation`.
- Each `resolveX()` helper prefers the flag if set, otherwise falls back to the existing `Laravel\Prompts\text()` prompt.
- Non-interactive email validation reuses the prompt's rules (`isInvalidEmail`, `userWithEmailExists`) but throws an `Exception` on failure so the command exits `FAILURE` instead of trying to re-prompt into a closed stdin.
- Fully backward compatible: `php artisan user:create-admin` with no flags behaves identically to today.

## Tests
Added four Pest cases next to the existing three:
- Full non-interactive success
- Non-interactive rejects invalid email
- Non-interactive rejects duplicate email
- Mixed: partial flag (`--email` only), remaining values still prompted

Existing tests kept untouched.

## Not in scope
- The `EntityNumberCounter` prefix collision that surfaces on a second run with the same org name (see the `handles an error correctly` test) — that's a pre-existing bug worth its own PR.
- `#15` (upstream sync) doesn't touch this file — running this in parallel, not stacked.