### PR TITLE
fix: derive expected review_at the way the implementation does

### DIFF
--- a/src/cms/tests/Feature/Import/Concerns/SnapshotHelperTest.php
+++ b/src/cms/tests/Feature/Import/Concerns/SnapshotHelperTest.php
@@ -10,7 +10,6 @@ use App\Models\Organisation;
 use App\Models\States\Snapshot\Established;
 use App\Services\Snapshot\SnapshotFactory;
 use App\ValueObjects\CalendarDate;
-use Carbon\CarbonImmutable;
 use Tests\Helpers\ConfigTestHelper;
 
 it('creates no snapshot if no configured state found', function (): void {
@@ -73,8 +72,18 @@ it('creates snapshot and sets review_at', function (): void {
         ->where(['id' => $id])
         ->firstOrFail();
 
-    $expectedReviewAt = CalendarDate::instance(CarbonImmutable::now(Config::string('app.display_timezone')))
-        ->addMonths($reviewAtDefaultInMonths);
+    // Mirror the implementation: review_at is derived from updated_at in the
+    // display timezone, not from now() in UTC. Deriving it any other way makes
+    // this test fail whenever the two disagree about the calendar day, which
+    // for Europe/Amsterdam is every night between 22:00 and 24:00 UTC.
+    $expectedReviewAt = CalendarDate::createFromFormat(
+        'Y-m-d',
+        $avgResponsibleProcessingRecord->updated_at
+            ->setTimezone(Config::string('app.display_timezone'))
+            ->floorDay()
+            ->addMonths($reviewAtDefaultInMonths)
+            ->format('Y-m-d'),
+    );
 
     expect($avgResponsibleProcessingRecord->snapshots()->count())
         ->toBe(1)


### PR DESCRIPTION
## Problem

`SnapshotHelperTest > it creates snapshot and sets review_at` fails every night between **22:00 and 24:00 UTC**, and passes the rest of the day. It is not intermittent — within that window it fails 100% of the time, so rerunning does not help.

## Cause

The two sides derive the date differently:

- **Implementation** (`SnapshotHelper::setReviewAt`) takes `updated_at`, converts it to the display timezone (`Europe/Amsterdam`), floors the day, adds the months, and formats as `Y-m-d`.
- **Test** built its expectation from `now()` passed through `CalendarDate::instance()`, whose constructor does `$date->utc()->floorDay()` — converting to UTC *before* flooring.

In CEST (UTC+2), any moment after 22:00 UTC is already the next calendar day in Amsterdam. The implementation sees that day; `CalendarDate::instance()` floors back to the UTC day. The two land one day apart and the assertion fails.

## Fix

Derive the expectation the same way the implementation does — from `updated_at` in the display timezone. Verified across the day: the old expectation diverges from the implementation at 22:00+ UTC, the new one matches at every hour.

| UTC time | implementation | old expectation | new expectation |
|---|---|---|---|
| 08:30 | 2026-10-20 | 2026-10-20 ✅ | 2026-10-20 ✅ |
| 21:30 | 2026-10-20 | 2026-10-20 ✅ | 2026-10-20 ✅ |
| 22:30 | 2026-10-21 | 2026-10-20 ❌ | 2026-10-21 ✅ |
| 23:30 | 2026-10-21 | 2026-10-20 ❌ | 2026-10-21 ✅ |

## Worth a second opinion

This changes the test to match the implementation, on the assumption the implementation is right — deriving a review date from the *record's* timestamp in the user-facing timezone is the behaviour that makes sense for users in NL.

But the underlying asymmetry is still there: `CalendarDate::instance()` converts to UTC before flooring, while `CalendarDate::createFromFormat()` does not. Anywhere else that feeds a zoned datetime into `instance()` can lose a day the same way. That may deserve a closer look at `CalendarDate` itself, beyond this test.

## Note

Found while trying to land #26 (native arm64 ClamAV), which CI blocked on this. That PR touches no PHP.