### PR TITLE
feat: build clamav natively for arm64

### DIFF
--- a/justfile
+++ b/justfile
@@ -104,15 +104,15 @@ dev-build:
 
 # Run tests
 test:
-    cd src/cms && ./vendor/bin/sail exec laravel.test ./vendor/bin/pest
+    cd src/cms && ./vendor/bin/sail exec web ./vendor/bin/pest
 
 # Run specific test
 test-filter filter:
-    cd src/cms && ./vendor/bin/sail exec laravel.test ./vendor/bin/pest --filter {{filter}}
+    cd src/cms && ./vendor/bin/sail exec web ./vendor/bin/pest --filter {{filter}}
 
 # Run tests with coverage
 test-coverage:
-    cd src/cms && ./vendor/bin/sail exec laravel.test ./vendor/bin/pest --coverage
+    cd src/cms && ./vendor/bin/sail exec web ./vendor/bin/pest --coverage
 
 # View logs
 dev-logs:

--- a/src/cms/docker-compose.yml
+++ b/src/cms/docker-compose.yml
@@ -65,10 +65,20 @@ services:
             - sail
 
     clamav:
-        image: 'clamav/clamav'
+        build:
+            context: ./docker/clamav
+        volumes:
+            - 'sail-clamav:/var/lib/clamav'
         networks:
             - sail
-        platform: 'linux/amd64'
+        healthcheck:
+            # The Debian package ships no clamdcheck.sh, so PING clamd over the
+            # same TCP port the app uses and expect the literal "PONG".
+            test: ["CMD-SHELL", "printf 'PING\\n' | nc -w 5 localhost 3310 | grep -q PONG"]
+            interval: 30s
+            timeout: 10s
+            retries: 5
+            start_period: 300s
 
     static-website:
         image: 'nginx:alpine'
@@ -124,4 +134,6 @@ volumes:
     sail-pgsql:
         driver: local
     sail-minio:
+        driver: local
+    sail-clamav:
         driver: local

--- a/src/cms/docker/clamav/Dockerfile
+++ b/src/cms/docker/clamav/Dockerfile
@@ -1,0 +1,36 @@
+# Multi-arch ClamAV image.
+#
+# The official clamav/clamav image is amd64-only, which forces emulation on
+# arm64 hosts (Apple Silicon). Debian ships clamav-daemon for both amd64 and
+# arm64, so building on debian:bookworm-slim gives us a native image on every
+# platform the base image supports.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        clamav-daemon \
+        clamav-freshclam \
+        ca-certificates \
+        netcat-openbsd \
+    && rm -rf /var/lib/apt/lists/*
+
+# The app connects over TCP (VIRUSSCANNER_SOCKET=tcp://clamav:3310). The Debian
+# package defaults to a unix socket in /var/run/clamav, which the unprivileged
+# clamav user cannot create in a container, so drop LocalSocket entirely and
+# listen on TCP only. Same for freshclam's NotifyClamd, which uses that socket.
+RUN sed -i '/^LocalSocket /d; /^LocalSocketGroup /d; /^LocalSocketMode /d; /^FixStaleSocket /d' /etc/clamav/clamd.conf \
+    && sed -i '/^NotifyClamd/d' /etc/clamav/freshclam.conf \
+    && { \
+        echo "TCPSocket 3310"; \
+        echo "TCPAddr 0.0.0.0"; \
+        echo "Foreground true"; \
+        echo "StreamMaxLength 100M"; \
+    } >> /etc/clamav/clamd.conf \
+    && echo "Foreground true" >> /etc/clamav/freshclam.conf
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 3310
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/src/cms/docker/clamav/entrypoint.sh
+++ b/src/cms/docker/clamav/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# clamd refuses to start without a signature database, and the Debian package
+# ships none. Fetch it on first boot; on later boots the volume already has it
+# and we just refresh in the background.
+if [ ! -f /var/lib/clamav/main.cvd ] && [ ! -f /var/lib/clamav/main.cld ]; then
+    echo "clamav: no signature database found, downloading (this takes a few minutes on first run)..."
+    freshclam --foreground --stdout
+fi
+
+# Keep signatures current alongside clamd.
+freshclam --daemon --stdout &
+
+exec clamd --foreground


### PR DESCRIPTION
## Why

`clamav/clamav` is amd64-only, so the compose file pinned `platform: linux/amd64` and the scanner ran under emulation on Apple Silicon — slow, and memory-hungry given clamd loads ~3.2M signatures.

Debian ships `clamav-daemon` for both amd64 and arm64, so we build on `debian:bookworm-slim` and get a native image on every platform the base supports. The app already talks to clamd over TCP 3310 (`VIRUSSCANNER_SOCKET=tcp://clamav:3310`), so the image swaps in with **no application code changes**.

## Changes

- New `src/cms/docker/clamav/` image (Dockerfile + entrypoint)
- Dropped the `platform: linux/amd64` pin
- Added a `sail-clamav` volume so the signature DB survives container recreation instead of re-downloading each time
- Added a healthcheck, so `web` waits for a scanner that is actually serving

Two things the Debian package does differently from the official image, both handled:

- It ships no `clamdcheck.sh`, so the healthcheck PINGs clamd over TCP and expects `PONG`
- It defaults to `LocalSocket /var/run/clamav/clamd.ctl`, which the unprivileged `clamav` user cannot create in a container. `LocalSocket` is removed rather than merely supplemented, and `NotifyClamd` with it

## Verification

Built and run on arm64 (`Arch: arm64`, no emulation):

- Healthcheck command returns `PONG`
- `zINSTREAM` over TCP — the exact protocol the app's Quahog client uses:
  - EICAR → `stream: Eicar-Test-Signature FOUND`
  - clean input → `stream: OK`
- Restart with the volume in place: serving in 0s, no signature re-download

Not verified: the amd64 build path (no amd64 host to hand). It uses the same Debian packages, which are published for both arches.

## Note on first run

First boot downloads the full signature database and takes a few minutes — unavoidable, and true of the current setup too. The difference is the volume means it now happens once rather than on every container recreate.

## Also included

A separate commit fixes `just test` / `test-filter` / `test-coverage`, which referenced a `laravel.test` service that does not exist (the service is `web`). Unrelated to ARM — those recipes were broken on every platform. `docker-compose.override.yml` already had to patch the same stale name for `static-website`'s `depends_on`.