### PR TITLE
fix: capture algorithm record content in snapshots

### DIFF
--- a/src/cms/app/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactory.php
+++ b/src/cms/app/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactory.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace App\Services\Snapshot\SnapshotSource;
 
+use App\Models\Snapshot;
 use App\Services\Snapshot\SnapshotSourceDataFactory;
 
 class AlgorithmRecordDataFactory extends DataFactory implements SnapshotSourceDataFactory
 {
+    public function generatePrivateMarkdown(Snapshot $snapshot): string
+    {
+        return $this->render('snapshot-data-create.algorithm-record.private-markdown', $snapshot);
+    }
 }

--- a/src/cms/resources/views/snapshot-data-create/algorithm-record/private-markdown.blade.php
+++ b/src/cms/resources/views/snapshot-data-create/algorithm-record/private-markdown.blade.php
@@ -1,0 +1,60 @@
+@php
+    /** @var App\Models\Algorithm\AlgorithmRecord $record */
+@endphp
+
+# {!! Str::toSingleLineEscapedString($record->name) !!}
+
+## {{ __('algorithm_record.step_processing_name') }}
+
+- **{{ __('algorithm_record.number') }}**: {!! Str::toSingleLineEscapedString($record->getNumber()) !!}
+- **{{ __('algorithm_record.description') }}**: {!! Str::toSingleLineEscapedString($record->description, '-') !!}
+- **{{ __('algorithm_record.theme') }}**: {!! Str::toSingleLineEscapedString($record->algorithmTheme?->name, '-') !!}
+- **{{ __('algorithm_record.status') }}**: {!! Str::toSingleLineEscapedString($record->algorithmStatus?->name, '-') !!}
+- **{{ __('algorithm_record.start_date') }}**: {{ DateFormat::toDate($record->start_date) ?? '-' }}
+- **{{ __('algorithm_record.end_date') }}**: {{ DateFormat::toDate($record->end_date) ?? '-' }}
+- **{{ __('algorithm_record.contact_data') }}**: {!! Str::toSingleLineEscapedString($record->contact_data, '-') !!}
+- **{{ __('algorithm_record.public_page_link') }}**: {!! Str::toSingleLineEscapedString($record->public_page_link, '-') !!}
+- **{{ __('algorithm_record.publication_category') }}**: {!! Str::toSingleLineEscapedString($record->algorithmPublicationCategory?->name, '-') !!}
+- **{{ __('algorithm_record.source_link') }}**: {!! Str::toSingleLineEscapedString($record->source_link, '-') !!}
+
+## {{ __('algorithm_record.step_responsible_use') }}
+
+- **{{ __('algorithm_record.resp_goal_and_impact') }}**: {!! Str::toSingleLineEscapedString($record->resp_goal_and_impact, '-') !!}
+- **{{ __('algorithm_record.resp_considerations') }}**: {!! Str::toSingleLineEscapedString($record->resp_considerations, '-') !!}
+- **{{ __('algorithm_record.resp_human_intervention') }}**: {!! Str::toSingleLineEscapedString($record->resp_human_intervention, '-') !!}
+- **{{ __('algorithm_record.resp_risk_analysis') }}**: {!! Str::toSingleLineEscapedString($record->resp_risk_analysis, '-') !!}
+- **{{ __('algorithm_record.resp_legal_base_title') }}**: {!! Str::toSingleLineEscapedString($record->resp_legal_base_title, '-') !!}
+- **{{ __('algorithm_record.resp_legal_base') }}**: {!! Str::toSingleLineEscapedString($record->resp_legal_base, '-') !!}
+- **{{ __('algorithm_record.resp_legal_base_link') }}**: {!! Str::toSingleLineEscapedString($record->resp_legal_base_link, '-') !!}
+- **{{ __('algorithm_record.resp_processor_registry_link') }}**: {!! Str::toSingleLineEscapedString($record->resp_processor_registry_link, '-') !!}
+- **{{ __('algorithm_record.resp_impact_tests') }}**: {!! Str::toSingleLineEscapedString($record->resp_impact_tests, '-') !!}
+- **{{ __('algorithm_record.resp_impact_test_links') }}**: {!! Str::toSingleLineEscapedString($record->resp_impact_test_links, '-') !!}
+- **{{ __('algorithm_record.resp_impact_tests_description') }}**: {!! Str::toSingleLineEscapedString($record->resp_impact_tests_description, '-') !!}
+
+## {{ __('algorithm_record.step_mechanics') }}
+
+- **{{ __('algorithm_record.oper_data_title') }}**: {!! Str::toSingleLineEscapedString($record->oper_data_title, '-') !!}
+- **{{ __('algorithm_record.oper_data') }}**: {!! Str::toSingleLineEscapedString($record->oper_data, '-') !!}
+- **{{ __('algorithm_record.oper_links') }}**: {!! Str::toSingleLineEscapedString($record->oper_links, '-') !!}
+- **{{ __('algorithm_record.oper_technical_operation') }}**: {!! Str::toSingleLineEscapedString($record->oper_technical_operation, '-') !!}
+- **{{ __('algorithm_record.oper_supplier') }}**: {!! Str::toSingleLineEscapedString($record->oper_supplier, '-') !!}
+- **{{ __('algorithm_record.oper_source_code_link') }}**: {!! Str::toSingleLineEscapedString($record->oper_source_code_link, '-') !!}
+
+## {{ __('algorithm_record.step_meta') }}
+
+- **{{ __('algorithm_record.meta_date_of_development') }}**: {{ DateFormat::toDate($record->meta_date_of_development) ?? '-' }}
+- **{{ __('algorithm_record.meta_owner_algorithm') }}**: {!! Str::toSingleLineEscapedString($record->meta_owner_algorithm, '-') !!}
+- **{{ __('algorithm_record.meta_product_owner_algorithm') }}**: {!! Str::toSingleLineEscapedString($record->meta_product_owner_algorithm, '-') !!}
+- **{{ __('algorithm_record.meta_national_id') }}**: {!! Str::toSingleLineEscapedString($record->meta_national_id, '-') !!}
+- **{{ __('algorithm_record.meta_source_id') }}**: {!! Str::toSingleLineEscapedString($record->meta_source_id, '-') !!}
+- **{{ __('algorithm_record.meta_tags') }}**: {!! Str::toSingleLineEscapedString($record->meta_tags, '-') !!}
+
+## {{ __('algorithm_record.step_impact') }}
+
+- **{{ __('algorithm_record.impact_with_consequences') }}**: {{ $record->impact_with_consequences === null ? '-' : ($record->impact_with_consequences ? __('general.yes') : __('general.no')) }}
+- **{{ __('algorithm_record.impact_more_algorithms_applied') }}**: {{ $record->impact_more_algorithms_applied === null ? '-' : ($record->impact_more_algorithms_applied ? __('general.yes') : __('general.no')) }}
+- **{{ __('algorithm_record.impact_effect_on_outcome') }}**: {{ $record->impact_effect_on_outcome === null ? '-' : ($record->impact_effect_on_outcome ? __('general.yes') : __('general.no')) }}
+
+## {{ __('algorithm_record.step_validation') }}
+
+- **{{ __('algorithm_record.validation_answers_checked_by_product_owner') }}**: {{ $record->validation_answers_checked_by_product_owner === null ? '-' : ($record->validation_answers_checked_by_product_owner ? __('general.yes') : __('general.no')) }}

