### PR TITLE
fix: reorder list tabs so action-oriented lists come first and all comes last

### DIFF
--- a/src/cms/app/Filament/Resources/OrganisationSnapshotApprovalResource/Pages/ListOrganisationSnapshotApprovalItems.php
+++ b/src/cms/app/Filament/Resources/OrganisationSnapshotApprovalResource/Pages/ListOrganisationSnapshotApprovalItems.php
@@ -29,17 +29,7 @@ class ListOrganisationSnapshotApprovalItems extends ListRecords
     public function getTabs(): array
     {
         return [
-            'all' => Tab::make()
-                ->label(__('general.all')),
-            'established-obsolete' => Tab::make()
-                ->label(__('snapshot_approval.established-obsolete'))
-                ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
-                    $query->whereIn('state', [
-                        Established::$name,
-                        Obsolete::$name,
-                    ]);
-                }),
-            'in_review-approved' => Tab::make()
+            self::TAB_ID_INREVIEW_APPROVED => Tab::make()
                 ->label(__('snapshot_approval.in_review-approved'))
                 ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
                     $query->whereIn('state', [
@@ -47,6 +37,16 @@ class ListOrganisationSnapshotApprovalItems extends ListRecords
                         Approved::$name,
                     ]);
                 }),
+            self::TAB_ID_ESTABLISHED_OBSOLETE => Tab::make()
+                ->label(__('snapshot_approval.established-obsolete'))
+                ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
+                    $query->whereIn('state', [
+                        Established::$name,
+                        Obsolete::$name,
+                    ]);
+                }),
+            self::TAB_ID_ALL => Tab::make()
+                ->label(__('general.all')),
         ];
     }
 }

--- a/src/cms/app/Filament/Resources/Pages/ListLookupListRecords.php
+++ b/src/cms/app/Filament/Resources/Pages/ListLookupListRecords.php
@@ -26,8 +26,6 @@ abstract class ListLookupListRecords extends ListRecords
     public function getTabs(): array
     {
         return [
-            'all' => Tab::make('all')
-                ->label(__('general.all')),
             'enabled' => Tab::make()
                 ->label(__('general.enabled'))
                 ->query(static function (Builder $query) {
@@ -38,6 +36,8 @@ abstract class ListLookupListRecords extends ListRecords
                 ->query(static function (Builder $query) {
                     return $query->where('enabled', false);
                 }),
+            'all' => Tab::make('all')
+                ->label(__('general.all')),
         ];
     }
 }

--- a/src/cms/app/Filament/Resources/PersonalSnapshotApprovalResource/Pages/ListPersonalSnapshotApprovalItems.php
+++ b/src/cms/app/Filament/Resources/PersonalSnapshotApprovalResource/Pages/ListPersonalSnapshotApprovalItems.php
@@ -27,15 +27,6 @@ class ListPersonalSnapshotApprovalItems extends ListRecords
     public function getTabs(): array
     {
         return [
-            self::TAB_ID_ALL => Tab::make()
-                ->label(__('general.all')),
-            self::TAB_ID_REVIEWED => Tab::make()
-                ->label(__('snapshot_approval.reviewed'))
-                ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
-                    $query->whereHas('snapshotApprovals', static function (SnapshotApprovalBuilder $query): void {
-                        $query->signed()->assignedTo(Authentication::user());
-                    });
-                }),
             self::TAB_ID_UNREVIEWED => Tab::make()
                 ->label(__('snapshot_approval.unreviewed'))
                 ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
@@ -43,6 +34,15 @@ class ListPersonalSnapshotApprovalItems extends ListRecords
                         $query->unsigned()->assignedTo(Authentication::user());
                     });
                 }),
+            self::TAB_ID_REVIEWED => Tab::make()
+                ->label(__('snapshot_approval.reviewed'))
+                ->modifyQueryUsing(static function (SnapshotBuilder $query): void {
+                    $query->whereHas('snapshotApprovals', static function (SnapshotApprovalBuilder $query): void {
+                        $query->signed()->assignedTo(Authentication::user());
+                    });
+                }),
+            self::TAB_ID_ALL => Tab::make()
+                ->label(__('general.all')),
         ];
     }
 }

--- a/src/cms/tests/Feature/Filament/Resources/AlgorithmPublicationCategoryResource/Pages/ListAlgorithmPublicationCategoriesTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AlgorithmPublicationCategoryResource/Pages/ListAlgorithmPublicationCategoriesTest.php
@@ -15,5 +15,6 @@ it('can load the list resource page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAlgorithmPublicationCategories::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($records);
 });

--- a/src/cms/tests/Feature/Filament/Resources/AlgorithmStatusResource/Pages/ListAlgorithmStatusesTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AlgorithmStatusResource/Pages/ListAlgorithmStatusesTest.php
@@ -15,5 +15,6 @@ it('can load the list resource page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAlgorithmStatuses::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($records);
 });

--- a/src/cms/tests/Feature/Filament/Resources/AlgorithmThemeResource/Pages/ListAlgorithmThemesTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AlgorithmThemeResource/Pages/ListAlgorithmThemesTest.php
@@ -15,5 +15,6 @@ it('can load the list resource page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAlgorithmThemes::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($records);
 });

--- a/src/cms/tests/Feature/Filament/Resources/AvgProcessorProcessingRecordServiceResource/AvgProcessorProcessingRecordServiceResourceTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AvgProcessorProcessingRecordServiceResource/AvgProcessorProcessingRecordServiceResourceTest.php
@@ -32,6 +32,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAvgProcessorProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords([$avgProcessorProcessingRecordService]);
 });
 

