### PR TITLE
fix: UUID cast on LookupListModel breaks inline option creation

### DIFF
--- a/src/cms/app/Models/LookupListModel.php
+++ b/src/cms/app/Models/LookupListModel.php
@@ -24,11 +24,4 @@ abstract class LookupListModel extends Model implements TenantAware
         'name',
         'enabled',
     ];
-
-    public function casts(): array
-    {
-        return [
-            'id' => 'string',
-        ];
-    }
 }

--- a/src/cms/tests/Feature/Filament/Forms/Components/SelectSingleWithLookupCreateOptionTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/SelectSingleWithLookupCreateOptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Components\Uuid\UuidInterface;
+use App\Filament\Resources\AlgorithmRecordResource\Pages\CreateAlgorithmRecord;
+use App\Models\Algorithm\AlgorithmTheme;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+it('selects the newly created option after inline creation', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $name = 'Inline created theme';
+
+    $component = $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CreateAlgorithmRecord::class);
+
+    $component->callFormComponentAction('algorithm_theme_id', 'createOption', data: ['name' => $name]);
+
+    $theme = AlgorithmTheme::query()->where('name', $name)->sole();
+    $instance = $component->instance();
+
+    expect($instance->form->getRawState()['algorithm_theme_id'])->toBe($theme->id->toString())
+        ->and($instance->getFormSelectOptionLabel('data.algorithm_theme_id'))->toBe($name);
+});
+
+it('casts lookup list ids to the uuid value object', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $this->asFilamentOrganisationUser($organisation);
+
+    $theme = AlgorithmTheme::factory()->recycle($organisation)->create();
+
+    expect($theme->getKey())->toBeInstanceOf(UuidInterface::class)
+        ->and($theme->fresh()->getKey())->toBeInstanceOf(UuidInterface::class);
+});


### PR DESCRIPTION
## Problem

Inline creation on `SelectSingleWithLookup` fields did not select the newly created item. The actual failure is worse than a UX gap: it **crashes** with `Expected an instance of UuidInterface. Got: string` at `SelectSingleWithLookup.php:68`.

Filament v3 is not at fault — it already auto-selects inline-created options:

```php
$state = $component->isMultiple() ? [...$component->getState(), $createdOptionKey] : $createdOptionKey;
$component->state($state);
```

Multi-selects (`TagsInput`, `SelectMultipleWithLookup`) were verified working.

## Root cause

`LookupListModel::casts()` declared `'id' => 'string'`, which overrides the `UuidCast` merged in by `HasUuidAsId::initializeHasUuidAsId()`. Laravel's `casts()` method takes precedence over `mergeCasts()`, so `getKey()` returned a plain string and the `Assert::isInstanceOf()` in `createOptionUsing` threw.

Removing the override is sufficient — `Model::casts()` already returns `[]`.

## Impact

Affects all 9 `LookupListModel` subclasses (`AlgorithmTheme`, `AlgorithmStatus`, `DocumentType`, `ContactPersonPosition`, the three `*ProcessingRecordService` models, etc.).

Test results on `tests/Feature/Filament` + `tests/Unit`:

| | Before | After |
|---|---|---|
| Passed | 327 | 519 |
| Failed | 195 | 5 |

This one line accounted for **190 pre-existing test failures**. The remaining 5 are S3/MinIO connection errors, unrelated and failing identically on unmodified code.

## Verification

- PHPStan clean, phpcs clean on changed files.
- Added `SelectSingleWithLookupCreateOptionTest.php` covering the inline-create selection path and the UUID cast.

## Worth a follow-up (not in this PR)

Given 190 tests fail on a clean checkout, it's worth confirming **CI is actually green** — if it is, its config differs from local in a way that masks this.

Separately: `TagsInput::createTagOptionsForm()` returns `[]` when the user lacks `TAG_CREATE`, but in Filament v3 an empty `createOptionForm` array still registers the create action (the modal renders with no fields), so that permission gate may not be closing.
