### PR TITLE
chore: drop dead algorithm columns and generalise ministry-specific wording

### DIFF
--- a/src/cms/app/Models/Algorithm/AlgorithmRecord.php
+++ b/src/cms/app/Models/Algorithm/AlgorithmRecord.php
@@ -34,8 +34,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $import_id
  * @property string $name
  * @property string|null $description
- * @property string|null $start_date
- * @property string|null $end_date
+ * @property CarbonImmutable|null $start_date
+ * @property CarbonImmutable|null $end_date
  * @property string|null $contact_data
  * @property string|null $source_link
  * @property string|null $public_page_link
@@ -56,7 +56,6 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string|null $oper_data_title
  * @property string|null $oper_supplier
  * @property string|null $oper_source_code_link
- * @property string|null $meta_lang
  * @property string|null $meta_national_id
  * @property string|null $meta_source_id
  * @property string|null $meta_tags
@@ -122,7 +121,6 @@ class AlgorithmRecord extends Model implements Cloneable, EntityNumerable, Snaps
         'oper_supplier',
         'oper_source_code_link',
 
-        'meta_lang',
         'meta_national_id',
         'meta_source_id',
         'meta_tags',
@@ -143,6 +141,8 @@ class AlgorithmRecord extends Model implements Cloneable, EntityNumerable, Snaps
             'algorithm_status_id' => UuidCast::class,
             'algorithm_publication_category_id' => UuidCast::class,
             'public_from' => 'datetime',
+            'start_date' => 'date',
+            'end_date' => 'date',
             'meta_date_of_development' => 'date',
             'impact_with_consequences' => 'boolean',
             'impact_more_algorithms_applied' => 'boolean',

--- a/src/cms/database/migrations/2026_07_21_120000_drop_algorithm_meta_schema_and_lang.php
+++ b/src/cms/database/migrations/2026_07_21_120000_drop_algorithm_meta_schema_and_lang.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\SqlExport\IndexNameTruncater;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('algorithm_records', static function (Blueprint $table): void {
+            $table->dropForeign(IndexNameTruncater::foreignKey(
+                'algorithm_records',
+                'algorithm_meta_schemas',
+                'id',
+            ));
+            $table->dropColumn(['algorithm_meta_schema_id', 'meta_lang']);
+        });
+
+        Schema::dropIfExists('algorithm_meta_schemas');
+    }
+};

--- a/src/cms/database/sql/v1.15.0/0001-drop_algorithm_meta_schema_and_lang.sql
+++ b/src/cms/database/sql/v1.15.0/0001-drop_algorithm_meta_schema_and_lang.sql
@@ -1,0 +1,24 @@
+alter table
+  "algorithm_records"
+drop
+  constraint "algorith_records_algor_meta_schem_id_foreign";
+
+alter table
+  "algorithm_records"
+drop
+  column "algorithm_meta_schema_id",
+drop
+  column "meta_lang";
+
+drop
+  table if exists "algorithm_meta_schemas";
+
+INSERT INTO "admin_log_entries" (
+  "message", "created_at", "updated_at"
+)
+values
+  (
+    'Migrated "2026_07_21_120000_drop_algorithm_meta_schema_and_lang"',
+    now(),
+    now()
+  );

