### PR TITLE
feat: add role descriptions to user management

### DIFF
--- a/src/cms/app/Filament/Forms/Components/OrganisationUserRolesRepeater.php
+++ b/src/cms/app/Filament/Forms/Components/OrganisationUserRolesRepeater.php
@@ -10,7 +10,6 @@ use App\Models\User;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\Toggle;
 use Webmozart\Assert\Assert;
 
 use function __;
@@ -63,20 +62,12 @@ class OrganisationUserRolesRepeater extends Repeater
      */
     private static function getOrganisationRoleToggles(string $name): array
     {
-        $organisationRoleToggleSections = [];
-
-        foreach (Role::organisationRoleGroups(true) as $organisationRoleGroup) {
-            $organisationRoleToggles = [];
-
-            foreach ($organisationRoleGroup as $organisationRole) {
-                $organisationRoleToggles[] = Toggle::make(sprintf('%s.%s', $name, $organisationRole->value))
-                    ->label(__(sprintf('role.%s', $organisationRole->value)));
-            }
-
-            $organisationRoleToggleSections[] = Section::make($organisationRoleToggles)->columns();
-        }
-
-        return $organisationRoleToggleSections;
+        return RoleToggle::organisationRoleSections(
+            true,
+            static function (Role $organisationRole) use ($name): string {
+                return sprintf('%s.%s', $name, $organisationRole->value);
+            },
+        );
     }
 
     /**

--- a/src/cms/app/Filament/Forms/Components/RoleToggle.php
+++ b/src/cms/app/Filament/Forms/Components/RoleToggle.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Forms\Components;
+
+use App\Enums\Authorization\Role;
+use Closure;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Toggle;
+
+use function __;
+use function sprintf;
+
+class RoleToggle extends Toggle
+{
+    public static function makeForRole(string $name, Role $role): static
+    {
+        return parent::make($name)
+            ->label(__(sprintf('role.%s', $role->value)))
+            ->helperText(__(sprintf('role.descriptions.%s', $role->value)));
+    }
+
+    /**
+     * Builds the grouped organisation role toggles shared by the user forms.
+     *
+     * @param Closure(Role): string $nameResolver
+     * @param Closure(static, Role): Toggle|null $configure
+     *
+     * @return array<Section>
+     */
+    public static function organisationRoleSections(
+        bool $includeCpoRoles,
+        Closure $nameResolver,
+        ?Closure $configure = null,
+    ): array {
+        $organisationRoleToggleSections = [];
+
+        foreach (Role::organisationRoleGroups($includeCpoRoles) as $organisationRoleGroup) {
+            $organisationRoleToggles = [];
+
+            foreach ($organisationRoleGroup as $organisationRole) {
+                $organisationRoleToggle = self::makeForRole($nameResolver($organisationRole), $organisationRole);
+
+                $organisationRoleToggles[] = $configure === null
+                    ? $organisationRoleToggle
+                    : $configure($organisationRoleToggle, $organisationRole);
+            }
+
+            $organisationRoleToggleSections[] = Section::make($organisationRoleToggles)->columns();
+        }
+
+        return $organisationRoleToggleSections;
+    }
+}

--- a/src/cms/app/Filament/Forms/Components/UserGlobalRoleToggle.php
+++ b/src/cms/app/Filament/Forms/Components/UserGlobalRoleToggle.php
@@ -8,15 +8,13 @@ use App\Enums\Authorization\Role;
 use App\Models\User;
 use Filament\Forms\Components\Toggle;
 
-use function __;
 use function sprintf;
 
