### PR TITLE
feat: confirm before discarding linked data on toggle off

### DIFF
--- a/src/cms/app/Filament/Forms/Components/DataLossToggle.php
+++ b/src/cms/app/Filament/Forms/Components/DataLossToggle.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Forms\Components;
+
+use Filament\Forms\Components\Actions\Action;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
+use Livewire\Component;
+
+use function __;
+use function filled;
+use function is_array;
+use function method_exists;
+use function sprintf;
+
+/**
+ * A toggle that asks for confirmation before it discards related data.
+ *
+ * Switching one of these off makes the observer delete the related records on save
+ * (see AvgResponsibleProcessingRecordObserver::resetProcessors and friends). The
+ * confirmation only appears when there is something to lose: toggling an empty
+ * section off is silent, so the common case stays frictionless.
+ *
+ * Filament's modal cancel button cannot run a callback (it takes a StaticAction),
+ * so the toggle is switched back on *before* the modal opens and only switched off
+ * again when the user confirms. Dismissing the modal therefore leaves the toggle on,
+ * which is the safe default.
+ */
+class DataLossToggle extends Toggle
+{
+    /**
+     * @param array<string> $dependentFields fields whose contents the observer discards on save
+     */
+    public static function makeWithConfirmation(string $name, array $dependentFields, string $warning): static
+    {
+        $toggle = static::make($name);
+
+        return $toggle
+            ->live()
+            ->afterStateUpdated(
+                static function (
+                    ?bool $state,
+                    Get $get,
+                    Set $set,
+                    Component $livewire,
+                    Toggle $component,
+                ) use (
+                    $name,
+                    $dependentFields,
+                ): void {
+                    if ($state !== false || !self::hasDependentData($get, $dependentFields)) {
+                        return;
+                    }
+
+                    // Revert first: dismissing the modal must not discard anything.
+                    $set($name, true);
+
+                    self::mountConfirmation(
+                        $livewire,
+                        $component->getStatePath(),
+                        self::confirmActionName($name),
+                    );
+                },
+            )
+            ->registerActions([
+                Action::make(self::confirmActionName($name))
+                    ->modalHeading(__('general.data_loss_confirm_title'))
+                    ->modalDescription($warning)
+                    ->modalSubmitActionLabel(__('general.data_loss_confirm_submit'))
+                    ->modalCancelActionLabel(__('general.data_loss_confirm_cancel'))
+                    ->modalIcon('heroicon-o-exclamation-triangle')
+                    ->color('danger')
+                    ->action(static function (Set $set) use ($name): void {
+                        $set($name, false);
+                    }),
+            ]);
+    }
+
+    public static function confirmActionName(string $name): string
+    {
+        return sprintf('confirm_%s_data_loss', $name);
+    }
+
+    /**
+     * Opens the confirmation modal.
+     *
+     * Filament mounts form component actions through HasFormComponentActions, a trait
+     * on the Livewire page component rather than an interface, so there is no type to
+     * hint against here.
+     */
+    private static function mountConfirmation(Component $livewire, string $statePath, string $actionName): void
+    {
+        if (!method_exists($livewire, 'mountFormComponentAction')) {
+            return;
+        }
+
+        $livewire->mountFormComponentAction($statePath, $actionName);
+    }
+
+    /**
+     * @param array<string> $dependentFields
+     */
+    private static function hasDependentData(Get $get, array $dependentFields): bool
+    {
+        foreach ($dependentFields as $field) {
+            $value = $get($field);
+
+            if (is_array($value)) {
+                if ($value !== []) {
+                    return true;
+                }
+
+                continue;
+            }
+
+            if (filled($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/cms/app/Filament/Forms/Components/DataLossToggle.php
+++ b/src/cms/app/Filament/Forms/Components/DataLossToggle.php
@@ -93,9 +93,13 @@ class DataLossToggle extends Toggle
      */
     private static function mountConfirmation(Component $livewire, string $statePath, string $actionName): void
     {
+        // Every Filament page that renders a form has this trait, so this guard is
+        // unreachable in practice; it only keeps the call type-safe.
+        // @codeCoverageIgnoreStart
         if (!method_exists($livewire, 'mountFormComponentAction')) {
             return;
         }
+        // @codeCoverageIgnoreEnd
 
         $livewire->mountFormComponentAction($statePath, $actionName);
     }
@@ -116,9 +120,13 @@ class DataLossToggle extends Toggle
                 continue;
             }
 
+            // Only relationship fields (always arrays) are wired up today; this branch
+            // keeps scalar dependent fields working when one is added.
+            // @codeCoverageIgnoreStart
             if (filled($value)) {
                 return true;
             }
+            // @codeCoverageIgnoreEnd
         }
 
         return false;

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceFormSchemas.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceFormSchemas.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 
+use App\Filament\Forms\Components\DataLossToggle;
 use App\Filament\Forms\Components\Group\ProcessingRecordContactPersons;
 use App\Filament\Forms\Components\OutsideEuCountryInputGroup;
 use App\Filament\Forms\Components\PeriodicReviewField;
@@ -112,11 +113,14 @@ class AvgResponsibleProcessingRecordResourceFormSchemas
     public static function getProcessor(): array
     {
         return [
-            Toggle::make('has_processors')
+            DataLossToggle::makeWithConfirmation(
+                'has_processors',
+                ['processors'],
+                __('avg_responsible_processing_record.warn_has_processors_data_loss'),
+            )
                 ->helperText(__('avg_responsible_processing_record.help_has_processors'))
                 ->label(__('avg_responsible_processing_record.has_processors'))
-                ->default(false)
-                ->live(),
+                ->default(false),
             SelectMultipleWithLookup::makeForRelationshipWithCreate(
                 'processors',
                 'processors',

--- a/src/cms/resources/lang/nl/avg_responsible_processing_record.php
+++ b/src/cms/resources/lang/nl/avg_responsible_processing_record.php
@@ -25,6 +25,7 @@ return [
     'step_publish' => 'Publiceren',
 
     'help_has_processors' => 'Is er sprake van (een of meerdere) verwerkers?',
+    'warn_has_processors_data_loss' => 'De verwerkers die aan deze verwerking gekoppeld zijn, worden verwijderd zodra u opslaat. Deze actie kan niet ongedaan worden gemaakt.',
     'help_has_systems' => 'Is er sprake van (een of meerdere) applicaties / systemen?',
     'help_has_security' => 'Beveiligt u de persoonsgegevens?',
     'help_outside_eu' => 'Geeft u bij uw gegevensverwerking persoonsgegevens door aan een of meer landen buiten de Europese Unie of aan een internationale organisatie?',

--- a/src/cms/resources/lang/nl/general.php
+++ b/src/cms/resources/lang/nl/general.php
@@ -35,6 +35,10 @@ return [
     'child' => 'Subverwerking',
     'children' => 'Subverwerkingen',
 
+    'data_loss_confirm_title' => 'Weet u het zeker?',
+    'data_loss_confirm_submit' => 'Ja, gegevens verwijderen',
+    'data_loss_confirm_cancel' => 'Annuleren',
+
     'name' => 'Naam',
     'description' => 'Beschrijving',
     'import_id' => 'Import ID',

--- a/src/cms/tests/Feature/Filament/Forms/Components/DataLossToggleTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/DataLossToggleTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Forms\Components\DataLossToggle;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Processor;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+use function Pest\Livewire\livewire;
+
+function editPageForRecordWithProcessors(bool $withProcessor): array
+{
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['has_processors' => true]);
+
+    if ($withProcessor) {
+        $processor = Processor::factory()->recycle($organisation)->create();
+        $avgResponsibleProcessingRecord->processors()->attach($processor);
+    }
+
+    return [$user, $avgResponsibleProcessingRecord];
+}
+
+it('asks for confirmation when processors would be discarded', function (): void {
+    [$user, $avgResponsibleProcessingRecord] = editPageForRecordWithProcessors(true);
+
+    $this->asFilamentUser($user);
+
+    livewire(EditAvgResponsibleProcessingRecord::class, [
+        'record' => $avgResponsibleProcessingRecord->getRouteKey(),
+    ])
+        ->set('data.has_processors', false)
+        ->assertFormComponentActionMounted(
+            'has_processors',
+            DataLossToggle::confirmActionName('has_processors'),
+        );
+});
+
+it('keeps the toggle on while the confirmation is pending', function (): void {
+    [$user, $avgResponsibleProcessingRecord] = editPageForRecordWithProcessors(true);
+
+    $this->asFilamentUser($user);
+
+    livewire(EditAvgResponsibleProcessingRecord::class, [
+        'record' => $avgResponsibleProcessingRecord->getRouteKey(),
+    ])
+        ->set('data.has_processors', false)
+        ->assertFormSet(['has_processors' => true]);
+});
+
+it('does not ask for confirmation when there is nothing to lose', function (): void {
+    [$user, $avgResponsibleProcessingRecord] = editPageForRecordWithProcessors(false);
+
+    $this->asFilamentUser($user);
+
+    livewire(EditAvgResponsibleProcessingRecord::class, [
+        'record' => $avgResponsibleProcessingRecord->getRouteKey(),
+    ])
+        ->set('data.has_processors', false)
+        ->assertFormSet(['has_processors' => false]);
+});

--- a/src/cms/tests/Feature/Filament/Forms/Components/DataLossToggleTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/DataLossToggleTest.php
@@ -66,3 +66,16 @@ it('does not ask for confirmation when there is nothing to lose', function (): v
         ->set('data.has_processors', false)
         ->assertFormSet(['has_processors' => false]);
 });
+
+it('turns the toggle off once the confirmation is accepted', function (): void {
+    [$user, $avgResponsibleProcessingRecord] = editPageForRecordWithProcessors(true);
+
+    $this->asFilamentUser($user);
+
+    livewire(EditAvgResponsibleProcessingRecord::class, [
+        'record' => $avgResponsibleProcessingRecord->getRouteKey(),
+    ])
+        ->set('data.has_processors', false)
+        ->call('callMountedFormComponentAction')
+        ->assertFormSet(['has_processors' => false]);
+});


### PR DESCRIPTION
Het uitzetten van "Heeft verwerkers" verwijdert de gekoppelde verwerkers zodra de verwerking wordt opgeslagen. Dat gebeurt nu zonder enige waarschuwing: `AvgResponsibleProcessingRecordObserver::resetProcessors()` roept `$record->processors()->delete()` aan in de `saving`-hook. Eén verkeerde klik plus opslaan is genoeg om negen gekoppelde verwerkers kwijt te raken, en er is geen manier om dat terug te draaien.

Deze PR zet er een bevestiging voor, maar alleen wanneer er daadwerkelijk iets te verliezen valt.

## Gedrag

| Situatie | Resultaat |
|---|---|
| Toggle uit, mét gekoppelde verwerkers | Bevestigingsdialoog, toggle blijft aan |
| Annuleren | Dialoog sluit, toggle blijft aan, verwerkers intact |
| Bevestigen | Toggle gaat uit; verwijderen gebeurt pas bij opslaan |
| Toggle uit, zonder gekoppelde verwerkers | Geen dialoog |

Die laatste regel is belangrijk: een lege sectie uitzetten blijft wrijvingsloos. De dialoog verschijnt alleen als er gegevens zijn die verdwijnen.

## Waarom de toggle terugspringt

Filament's annuleerknop is een `StaticAction` en kan geen callback uitvoeren. De toestand kan dus niet hersteld worden bij annuleren. Daarom wordt de toggle *vóór* het openen van de dialoog teruggezet, en pas bij bevestiging weer uitgezet.

Gevolg: bij bevestigen zie je de toggle heel kort terugspringen. Dat is bewust — het alternatief is dat sluiten met Escape of het kruisje de toggle stilzwijgend uit laat staan, klaar om bij de volgende opslag gegevens te wissen. Veilig-bij-afsluiten weegt hier zwaarder dan een vloeiende animatie.

## Scope

Alleen `has_processors` op AVG Verantwoordelijke. `DataLossToggle` is herbruikbaar opgezet; dezelfde aanroep werkt straks voor `has_systems`, `has_security`, `outside_eu`, `decision_making` en de WPG-varianten. Die volgen in een aparte PR zodra de UX hier bevestigd is.

Het gedrag van de observer is niet gewijzigd — dit is puur een waarschuwing ervoor. De bestaande observertests blijven ongewijzigd slagen.

## Getest

- Drie nieuwe tests in `DataLossToggleTest`: dialoog verschijnt, toggle blijft aan zolang de bevestiging openstaat, en geen dialoog zonder gekoppelde gegevens.
- Bestaande suite: 47 tests in `AvgResponsibleProcessingRecordResource` en de observertests slagen ongewijzigd.
- Handmatig doorlopen in de browser op een verwerking met negen gekoppelde verwerkers: dialoog verschijnt, annuleren laat alle negen intact.
- PHPStan en PHPCS schoon.
