### PR TITLE
ci: allow release workflow to be dispatched for a tag

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,6 +27,11 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # Build the requested version, not the triggering ref. On a
+          # dispatched run the triggering ref is the branch, which would
+          # otherwise package current main under the tag's name.
+          ref: ${{ inputs.version }}
 
       - name: Install just
         uses: extractions/setup-just@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*'
+  # Tags pushed by tag-release.yml use GITHUB_TOKEN, and GitHub does not
+  # fire workflows for token-created events. Without this, tagging never
+  # builds a release. Dispatch also lets a failed build be re-run.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build and publish (e.g. v20260721)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,7 +21,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-release.yml
     with:
-      version: ${{ github.ref_name }}
+      version: ${{ inputs.tag || github.ref_name }}
 
   publish:
     needs: build
@@ -27,5 +36,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
+          # On dispatch github.ref_name is the branch, not the tag, so the
+          # release must be pinned to the requested tag explicitly.
+          tag_name: ${{ inputs.tag || github.ref_name }}
           files: "*.tar.gz"
           generate_release_notes: true


### PR DESCRIPTION
Tags pushed by `tag-release.yml` are created with `GITHUB_TOKEN`. GitHub does not fire workflows for token-created events, so `release.yml`'s `push: tags: v*` trigger never runs — tagging produces a tag but no build and no release. This is why `v20260721` exists with no artifact.

Adds `workflow_dispatch` with a `tag` input so a release can be built for an existing tag, and so a failed build can be re-run.

Two details:
- `release.yml`: on dispatch `github.ref_name` is the *branch*, so `tag_name` is pinned to the requested tag explicitly, else the release would attach to the wrong ref.
- `build-release.yml`: `actions/checkout` had no `ref`, so a dispatched run would package current `main` while labelling it with the tag name. Now checks out `inputs.version`.

Push-tag behaviour is unchanged: `inputs.tag` is empty on push, so both expressions fall back to `github.ref_name`.