--- a/src/cms/tests/Feature/Filament/Resources/AvgProcessorProcessingRecordServiceResource/Pages/ListAvgProcessorProcessingRecordServiceTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AvgProcessorProcessingRecordServiceResource/Pages/ListAvgProcessorProcessingRecordServiceTest.php
@@ -15,6 +15,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAvgProcessorProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($avgProcessorProcessingRecordService);
 });
 

--- a/src/cms/tests/Feature/Filament/Resources/AvgResponsibleProcessingRecordServiceResource/AvgResponsibleProcessingRecordServiceResourceTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AvgResponsibleProcessingRecordServiceResource/AvgResponsibleProcessingRecordServiceResourceTest.php
@@ -32,6 +32,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAvgResponsibleProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords([$avgResponsibleProcessingRecordService]);
 });
 

--- a/src/cms/tests/Feature/Filament/Resources/AvgResponsibleProcessingRecordServiceResource/Pages/ListAvgResponsibleProcessingRecordServicesTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AvgResponsibleProcessingRecordServiceResource/Pages/ListAvgResponsibleProcessingRecordServicesTest.php
@@ -15,6 +15,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListAvgResponsibleProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($avgResponsibleProcessingRecordService);
 });
 

--- a/src/cms/tests/Feature/Filament/Resources/ContactPersonPositionResource/Pages/ListContactPersonPositionsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/ContactPersonPositionResource/Pages/ListContactPersonPositionsTest.php
@@ -15,5 +15,6 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListContactPersonPositions::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($contactPersonPositions);
 });

--- a/src/cms/tests/Feature/Filament/Resources/PersonalSnapshotApprovalResource/Pages/ListPersonalSnapshotApprovalsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/PersonalSnapshotApprovalResource/Pages/ListPersonalSnapshotApprovalsTest.php
@@ -38,6 +38,7 @@ it('loads the list items', function (): void {
 
     $this->asFilamentUser($user)
         ->createLivewireTestable(ListPersonalSnapshotApprovalItems::class)
+        ->set('activeTab', ListPersonalSnapshotApprovalItems::TAB_ID_ALL)
         ->assertCanSeeTableRecords($snapshots);
 });
 
@@ -103,6 +104,7 @@ it('can bulk approve', function (): void {
 
     $this->asFilamentUser($user)
         ->createLivewireTestable(ListPersonalSnapshotApprovalItems::class)
+        ->set('activeTab', ListPersonalSnapshotApprovalItems::TAB_ID_ALL)
         ->assertCountTableRecords(3)
         ->assertCanSeeTableRecords([
             $snapshotApprovalApproved->snapshot,

--- a/src/cms/tests/Feature/Filament/Resources/WpgProcessingRecordServiceResource/Pages/ListWpgProcessorProcessingRecordServiceTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/WpgProcessingRecordServiceResource/Pages/ListWpgProcessorProcessingRecordServiceTest.php
@@ -15,6 +15,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListWpgProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords($wpgProcessingRecordService);
 });
 

--- a/src/cms/tests/Feature/Filament/Resources/WpgProcessingRecordServiceResource/WpgProcessingRecordServiceResourceTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/WpgProcessingRecordServiceResource/WpgProcessingRecordServiceResourceTest.php
@@ -30,6 +30,7 @@ it('loads the list page', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(ListWpgProcessingRecordServices::class)
+        ->set('activeTab', 'all')
         ->assertCanSeeTableRecords([$wpgProcessingRecordService]);
 });
 


### PR DESCRIPTION
Tab ordering on list screens put "Alle" first everywhere, which made the broadest, least actionable view the default landing spot. This reorders all three tab definitions so the action-oriented list comes first and "Alle" goes last.

## Changes

**`ListLookupListRecords.php`** — base class, affects 7 lookup screens (algorithm publication categories, algorithm statuses, algorithm themes, AVG processor/responsible processing record services, contact person positions, WPG processing record services)
`Ingeschakeld` → `Uitgeschakeld` → `Alle`

**`ListPersonalSnapshotApprovalItems.php`** — Mijn ondertekeningen
`Niet Ondertekend` → `Ondertekend` → `Alle`

**`ListOrganisationSnapshotApprovalItems.php`** — Alle Versies
`In review & goedgekeurd` → `Vastgesteld & vervallen` → `Alle`

Also swapped hardcoded string literals for the `TAB_ID_*` constants that were already declared in this file but unused.

## Behavioural change

Filament derives the default active tab from the first array element, so all 9 screens now land on a different tab than before. That is the intent of the change, but it is worth a click-through when reviewing.

Of note: the email sign-in flow (`SnapshotSignLoginController.php:133`) and `ViewSnapshot.php:89` both already pass `activeTab=unreviewed` explicitly — they were compensating for the old default. Those params are now redundant rather than wrong; left in place as self-documenting.

## Test changes

The reorder broke 12 tests, all in the affected screens. None referenced tabs by position — they referenced no tab at all and silently inherited whatever was first:

- The 8 lookup-list factories set `'enabled' => $this->faker->boolean()`. Those tests seeded 5 records and asserted all 5 visible, which only held while the default tab was "Alle". With "Ingeschakeld" first, roughly half get filtered out.
- The 2 PersonalSnapshotApproval tests seeded 3 approvals across all statuses and asserted all 3, but the default is now `unreviewed`, which shows 1.

Fixed by pinning `activeTab` explicitly on the 12 tests that mean "every seeded record appears in this list" — matching how the enabled/disabled tests in those same files already pin theirs. Purely additive: 12 inserted lines, no assertions weakened or removed. Tests that were already explicit about their tab needed no change.

## Verification

CI green: **1274 passed (3060 assertions)**, plus phpcs, phpstan, and phpmd.