--- a/src/cms/tests/.pest/snapshots/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest/it_can_generate_private_markdown.snap
+++ b/src/cms/tests/.pest/snapshots/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest/it_can_generate_private_markdown.snap
@@ -1,0 +1,56 @@
+# a5c2f0f4\-1d1e\-4a4a\-9d5c\-1f6a1b2c3d4e
+
+## Naam algoritme
+
+- **Nummer**: ALG000001
+- **Korte omschrijving**: Beschrijving van het algoritme\.
+- **Thema**: Verkeer
+- **Status**: In gebruik
+- **Begindatum**: 01-01-2024
+- **Einddatum**: -
+- **Contactgegevens**: contact@example\.com
+- **Link naar publiekspagina**: https://example\.com/algoritme
+- **Publicatiecategorie**: Impactvolle algoritmes
+- **Link naar bronregistratie**: https://example\.com/bron
+
+## Verantwoord gebruik
+
+- **Doel en impact**: Doel en impact\.
+- **Afwegingen**: Afwegingen\.
+- **Menselijke tussenkomst**: Menselijke tussenkomst\.
+- **Risicobeheer**: Risicobeheer\.
+- **Titel van wettelijke basis**: Wegenverkeerswet 1994
+- **Wettelijke basis**: Wettelijke basis\.
+- **Link naar wettelijke basis**: https://example\.com/wet
+- **Link naar verwerkingsregister**: https://example\.com/verwerkingsregister
+- **Impacttoetsen**: DPIA
+- **Links naar impacttoetsen**: https://example\.com/dpia
+- **Toelichting op impacttoetsen**: Toelichting op impacttoetsen\.
+
+## Werking
+
+- **Titel van gegevensbron**: Titel van gegevensbron
+- **Gegevens**: Gegevens\.
+- **Links naar gegevensbronnen**: https://example\.com/gegevensbron
+- **Technische werking**: Technische werking\.
+- **Leverancier**: Intern ontwikkeld
+- **Link naar broncode**: https://example\.com/broncode
+
+## Metadata
+
+- **Datum van ontwikkeling**: 01-06-2023
+- **Eigenaar van het algoritme**: Afdelingshoofd
+- **Product owner van het algoritme**: Product owner
+- **Landelijk-ID**: REG\-001
+- **Bron-ID**: BRON\-001
+- **Zoektermen**: verkeer, sensoren
+
+## Impactvol algoritme
+
+- **Is er sprake van een proces met directe gevolgen voor burgers of organisaties?**: Ja
+- **Worden er in dit proces één of meerdere algoritmes toegepast?**: Nee
+- **Heeft het algoritme een significant effect op de uitkomst van het proces?**: -
+
+## Validatie
+
+- **Antwoorden op de toetsvragen gecontroleerd door product owner**: Ja

