### PR TITLE
ci: run CI on pushes to main instead of develop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - develop
+      - main
 
 jobs:
   CI:


### PR DESCRIPTION
The `CI` workflow's push trigger still pointed at `develop`, left over from when that was the integration branch:

```yaml
push:
  branches:
    - develop     # -> main
```

`main` is the default branch but never ran the test suite on push — only "Build Dev Release" did. Its content was therefore exercised only when merged into a branch that ran CI.

That gap hid two real problems, both found while reconciling #31:

- `src/cms/docker-compose.yml` on `main` declares `static-website.depends_on: laravel.test`, a service that does not exist in the file. `docker compose config` rejects the whole project, so a plain clone of `main` cannot start at all.
- `ci.yml` on `main` had no MinIO service or `AWS_*` env, while the S3-backed tests still ran — 7 `filament_exports` tests fail without it.

`pull_request` and `workflow_dispatch` triggers are unchanged, so PR runs behave exactly as before. This only adds coverage for direct pushes and merges to `main`.

Checked the other workflows while here: `sql-migration.yml` already covers `[main, develop]`, and `build-dev`/`release`/`tag-release` are correctly scoped. `ci.yml` was the only stale one.