--- a/src/cms/resources/lang/nl/algorithm_record.php
+++ b/src/cms/resources/lang/nl/algorithm_record.php
@@ -45,7 +45,7 @@ return [
     'oper_technical_operation' => 'Technische werking',
     'oper_supplier' => 'Leverancier',
     'oper_source_code_link' => 'Link naar broncode',
-    'meta_national_id' => 'Landelijk-ID',
+    'meta_national_id' => 'Extern registratienummer',
     'meta_source_id' => 'Bron-ID',
     'meta_tags' => 'Zoektermen',
     'meta_date_of_development' => 'Datum van ontwikkeling',
@@ -54,7 +54,7 @@ return [
     'impact_with_consequences' => 'Is er sprake van een proces met directe gevolgen voor burgers of organisaties?',
     'impact_more_algorithms_applied' => 'Worden er in dit proces één of meerdere algoritmes toegepast?',
     'impact_effect_on_outcome' => 'Heeft het algoritme een significant effect op de uitkomst van het proces?',
-    'impact_algorithm_message' => 'Alle drie de vragen zijn met "Ja" beantwoord, dit algoritme wordt aangemerkt als impactvol en opgenomen in het (rijksbrede) algoritmeregister.',
+    'impact_algorithm_message' => 'Alle drie de vragen zijn met "Ja" beantwoord, dit algoritme wordt aangemerkt als impactvol en opgenomen in het algoritmeregister.',
 
     'help_description' => 'Eén alinea in begrijpelijke taal voor een burger; maximaal 400 tekens.',
     'help_theme' => 'Het beleidsterrein waarop het algoritme wordt ingezet, bijvoorbeeld Openbare orde en veiligheid.',

--- a/src/cms/resources/lang/nl/information_blocks.php
+++ b/src/cms/resources/lang/nl/information_blocks.php
@@ -599,11 +599,11 @@ return [
 
         'step_meta_title' => 'Informatie over Metadata',
         'step_meta_info' => '
-            <p class="text-sm text-gray-500">Geef bij "Datum van ontwikkeling" aan wanneer een algoritme ontwikkeld is, helpt AI compliance officers bij overzicht recent of nog te ontwikkelen algoritmes. Geef bij "Eigenaar van het algoritme" aan wie de eindverantwoordelijk is (bijv. proceseigenaar). Geef bij "Product owner van het algoritme" aan wie operationeel verantwoordelijk is voor beheer en doorontwikkeling. Vermeld bij "Landelijk-ID" het identificatienummer dat het Algoritmeregister aan deze registratie heeft toegekend. Noteer bij "Bron-ID" de unieke identificatie voor deze registratie zoals die binnen de eigen organisatie wordt gehanteerd. Voeg bij "Zoektermen" relevante trefwoorden toe die het algoritme beschrijven, gescheiden door komma\'s. Deze zoektermen zijn niet zichtbaar op de website, maar verbeteren wel de vindbaarheid.</p>',
+            <p class="text-sm text-gray-500">Geef bij "Datum van ontwikkeling" aan wanneer een algoritme ontwikkeld is, helpt AI compliance officers bij overzicht recent of nog te ontwikkelen algoritmes. Geef bij "Eigenaar van het algoritme" aan wie de eindverantwoordelijk is (bijv. proceseigenaar). Geef bij "Product owner van het algoritme" aan wie operationeel verantwoordelijk is voor beheer en doorontwikkeling. Vermeld bij "Extern registratienummer" het identificatienummer dat een extern register aan deze registratie heeft toegekend, bijvoorbeeld het landelijke Algoritmeregister. Noteer bij "Bron-ID" de unieke identificatie voor deze registratie zoals die binnen de eigen organisatie wordt gehanteerd. Voeg bij "Zoektermen" relevante trefwoorden toe die het algoritme beschrijven, gescheiden door komma\'s. Deze zoektermen zijn niet zichtbaar op de website, maar verbeteren wel de vindbaarheid.</p>',
 
         'step_impact_title' => 'Informatie over Impactvol algoritme',
         'step_impact_info' => '
-            <p class="text-sm text-gray-500">Beantwoord de toetsvragen met een "Ja" of "Nee", <span class="font-bold">Let op:</span> als alle drie de vragen met "Ja" zijn beantwoord, moet het algoritme als impactvol worden aangemerkt en opgenomen worden in het (rijksbrede) algoritmeregister.</p>',
+            <p class="text-sm text-gray-500">Beantwoord de toetsvragen met een "Ja" of "Nee", <span class="font-bold">Let op:</span> als alle drie de vragen met "Ja" zijn beantwoord, moet het algoritme als impactvol worden aangemerkt en opgenomen worden in het algoritmeregister.</p>',
 
         'step_validation_title' => 'Informatie over Validatie',
         'step_validation_info' => '

--- a/src/cms/tests/Feature/Console/Commands/SqlExecuteTest.php
+++ b/src/cms/tests/Feature/Console/Commands/SqlExecuteTest.php
@@ -9,7 +9,7 @@ use Tests\Helpers\ConfigTestHelper;
 it('can run the artisan sql-execute command', function (): void {
     $this->mock(DatabaseManager::class)
         ->shouldReceive('unprepared')
-        ->times(169);
+        ->times(170);
 
     $this->artisan('sql-execute')
         ->assertSuccessful();

--- a/src/cms/tests/Feature/Filament/Resources/AlgorithmRecordResource/Pages/EditAlgorithmRecordTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/AlgorithmRecordResource/Pages/EditAlgorithmRecordTest.php
@@ -88,8 +88,7 @@ it('can be cloned', function (): void {
         ->and($algorithmRecordClone->public_from?->toJson())->toBe($algorithmRecord->public_from?->toJson())
         ->and($algorithmRecordClone->algorithm_theme_id)->toEqual($algorithmRecord->algorithm_theme_id)
         ->and($algorithmRecordClone->algorithm_status_id)->toEqual($algorithmRecord->algorithm_status_id)
-        ->and($algorithmRecordClone->algorithm_publication_category_id)->toEqual($algorithmRecord->algorithm_publication_category_id)
-        ->and($algorithmRecordClone->algorithm_meta_schema_id)->toEqual($algorithmRecord->algorithm_meta_schema_id);
+        ->and($algorithmRecordClone->algorithm_publication_category_id)->toEqual($algorithmRecord->algorithm_publication_category_id);
 
     expect($algorithmRecordClone->fgRemark)->toBeNull();
     expect($algorithmRecordClone->snapshots)->toBeEmpty();


### PR DESCRIPTION
Vervolg op #32. Nu OpenVWR van ministeriespecifiek naar algemeen inzetbaar gaat, vervallen de plannen om aan te leveren aan algoritmes.overheid.nl. Deze PR ruimt op wat daardoor overbodig is geworden.

## Dode kolommen verwijderd

`algorithm_meta_schema_id` en `meta_lang` verloren in #32 hun laatste gebruiker: geen formulier, geen model, geen relatie, geen export. De kolommen en de tabel `algorithm_meta_schemas` gaan er nu uit, inclusief de SQL-mirror (`v1.15.0`, gegenereerd met `sql-generate`).

## Datum-casts rechtgetrokken

`start_date` en `end_date` zijn `date`-kolommen zonder cast — als enige in de codebase. `DataBreachRecord`, `Document` en de rest casten hun datumkolommen wel. Ze kwamen dus terug als string terwijl `public_from` wél een `CarbonImmutable` opleverde. Nu consistent.

## Ministeriespecifieke teksten algemener gemaakt

- **"Landelijk-ID" → "Extern registratienummer"**. Het veld ging uit van één landelijk register; nu beschrijft het elk extern register, met het landelijke Algoritmeregister als voorbeeld in de helptekst.
- **"(rijksbrede)" geschrapt** uit twee teksten over impactvolle algoritmes.

Let op: dit raakt tekst uit #31 (@tschmits weet wie daaraan werkte). Ik heb bewust **alleen labels en helpteksten** aangepast — de kolomnaam `meta_national_id`, de toetsvragen en de logica eromheen blijven ongemoeid. Als de oorspronkelijke bewoording bedoeld was, draai die commit gerust terug.

## Bewust niet gedaan

- `import_id` leek dood gewicht, maar blijkt een conventie over ~10 modellen (ContactPerson, Responsible, System, alle AVG-modellen). Alleen bij `AlgorithmRecord` weghalen zou juist inconsistent zijn.
- De lookup-tabellen voor thema/status/publicatiecategorie blijven per organisatie instelbaar. Voor een algemeen product is dat juist het goede model — elke klant beheert zijn eigen waardelijst.

## Getest

- `phpcs` en `phpstan` schoon.
- Migratie draait; kolommen en tabel geverifieerd verdwenen uit het schema.
- Testsuite in een worktree vergeleken met en zonder deze wijzigingen: in beide gevallen exact dezelfde enkele failure (ontbrekende Vite-manifest in de worktree, geen regressie). CI draait de suite volledig.

## Nog open

`AlgorithmRecordDataFactory` is een lege class: algoritme-snapshots slaan geen enkele inhoud op (`private_markdown` NULL, `public_frontmatter` `[]`). Een vastgestelde snapshot is dus een lege envelop. Of snapshots hier niet nodig zijn, of het is onaf — de moeite waard om te bevestigen, maar buiten scope van deze PR.