-class UserGlobalRoleToggle extends Toggle
+class UserGlobalRoleToggle extends RoleToggle
 {
     public static function makeForUser(string $name, User $user, Role $role): static
     {
-        return parent::make(sprintf('%s.%s', $name, $role->value))
-            ->label(__(sprintf('role.%s', $role->value)))
+        return parent::makeForRole(sprintf('%s.%s', $name, $role->value), $role)
             ->afterStateHydrated(static function (Toggle $component) use ($user, $role): void {
                 $hasRole = $user->globalRoles
                     ->pluck('role')

--- a/src/cms/app/Filament/Resources/OrganisationUserResource/OrganisationUserResourceForm.php
+++ b/src/cms/app/Filament/Resources/OrganisationUserResource/OrganisationUserResourceForm.php
@@ -7,6 +7,7 @@ namespace App\Filament\Resources\OrganisationUserResource;
 use App\Enums\Authorization\Permission;
 use App\Enums\Authorization\Role;
 use App\Facades\Authorization;
+use App\Filament\Forms\Components\RoleToggle;
 use App\Models\OrganisationUserRole;
 use App\Models\User;
 use Filament\Forms\Components\Section;
@@ -15,7 +16,6 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 
 use function __;
-use function sprintf;
 
 class OrganisationUserResourceForm
 {
@@ -46,28 +46,23 @@ class OrganisationUserResourceForm
      */
     private static function getOrganisationRoleToggles(): array
     {
-        $organisationRoleToggleSections = [];
         $includeCpoRoles = Authorization::hasPermission(Permission::USER_ROLE_ORGANISATION_CPO_MANAGE);
 
-        foreach (Role::organisationRoleGroups($includeCpoRoles) as $organisationRoleGroup) {
-            $organisationRoleToggles = [];
+        return RoleToggle::organisationRoleSections(
+            $includeCpoRoles,
+            static function (Role $organisationRole): string {
+                return $organisationRole->value;
+            },
+            static function (RoleToggle $toggle, Role $organisationRole): Toggle {
+                return $toggle->formatStateUsing(static function (User $record) use ($organisationRole): bool {
+                    $organisationRoles = $record->organisationRoles
+                        ->map(static function (OrganisationUserRole $organisationUserRole): Role {
+                            return $organisationUserRole->role;
+                        });
 
-            foreach ($organisationRoleGroup as $organisationRole) {
-                $organisationRoleToggles[] = Toggle::make($organisationRole->value)
-                    ->label(__(sprintf('role.%s', $organisationRole->value)))
-                    ->formatStateUsing(static function (User $record) use ($organisationRole): bool {
-                        $organisationRoles = $record->organisationRoles
-                            ->map(static function (OrganisationUserRole $organisationUserRole): Role {
-                                return $organisationUserRole->role;
-                            });
-
-                        return $organisationRoles->contains($organisationRole);
-                    });
-            }
-
-            $organisationRoleToggleSections[] = Section::make($organisationRoleToggles)->columns();
-        }
-
-        return $organisationRoleToggleSections;
+                    return $organisationRoles->contains($organisationRole);
+                });
+            },
+        );
     }
 }

--- a/src/cms/app/Filament/Resources/OrganisationUserResource/Pages/CreateOrganisationUser.php
+++ b/src/cms/app/Filament/Resources/OrganisationUserResource/Pages/CreateOrganisationUser.php
@@ -8,6 +8,7 @@ use App\Enums\Authorization\Permission;
 use App\Enums\Authorization\Role;
 use App\Facades\Authentication;
 use App\Facades\Authorization;
+use App\Filament\Forms\Components\RoleToggle;
 use App\Filament\Pages\CreateRecord;
 use App\Filament\Resources\OrganisationUserResource;
 use App\Models\OrganisationUserRole;
@@ -15,7 +16,6 @@ use App\Models\User;
 use Closure;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
-use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
@@ -25,7 +25,6 @@ use Webmozart\Assert\Assert;
 
 use function __;
 use function in_array;
-use function sprintf;
 
 class CreateOrganisationUser extends CreateRecord
 {
@@ -91,21 +90,14 @@ class CreateOrganisationUser extends CreateRecord
      */
     private static function getOrganisationRoleToggles(): array
     {
-        $organisationRoleToggleSections = [];
         $includeCpoRoles = Authorization::hasPermission(Permission::USER_ROLE_ORGANISATION_CPO_MANAGE);
 
-        foreach (Role::organisationRoleGroups($includeCpoRoles) as $organisationRoleGroup) {
-            $organisationRoleToggles = [];
-
-            foreach ($organisationRoleGroup as $organisationRole) {
-                $organisationRoleToggles[] = Toggle::make($organisationRole->value)
-                    ->label(__(sprintf('role.%s', $organisationRole->value)));
-            }
-
-            $organisationRoleToggleSections[] = Section::make($organisationRoleToggles)->columns();
-        }
-
-        return $organisationRoleToggleSections;
+        return RoleToggle::organisationRoleSections(
+            $includeCpoRoles,
+            static function (Role $organisationRole): string {
+                return $organisationRole->value;
+            },
+        );
     }
 
     /**

--- a/src/cms/resources/lang/nl/role.php
+++ b/src/cms/resources/lang/nl/role.php
@@ -13,4 +13,15 @@ return [
     Role::INPUT_PROCESSOR_DATABREACH->value => 'Invoerder Datalekken',
     Role::MANDATE_HOLDER->value => 'Mandaathouder',
     Role::PRIVACY_OFFICER->value => 'Privacy Officer',
+
+    'descriptions' => [
+        Role::CHIEF_PRIVACY_OFFICER->value => 'Volledig beheer van de registratie binnen de organisatie, inclusief het vaststellen van snapshots. Kan daarnaast alle organisatierollen toekennen.',
+        Role::COUNSELOR->value => 'Alleen-lezen toegang tot de registratie, datalekken en snapshots.',
+        Role::DATA_PROTECTION_OFFICIAL->value => 'Bekijkt de volledige registratie, plaatst FG-opmerkingen en kan gegevens exporteren. Wijzigt zelf niets.',
+        Role::FUNCTIONAL_MANAGER->value => 'Beheert de applicatie: organisaties, gebruikers en globale instellingen. Kent rollen toe en heeft inzage in het beheerlogboek.',
+        Role::INPUT_PROCESSOR->value => 'Legt verwerkingen, documenten en verantwoordelijken vast en werkt deze bij. Kan snapshots aanmaken maar niet vaststellen.',
+        Role::INPUT_PROCESSOR_DATABREACH->value => 'Legt datalekken vast en werkt deze bij, met bijbehorende documenten en verantwoordelijken.',
+        Role::MANDATE_HOLDER->value => 'Bekijkt de registratie en geeft een eigen akkoord op de aan hem of haar toegewezen snapshots.',
+        Role::PRIVACY_OFFICER->value => 'Volledig beheer van de registratie binnen de organisatie, inclusief het vaststellen van snapshots. Kan rollen toekennen, behalve die van chief privacy officer.',
+    ],
 ];

--- a/src/cms/tests/Unit/Config/RoleTranslationTest.php
+++ b/src/cms/tests/Unit/Config/RoleTranslationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use App\Enums\Authorization\Role;
+use Tests\TestCase;
+
+use function __;
+use function it;
+use function sprintf;
+use function uses;
+
+uses(TestCase::class);
+
+it('has a label and a description for every role', function (): void {
+    foreach (Role::cases() as $role) {
+        $labelKey = sprintf('role.%s', $role->value);
+        $descriptionKey = sprintf('role.descriptions.%s', $role->value);
+
+        $this->assertNotSame(
+            $labelKey,
+            __($labelKey),
+            sprintf('Missing translation for %s.', $labelKey),
+        );
+
+        $this->assertNotSame(
+            $descriptionKey,
+            __($descriptionKey),
+            sprintf('Missing translation for %s.', $descriptionKey),
+        );
+    }
+});


### PR DESCRIPTION
## Why

The user management screens showed role assignment as bare toggles labelled only with the role name. Whoever assigns roles had no way to tell what a role actually grants without leaving the screen — the real source of truth is the 190-line `config/permissions.php`.

## What

- **`resources/lang/nl/role.php`** — new nested `descriptions` array, one 1–2 line summary per role, derived from `config/permissions.php`. Existing flat label lookups untouched.
- **New `RoleToggle` component** — single factory owning label + `helperText()`, plus `organisationRoleSections()` centralizing the grouped-section loop. Takes a `$nameResolver` (call sites use different field-name schemes) and an optional `$configure` closure (one site needs `formatStateUsing`).
- **Four call sites now delegate** — the toggle-building loop was copy-pasted in four places, so descriptions are added once rather than four times. `UserGlobalRoleToggle` now extends `RoleToggle`.
- **`tests/Unit/Config/RoleTranslationTest.php`** — fails if a future `Role` case ships without a label or description.

Net −55/+42 lines in the touched files.

## Verification

Passing: phpcs, phpmd, phpstan (1174 files, no errors), and the new unit test.

Behaviour-preservation was checked by booting the app and rendering the schemas directly: all 8 roles resolve label + description, field names are byte-identical to before (`organisation_user_roles.privacy-officer` for the repeater, bare `privacy-officer` for the org forms), grouping intact, and the CPO permission gate still drops that group (3 → 2 sections).

## For the reviewer

- **The Dutch copy is a first draft** derived from the permission config — worth a wording pass. One claim was corrected during implementation: the mandate holder description said "keurt snapshots goed", but the permission is `SNAPSHOT_APPROVAL_UPDATE_PERSONAL` (a *personal* approval resource), so it now reads "geeft een eigen akkoord op".
- Read-only infolist views were deliberately left label-only; the `role.descriptions.*` keys are available if they should follow.
- The Feature suite (needs pgsql via sail) was **not** run locally — the Docker image build didn't finish. Since this refactor must keep field names identical, those tests are the real regression check; relying on CI for them.