--- a/src/cms/tests/.pest/snapshots/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest/it_can_generate_private_markdown.snap
+++ b/src/cms/tests/.pest/snapshots/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest/it_can_generate_private_markdown.snap
@@ -41,7 +41,7 @@
 - **Datum van ontwikkeling**: 01-06-2023
 - **Eigenaar van het algoritme**: Afdelingshoofd
 - **Product owner van het algoritme**: Product owner
-- **Landelijk-ID**: REG\-001
+- **Extern registratienummer**: REG\-001
 - **Bron-ID**: BRON\-001
 - **Zoektermen**: verkeer, sensoren
 

--- a/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest.php
+++ b/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/AlgorithmRecordDataFactoryTest.php
@@ -2,16 +2,70 @@
 
 declare(strict_types=1);
 
+use App\Models\Algorithm\AlgorithmPublicationCategory;
+use App\Models\Algorithm\AlgorithmRecord;
+use App\Models\Algorithm\AlgorithmStatus;
+use App\Models\Algorithm\AlgorithmTheme;
+use App\Models\EntityNumber;
 use App\Models\Snapshot;
 use App\Services\Snapshot\SnapshotSource\AlgorithmRecordDataFactory;
 
 it('can generate private markdown', function (): void {
+    $algorithmRecord = AlgorithmRecord::factory()
+        ->create([
+            'entity_number_id' => EntityNumber::factory()->state([
+                'number' => 'ALG000001',
+            ]),
+            'name' => 'a5c2f0f4-1d1e-4a4a-9d5c-1f6a1b2c3d4e',
+            'description' => 'Beschrijving van het algoritme.',
+            'algorithm_theme_id' => AlgorithmTheme::factory()->create(['name' => 'Verkeer']),
+            'algorithm_status_id' => AlgorithmStatus::factory()->create(['name' => 'In gebruik']),
+            'algorithm_publication_category_id' => AlgorithmPublicationCategory::factory()
+                ->create(['name' => 'Impactvolle algoritmes']),
+            'start_date' => '2024-01-01',
+            'end_date' => null,
+            'contact_data' => 'contact@example.com',
+            'public_page_link' => 'https://example.com/algoritme',
+            'source_link' => 'https://example.com/bron',
+
+            'resp_goal_and_impact' => 'Doel en impact.',
+            'resp_considerations' => 'Afwegingen.',
+            'resp_human_intervention' => 'Menselijke tussenkomst.',
+            'resp_risk_analysis' => 'Risicobeheer.',
+            'resp_legal_base_title' => 'Wegenverkeerswet 1994',
+            'resp_legal_base' => 'Wettelijke basis.',
+            'resp_legal_base_link' => 'https://example.com/wet',
+            'resp_processor_registry_link' => 'https://example.com/verwerkingsregister',
+            'resp_impact_tests' => 'DPIA',
+            'resp_impact_test_links' => 'https://example.com/dpia',
+            'resp_impact_tests_description' => 'Toelichting op impacttoetsen.',
+
+            'oper_data_title' => 'Titel van gegevensbron',
+            'oper_data' => 'Gegevens.',
+            'oper_links' => 'https://example.com/gegevensbron',
+            'oper_technical_operation' => 'Technische werking.',
+            'oper_supplier' => 'Intern ontwikkeld',
+            'oper_source_code_link' => 'https://example.com/broncode',
+
+            'meta_date_of_development' => '2023-06-01',
+            'meta_owner_algorithm' => 'Afdelingshoofd',
+            'meta_product_owner_algorithm' => 'Product owner',
+            'meta_national_id' => 'REG-001',
+            'meta_source_id' => 'BRON-001',
+            'meta_tags' => 'verkeer, sensoren',
+            'impact_with_consequences' => true,
+            'impact_more_algorithms_applied' => false,
+            'impact_effect_on_outcome' => null,
+            'validation_answers_checked_by_product_owner' => true,
+        ]);
+
     $snapshot = Snapshot::factory()
+        ->for($algorithmRecord, 'snapshotSource')
         ->create();
 
     $algorithmRecordDataFactory = new AlgorithmRecordDataFactory();
     expect($algorithmRecordDataFactory->generatePrivateMarkdown($snapshot))
-        ->toBeNull();
+        ->toMatchSnapshot();
 });
 
 it('can generate public frontmatter', function (): void {

--- a/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/DataFactoryTest.php
+++ b/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/DataFactoryTest.php
@@ -6,7 +6,8 @@ use App\Models\Snapshot;
 use App\Services\Snapshot\SnapshotSource\DataFactory;
 
 it('returns empty defaults for a source that generates no data', function (): void {
-    $factory = new class extends DataFactory {};
+    $factory = new class extends DataFactory {
+    };
 
     $snapshot = Snapshot::factory()->create();
 

--- a/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/DataFactoryTest.php
+++ b/src/cms/tests/Feature/Services/Snapshot/SnapshotSource/DataFactoryTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Snapshot;
+use App\Services\Snapshot\SnapshotSource\DataFactory;
+
+it('returns empty defaults for a source that generates no data', function (): void {
+    $factory = new class extends DataFactory {};
+
+    $snapshot = Snapshot::factory()->create();
+
+    expect($factory->generatePrivateMarkdown($snapshot))->toBeNull()
+        ->and($factory->generatePublicMarkdown($snapshot))->toBeNull()
+        ->and($factory->generatePublicFrontmatter($snapshot))->toBe([]);
+});


### PR DESCRIPTION
Vervangt #40, dat per ongeluk in de branch van #39 is gemerged in plaats van in `main` — inhoudelijk hetzelfde werk, nu tegen `main` en zelfstandig te mergen.

## Probleem

`AlgorithmRecordDataFactory` had een lege body:

```php
class AlgorithmRecordDataFactory extends DataFactory implements SnapshotSourceDataFactory
{
}
```

De abstracte `DataFactory` geeft standaard `null`, `[]` en `null` terug. Elke snapshot van een algoritme werd dus opgeslagen met `private_markdown = NULL`, `public_frontmatter = []` en `public_markdown = NULL`.

Een algoritme doorloopt daarmee de volledige goedkeuringsflow — InReview → Approved → Established — terwijl de snapshot **niets vastlegt over het record**. De PDF-export en de snapshotweergave hebben niets om te tonen. Omdat snapshots gerenderde tekst bevriezen en geen attributen, valt dat achteraf ook niet te reconstrueren.

Van de negen modellen die `SnapshotSource` implementeren was dit de enige zonder blade-template in `resources/views/snapshot-data-create/`. De bestaande test legde het gat vast met `->toBeNull()`.

## Oplossing

Template volgens hetzelfde patroon als de AVG- en WPG-varianten: `## {{ __('...step_*') }}`-secties die de stappen van het formulier volgen, `- **label**: waarde`-regels, `Str::toSingleLineEscapedString(..., '-')` voor lege waarden en `DateFormat::toDate()` voor datums. De secties lopen gelijk met de wizard, inclusief de velden uit #31. Booleans renderen als Ja / Nee / `-` via `general.yes` en `general.no`, net als de radio's in het formulier.

## Waarom de date-cast hierin zit

`DateFormat::toDate()` accepteert alleen `CalendarDate|CarbonImmutable|null`. `start_date` en `end_date` waren `date`-kolommen **zonder cast** — als enige in de codebase — dus kwam er een string uit en faalde de aanroep met een TypeError. De cast zit daarom in deze PR.

Diezelfde cast zit ook in #39. Wat er als tweede merget krijgt een triviaal conflict in `casts()`; beide kanten zijn identiek, dus elke resolutie is goed.

## Getest

- `phpcs`, `phpstan` en de drie tests in `AlgorithmRecordDataFactoryTest` slagen tegen `main`.
- Alle velden die de template leest zijn vastgezet (inclusief het entity number, zoals in `AvgResponsibleProcessingRecordDataFactoryTest`), zodat de snapshot reproduceerbaar is.

## Let op bij review

De template bepaalt **wat** er in een snapshot terechtkomt, en dat is voor bestaande snapshots achteraf niet meer te wijzigen. De veldkeuze is nu "alles wat in het formulier staat". Als bepaalde velden er bewust niet in horen, is dit het moment om dat te zeggen.

Eén afhankelijkheid om te weten: #39 hernoemt het label "Landelijk-ID" naar "Extern registratienummer", en dat label staat in de vastgelegde snapshot. Na het mergen van #39 moet `it_can_generate_private_markdown.snap` opnieuw gegenereerd worden (`vendor/bin/pest -d --update-snapshots`), of andersom. Klein, maar niet vergeten.
