### PR TITLE
feat: Nederlandstalige demo-seeder voor sales en demo-deployments

### DIFF
--- a/src/cms/database/seeders/CreatesEntityNumbers.php
+++ b/src/cms/database/seeders/CreatesEntityNumbers.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\EntityNumberType;
+use App\Models\EntityNumber;
+use App\Models\EntityNumberCounter;
+use App\Models\Organisation;
+
+use function sprintf;
+
+/**
+ * Issues register and data-breach numbers from an organisation's counters.
+ *
+ * Shared by DemoSeeder and DemoRegisterSeeder: both create numbered entities,
+ * and the counter has to advance across the two so numbers stay unique and
+ * read as one continuous series (ZGN002, ZGN003, ...) in the overview tables.
+ */
+trait CreatesEntityNumbers
+{
+    private function createEntityNumber(Organisation $organisation, EntityNumberType $type): EntityNumber
+    {
+        $counter = $type === EntityNumberType::REGISTER
+            ? $organisation->registerEntityNumberCounter
+            : $organisation->databreachEntityNumberCounter;
+
+        $this->advance($counter);
+
+        return EntityNumber::factory()->create([
+            'type' => $type,
+            'number' => sprintf('%s%03d', $counter->prefix, $counter->number),
+        ]);
+    }
+
+    private function advance(EntityNumberCounter $counter): void
+    {
+        $counter->number++;
+        $counter->save();
+    }
+}

--- a/src/cms/database/seeders/DemoAvgRegisterSeeder.php
+++ b/src/cms/database/seeders/DemoAvgRegisterSeeder.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\CoreEntityDataCollectionSource;
+use App\Enums\EntityNumberType;
+use App\Enums\Snapshot\SnapshotApprovalLogMessageType;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Models\Avg\AvgGoal;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Document;
+use App\Models\FgRemark;
+use App\Models\Organisation;
+use App\Models\Remark;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\SnapshotApprovalLog;
+use App\Models\Stakeholder;
+use App\Models\States\Snapshot\Approved;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\InReview;
+use App\Models\States\Snapshot\Obsolete;
+use App\Models\User;
+use App\Services\Snapshot\SnapshotDataFactory;
+use Carbon\CarbonInterface;
+
+use function count;
+use function now;
+
+/**
+ * The AVG-verantwoordelijke register: the register a demo opens on, and the
+ * only one carrying a full version history and approval trail.
+ *
+ * Split from DemoSeeder so that class stays about building an organisation
+ * (users, lookup lists, shared entities) while the register content - records,
+ * goals, stakeholders, remarks, versions and signatures - lives here.
+ *
+ * @phpstan-type AvgRecordDefinition array{name: string, service: string, goal: string, legal_base: string, retention: string, stakeholder: string, data_items: list<string>, special_data: bool, bsn: bool, systems: list<int>, processors: list<int>, receivers: list<int>, tags: list<int>, state: string, review_offset_months: int, dpia: bool, outside_eu: bool, description: string}
+ */
+final class DemoAvgRegisterSeeder
+{
+    use CreatesEntityNumbers;
+
+    /**
+     * @param array<string, User> $users
+     */
+    public function __construct(
+        private readonly Organisation $organisation,
+        private readonly DemoRelatedEntities $related,
+        private readonly array $users,
+        private readonly SnapshotDataFactory $snapshotDataFactory = new SnapshotDataFactory(),
+    ) {
+    }
+
+    /**
+     * @param list<Document> $documents
+     */
+    public function seed(array $documents, bool $isPrimary): void
+    {
+        $this->createAvgResponsibleRecords($this->organisation, $this->related, $documents, $this->users, $isPrimary);
+    }
+
+    /**
+     * @param list<Document> $documents
+     * @param array<string, User> $users
+     */
+    private function createAvgResponsibleRecords(
+        Organisation $organisation,
+        DemoRelatedEntities $related,
+        array $documents,
+        array $users,
+        bool $isPrimary,
+    ): void {
+        // Secondary organisations get a shorter register: enough to prove the
+        // tenant is populated, not so much that it competes for attention.
+        $definitions = $isPrimary
+            ? DemoContent::AVG_RECORDS
+            : [DemoContent::AVG_RECORDS[0], DemoContent::AVG_RECORDS[2], DemoContent::AVG_RECORDS[4]];
+
+        foreach ($definitions as $index => $definition) {
+            $record = AvgResponsibleProcessingRecord::factory()->for($organisation)->recycle($organisation)->create([
+                'import_id' => null,
+                'name' => $definition['name'],
+                'data_collection_source' => CoreEntityDataCollectionSource::PRIMARY,
+                'avg_responsible_processing_record_service_id' => $related->services[$definition['service']]->id,
+                'entity_number_id' => $this->createEntityNumber($organisation, EntityNumberType::REGISTER),
+                'responsibility_distribution' => $definition['description'],
+
+                'has_pseudonymization' => $definition['special_data'],
+                'pseudonymization' => $definition['special_data']
+                    ? 'Gegevens worden gepseudonimiseerd voordat zij voor analyse worden gebruikt.'
+                    : null,
+
+                'outside_eu' => $definition['outside_eu'],
+                'outside_eu_description' => $definition['outside_eu']
+                    ? 'De leverancier verwerkt gegevens op servers in de Verenigde Staten.'
+                    : null,
+                'outside_eu_protection_level' => $definition['outside_eu'],
+                'outside_eu_protection_level_description' => $definition['outside_eu']
+                    ? 'Er zijn standaardcontractbepalingen (SCC\'s) afgesloten en er is een transfer '
+                        . 'impact assessment uitgevoerd.'
+                    : null,
+
+                // No automated decision-making anywhere in the register: that
+                // story belongs to the algorithm register, and claiming it here
+                // too would invite the wrong question at the wrong moment.
+                'decision_making' => false,
+                'logic' => null,
+                'importance_consequences' => null,
+
+                'geb_dpia_executed' => $definition['dpia'],
+                'geb_dpia_automated' => false,
+                'geb_dpia_large_scale_processing' => $definition['special_data'],
+                'geb_dpia_large_scale_monitoring' => $definition['name'] === 'Cameratoezicht toegangsbeveiliging',
+                'geb_dpia_list_required' => $definition['dpia'],
+                'geb_dpia_criteria_wp248' => $definition['dpia'],
+                'geb_dpia_high_risk_freedoms' => $definition['special_data'],
+
+                // Every demo record names at least one system; only the
+                // processors list is genuinely empty for some (the inkoop
+                // record is run entirely in-house).
+                'has_processors' => $definition['processors'] !== [],
+                'has_systems' => true,
+                'has_security' => true,
+
+                'review_at' => now()->addMonths($definition['review_offset_months'])->toDateString(),
+                'public_from' => $definition['state'] === 'established' ? now()->subMonth() : null,
+            ]);
+
+            $this->attachRelated($record, $related, $definition);
+
+            AvgGoal::factory()
+                ->for($organisation)
+                ->hasAttached($record)
+                ->create([
+                    'goal' => $definition['goal'],
+                    'avg_goal_legal_base' => $definition['legal_base'],
+                    'import_id' => null,
+                    'remarks' => null,
+                ]);
+
+            $this->createStakeholder($organisation, $record, $definition);
+
+            // Spread documents across records rather than attaching all of them
+            // everywhere: the document register is more convincing when the
+            // DPIA sits on the record it was written for.
+            if ($documents !== []) {
+                $record->documents()->attach($documents[$index % count($documents)]->id);
+            }
+
+            $this->createRemarks($record, $index, $users);
+            $this->createSnapshots($organisation, $record, $definition, $users);
+        }
+    }
+
+    /**
+     * @param AvgRecordDefinition $definition
+     */
+    private function attachRelated(
+        AvgResponsibleProcessingRecord $record,
+        DemoRelatedEntities $related,
+        array $definition,
+    ): void {
+        foreach ($definition['systems'] as $key) {
+            $record->systems()->attach($related->systems[$key]->id);
+        }
+
+        foreach ($definition['processors'] as $key) {
+            $record->processors()->attach($related->processors[$key]->id);
+        }
+
+        foreach ($definition['receivers'] as $key) {
+            $record->receivers()->attach($related->receivers[$key]->id);
+        }
+
+        foreach ($definition['tags'] as $key) {
+            $record->tags()->attach($related->tags[$key]->id);
+        }
+
+        $record->responsibles()->attach($related->responsible->id);
+
+        foreach ($related->contactPersons as $contactPerson) {
+            $record->contactPersons()->attach($contactPerson->id);
+        }
+    }
+
+    /**
+     * @param AvgRecordDefinition $definition
+     */
+    private function createStakeholder(
+        Organisation $organisation,
+        AvgResponsibleProcessingRecord $record,
+        array $definition,
+    ): void {
+        $stakeholder = Stakeholder::factory()
+            ->for($organisation)
+            ->hasAttached($record)
+            ->create([
+                'description' => $definition['stakeholder'],
+
+                'health' => $definition['special_data'],
+                'biometric' => false,
+                'faith_or_belief' => false,
+                'genetic' => false,
+                'political_attitude' => false,
+                'race_or_ethnicity' => false,
+                'sexual_life' => false,
+                'trade_association_membership' => false,
+                'criminal_law' => false,
+                'special_collected_data_explanation' => $definition['special_data']
+                    ? 'Gezondheidsgegevens worden uitsluitend verwerkt voor zover noodzakelijk voor '
+                        . 'de verzuimbegeleiding en zijn alleen toegankelijk voor de arbodienst.'
+                    : '',
+                'citizen_service_numbers' => $definition['bsn'],
+            ]);
+
+        // A data item carries its own purpose, retention period and source, so
+        // fill all of it: this is the level of detail an auditor asks about,
+        // and an empty retention period is the first thing they would spot.
+        foreach ($definition['data_items'] as $sort => $item) {
+            $stakeholder->stakeholderDataItems()->create([
+                'organisation_id' => $organisation->id,
+                'import_id' => null,
+                'description' => $item,
+                'collection_purpose' => $definition['goal'],
+                'retention_period' => $definition['retention'],
+                'is_source_stakeholder' => true,
+                'source_description' => 'De gegevens worden verstrekt door de betrokkene zelf.',
+                'is_stakeholder_mandatory' => $definition['legal_base'] !== DemoContent::LEGAL_BASE_CONSENT,
+                'stakeholder_consequences' => $definition['legal_base'] === DemoContent::LEGAL_BASE_CONSENT
+                    ? 'Zonder toestemming vindt geen verwerking plaats; deelname is vrijwillig.'
+                    : 'Zonder deze gegevens kan de verwerking niet worden uitgevoerd.',
+                'sort' => $sort,
+            ]);
+        }
+    }
+
+    /**
+     * @param array<string, User> $users
+     */
+    private function createRemarks(
+        AvgResponsibleProcessingRecord $record,
+        int $index,
+        array $users,
+    ): void {
+        $author = $users['privacy-officer'];
+
+        Remark::create([
+            'remark_relatable_id' => $record->id,
+            'remark_relatable_type' => $record::class,
+            'user_id' => $author->id,
+            'body' => DemoContent::REMARKS[$index % count(DemoContent::REMARKS)],
+        ]);
+
+        // FG remarks are visible only to the Functionaris Gegevensbescherming,
+        // so only some records carry one — a note on every record would make
+        // the role's view indistinguishable from everyone else's.
+        if ($index % 3 !== 0) {
+            return;
+        }
+
+        FgRemark::create([
+            'fg_remark_relatable_id' => $record->id,
+            'fg_remark_relatable_type' => $record::class,
+            'body' => DemoContent::FG_REMARKS[$index % count(DemoContent::FG_REMARKS)],
+        ]);
+    }
+
+    /**
+     * Build the version history behind a record.
+     *
+     * The `state` in DemoContent describes where the *newest* version sits.
+     * Anything past "draft" also gets a superseded established version, so the
+     * versions tab shows a history rather than a single row — a register whose
+     * every record has exactly one version does not look like one in use.
+     *
+     * @param AvgRecordDefinition $definition
+     * @param array<string, User> $users
+     */
+    private function createSnapshots(
+        Organisation $organisation,
+        AvgResponsibleProcessingRecord $record,
+        array $definition,
+        array $users,
+    ): void {
+        if ($definition['state'] === 'draft') {
+            // Never versioned: shows what a record looks like before it enters
+            // the approval process at all.
+            return;
+        }
+
+        $version = 1;
+
+        if ($definition['state'] !== 'established' || $definition['review_offset_months'] < 12) {
+            $this->createSnapshot($organisation, $record, $version, Obsolete::class, now()->subMonths(13));
+            $version++;
+        }
+
+        $state = match ($definition['state']) {
+            'in_review' => InReview::class,
+            'approved' => Approved::class,
+            'obsolete' => Obsolete::class,
+            default => Established::class,
+        };
+
+        $snapshot = $this->createSnapshot(
+            $organisation,
+            $record,
+            $version,
+            $state,
+            $definition['state'] === 'obsolete' ? now()->subMonths(2) : null,
+        );
+
+        $this->createApprovals($organisation, $snapshot, $definition, $users);
+    }
+
+
+    /**
+     * @param array<string, mixed> $options
+     */
+
+    /**
+     * Snapshot's $fillable covers only name, version and state: organisation_id,
+     * snapshot_source_* and replaced_at are guarded and would be dropped
+     * silently by create(). Force-fill them here so every snapshot in the demo
+     * is complete, and so the omission cannot recur per call site.
+     */
+    private function makeSnapshot(
+        Organisation $organisation,
+        AvgResponsibleProcessingRecord $source,
+        string $name,
+        int $version,
+        string $state,
+        ?CarbonInterface $replacedAt = null,
+    ): Snapshot {
+        $snapshot = new Snapshot();
+
+        $snapshot->forceFill([
+            'organisation_id' => $organisation->id,
+            'snapshot_source_id' => $source->id,
+            'snapshot_source_type' => $source::class,
+            'name' => $name,
+            'version' => $version,
+            'state' => $state,
+            'replaced_at' => $replacedAt,
+        ]);
+
+        $snapshot->save();
+
+        return $snapshot;
+    }
+
+    private function createSnapshot(
+        Organisation $organisation,
+        AvgResponsibleProcessingRecord $record,
+        int $version,
+        string $state,
+        ?CarbonInterface $replacedAt = null,
+    ): Snapshot {
+        $snapshot = $this->makeSnapshot($organisation, $record, $record->name, $version, $state, $replacedAt);
+
+        // Build the snapshot content with the same service the application
+        // uses when a version is really created, rather than the faker-backed
+        // SnapshotData factory. That factory writes lorem ipsum into
+        // public_markdown, which surfaces verbatim on the version detail page
+        // and on the public website - the two screens a demo is most likely to
+        // put on a projector.
+        $this->snapshotDataFactory->createDataForSnapshot($snapshot->refresh());
+
+        return $snapshot;
+    }
+
+    /**
+     * Approvals are where the goedkeuringsproces becomes visible, so all three
+     * outcomes are represented across the register: signed off, still waiting,
+     * and declined with a reason.
+     *
+     * @param AvgRecordDefinition $definition
+     * @param array<string, User> $users
+     */
+    private function createApprovals(
+        Organisation $organisation,
+        Snapshot $snapshot,
+        array $definition,
+        array $users,
+    ): void {
+        $mandateHolder = $users['mandate-holder'];
+
+        $status = match ($definition['state']) {
+            // Approved but not yet established: this is the version sitting in
+            // the mandate holder's inbox, and the one to open when showing the
+            // "Akkoord geven" screen.
+            'approved' => SnapshotApprovalStatus::UNKNOWN,
+            'in_review' => SnapshotApprovalStatus::DECLINED,
+            'established' => SnapshotApprovalStatus::APPROVED,
+            default => null,
+        };
+
+        if ($status === null) {
+            return;
+        }
+
+        $officer = $users['privacy-officer'];
+
+        $approval = new SnapshotApproval();
+
+        $approval->forceFill([
+            'snapshot_id' => $snapshot->id,
+            'requested_by' => $officer->id,
+            'assigned_to' => $mandateHolder->id,
+            'status' => $status,
+            // An unsigned approval must look un-notified, otherwise the demo
+            // account shows a task that the system believes it already chased.
+            'notified_at' => $status === SnapshotApprovalStatus::UNKNOWN ? null : now()->subWeek(),
+        ]);
+
+        $approval->save();
+
+        // The approval trail on the version page is built from these log
+        // entries, and the decline reason lives here rather than on the
+        // approval itself. Mirror the shape SnapshotApprovalService writes, so
+        // the trail renders exactly as it would after a real sign-off.
+        SnapshotApprovalLog::create([
+            'snapshot_id' => $snapshot->id,
+            'user_id' => $officer->id,
+            'message' => [
+                'type' => SnapshotApprovalLogMessageType::APPROVAL_REQUEST,
+                'assigned_to' => $mandateHolder->logName,
+            ],
+        ]);
+
+        if ($status === SnapshotApprovalStatus::UNKNOWN) {
+            return;
+        }
+
+        SnapshotApprovalLog::create([
+            'snapshot_id' => $snapshot->id,
+            'user_id' => $mandateHolder->id,
+            'message' => [
+                'type' => SnapshotApprovalLogMessageType::APPROVAL_UPDATE,
+                'assigned_to' => $mandateHolder->logName,
+                'status' => $status->value,
+                'notes' => $status === SnapshotApprovalStatus::DECLINED ? DemoContent::DECLINE_REASON : null,
+            ],
+        ]);
+    }
+}

--- a/src/cms/database/seeders/DemoContent.php
+++ b/src/cms/database/seeders/DemoContent.php
@@ -1,0 +1,587 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+/**
+ * Hand-authored Dutch content for DemoSeeder.
+ *
+ * Kept apart from the seeder itself so the seeder reads as structure (which
+ * states exist, how entities relate) and this file reads as copy. Every string
+ * here is written out rather than generated: a demo is clicked through in front
+ * of a prospect, and faker latin behind the third tab undoes the whole pitch.
+ *
+ * The content is deliberately sector-neutral. Processings like personnel
+ * administration, access control and CCTV exist verbatim at a municipality, a
+ * hospital and an insurer alike, so the same register reads as plausible to
+ * whichever audience is in the room.
+ */
+final class DemoContent
+{
+    /**
+     * Organisations. Neutral registry-keeping bodies: recognisable as real
+     * organisations without tying the demo to government or to healthcare.
+     */
+    public const ORGANISATIONS = [
+        [
+            'name' => 'Stichting Zorggroep Noorderbrug',
+            'slug' => 'noorderbrug',
+            'prefix' => 'ZGN',
+            'legal_entity' => 'Stichting Zorggroep Noorderbrug',
+            'review_months' => 12,
+            'content' => 'Zorggroep Noorderbrug levert medisch-specialistische zorg vanuit drie '
+                . 'locaties. In dit register publiceren wij de verwerkingen van persoonsgegevens '
+                . 'waarvoor wij verwerkingsverantwoordelijke zijn.',
+        ],
+        [
+            'name' => 'Gemeente Westerdam',
+            'slug' => 'westerdam',
+            'prefix' => 'GWD',
+            'legal_entity' => 'Gemeente Westerdam',
+            'review_months' => 24,
+            'content' => 'De gemeente Westerdam verwerkt persoonsgegevens bij de uitvoering van haar '
+                . 'wettelijke taken. Dit register geeft inzicht in welke gegevens wij verwerken en '
+                . 'met welk doel.',
+        ],
+        [
+            'name' => 'Waarborgfonds Meridiaan',
+            'slug' => 'meridiaan',
+            'prefix' => 'WFM',
+            'legal_entity' => 'Waarborgfonds Meridiaan N.V.',
+            'review_months' => 12,
+            'content' => 'Waarborgfonds Meridiaan beheert collectieve verzekeringen en garantstellingen. '
+                . 'Wij hechten aan transparantie over de persoonsgegevens die wij daarbij verwerken.',
+        ],
+    ];
+
+    /**
+     * Demo users. One per role, so any feature can be shown from the account
+     * that would really perform it: the approval flow in particular only makes
+     * sense when the mandate holder is a different person from the officer who
+     * approved the version.
+     */
+    public const USERS = [
+        ['name' => 'Sanne de Groot', 'email' => 'sanne.degroot', 'role' => 'chief-privacy-officer'],
+        ['name' => 'Marieke de Vries', 'email' => 'marieke.devries', 'role' => 'mandate-holder'],
+        ['name' => 'Joost Bakker', 'email' => 'joost.bakker', 'role' => 'privacy-officer'],
+        ['name' => 'Fatima El Amrani', 'email' => 'fatima.elamrani', 'role' => 'input-processor'],
+        ['name' => 'Tom Hendriks', 'email' => 'tom.hendriks', 'role' => 'input-processor-databreach'],
+        ['name' => 'Hans Willems', 'email' => 'hans.willems', 'role' => 'data-protection-official'],
+        ['name' => 'Els Vermeer', 'email' => 'els.vermeer', 'role' => 'counselor'],
+    ];
+
+    /** Departments, used for the "AVG Verantwoordelijke Dienst" field. */
+    public const SERVICES = [
+        'Directie Bedrijfsvoering',
+        'Directie Informatievoorziening',
+        'Directie Juridische Zaken',
+        'Directie Personeel en Organisatie',
+        'Directie Publieke Dienstverlening',
+        'Directie Financiën en Control',
+    ];
+
+    /** Labels shown on records; a mix a privacy officer would really apply. */
+    public const TAGS = [
+        'Bijzondere persoonsgegevens',
+        'Cameratoezicht',
+        'DPIA uitgevoerd',
+        'Extern gedeeld',
+        'Financieel',
+        'Hoog risico',
+        'Medewerkers',
+        'Publiek toegankelijk',
+        'Verwerker betrokken',
+        'Wettelijke verplichting',
+    ];
+
+    /** Document types for the document register. */
+    public const DOCUMENT_TYPES = [
+        'DPIA',
+        'Verwerkersovereenkomst',
+        'Beveiligingsbeleid',
+        'Bewaartermijnenbeleid',
+        'Toestemmingsformulier',
+        'Auditrapport',
+    ];
+
+    /** Positions for contact persons. */
+    public const CONTACT_POSITIONS = [
+        'Privacy Officer',
+        'Functionaris Gegevensbescherming',
+        'Informatiebeveiligingsadviseur',
+        'Teamleider',
+        'Applicatiebeheerder',
+    ];
+
+    /**
+     * Systems in which processing takes place.
+     */
+    public const SYSTEMS = [
+        'AFAS Profit — personeels- en salarisadministratie',
+        'TOPdesk — meldingen en serviceverzoeken',
+        'Microsoft 365 — kantoorautomatisering en e-mail',
+        'Centraal dossiersysteem',
+        'Genetec Security Center — cameratoezicht',
+        'Active Directory — toegangs- en rechtenbeheer',
+        'Zaaksysteem Djuma',
+        'Exact Online — financiële administratie',
+    ];
+
+    /**
+     * Processors, with plausible contact details. Emails use example.com so
+     * nothing in the demo can send mail to a real address.
+     */
+    public const PROCESSORS = [
+        ['name' => 'AFAS Software B.V.', 'email' => 'privacy@afas.example.com', 'phone' => '+31331234567'],
+        ['name' => 'TOPdesk Nederland B.V.', 'email' => 'privacy@topdesk.example.com', 'phone' => '+31152345678'],
+        ['name' => 'Cloudbeheer Nederland B.V.', 'email' => 'avg@cloudbeheer.example.com', 'phone' => '+31203456789'],
+        ['name' => 'Archiefdiensten Delta B.V.', 'email' => 'privacy@delta-archief.example.com', 'phone' => '+31304567890'],
+        ['name' => 'Salarisverwerking Contour B.V.', 'email' => 'fg@contour.example.com', 'phone' => '+31105678901'],
+    ];
+
+    /**
+     * Recipients of personal data. Described rather than named, matching how
+     * the field is used in the application.
+     */
+    public const RECEIVERS = [
+        'Belastingdienst — in het kader van de loonaangifte',
+        'UWV — voor de uitvoering van de sociale zekerheidswetgeving',
+        'Pensioenfonds — voor de pensioenadministratie van medewerkers',
+        'Arbodienst — voor de verzuimbegeleiding',
+        'Zorgverzekeraars — voor de declaratie van geleverde zorg',
+        'Nationale politie — uitsluitend na een rechtmatig vorderingsbevel',
+        'Accountant — in het kader van de jaarrekeningcontrole',
+    ];
+
+    /** Legal bases, matching the options the application offers. */
+    public const LEGAL_BASE_LEGAL_OBLIGATION = 'Wettelijke verplichting';
+    public const LEGAL_BASE_AGREEMENT = 'Uitvoering overeenkomst';
+    public const LEGAL_BASE_PUBLIC_TASK = 'Vervulling taak van algemeen belang';
+    public const LEGAL_BASE_CONSENT = 'Toestemming betrokkene';
+    public const LEGAL_BASE_LEGITIMATE_INTEREST = 'Gerechtvaardigd belang';
+
+    /**
+     * The AVG responsible processing records: the register the demo opens on.
+     *
+     * The set is chosen to span the states worth demonstrating rather than to
+     * be exhaustive — see DemoSeeder for how `state` and `review_offset_months`
+     * are turned into version histories and review warnings.
+     */
+    public const AVG_RECORDS = [
+        [
+            'name' => 'Personeels- en salarisadministratie',
+            'retention' => '7 jaar na uitdiensttreding, op grond van de fiscale bewaarplicht.',
+            'service' => 'Directie Personeel en Organisatie',
+            'goal' => 'Het voeren van de personeels- en salarisadministratie, inclusief het uitbetalen '
+                . 'van salarissen en het afdragen van loonheffing.',
+            'legal_base' => self::LEGAL_BASE_LEGAL_OBLIGATION,
+            'stakeholder' => 'Medewerkers in loondienst',
+            'data_items' => ['NAW-gegevens', 'Burgerservicenummer', 'Bankrekeningnummer', 'Salarisgegevens', 'Contractgegevens'],
+            'special_data' => false,
+            'bsn' => true,
+            'systems' => [0, 5],
+            'processors' => [0, 4],
+            'receivers' => [0, 1, 2],
+            'tags' => [4, 6, 9],
+            'state' => 'established',
+            'review_offset_months' => 8,
+            'dpia' => true,
+            'outside_eu' => false,
+            'description' => 'De salarisadministratie wordt uitgevoerd door een externe verwerker. '
+                . 'De verwerkingsverantwoordelijke bepaalt doel en middelen; de uitvoering is belegd '
+                . 'bij de directie Personeel en Organisatie.',
+        ],
+        [
+            'name' => 'Verzuimbegeleiding en re-integratie',
+            'retention' => '2 jaar na afronding van het verzuimtraject.',
+            'service' => 'Directie Personeel en Organisatie',
+            'goal' => 'Het begeleiden van zieke medewerkers en het uitvoeren van de re-integratie '
+                . 'conform de Wet verbetering poortwachter.',
+            'legal_base' => self::LEGAL_BASE_LEGAL_OBLIGATION,
+            'stakeholder' => 'Medewerkers met een verzuimmelding',
+            'data_items' => ['NAW-gegevens', 'Verzuimdata', 'Functionele beperkingen', 'Re-integratieafspraken'],
+            'special_data' => true,
+            'bsn' => true,
+            'systems' => [0],
+            'processors' => [0],
+            'receivers' => [1, 3],
+            'tags' => [0, 4, 5],
+            'state' => 'established',
+            'review_offset_months' => 2,
+            'dpia' => true,
+            'outside_eu' => false,
+            'description' => 'Gezondheidsgegevens worden uitsluitend verwerkt door de arbodienst. '
+                . 'De werkgever ontvangt alleen gegevens over de belastbaarheid, niet over de '
+                . 'medische oorzaak van het verzuim.',
+        ],
+        [
+            'name' => 'Cameratoezicht toegangsbeveiliging',
+            'retention' => '28 dagen, tenzij beelden nodig zijn voor de afhandeling van een incident.',
+            'service' => 'Directie Bedrijfsvoering',
+            'goal' => 'Het beveiligen van gebouwen en eigendommen en het beschermen van de veiligheid '
+                . 'van medewerkers en bezoekers.',
+            'legal_base' => self::LEGAL_BASE_LEGITIMATE_INTEREST,
+            'stakeholder' => 'Bezoekers en medewerkers van de locaties',
+            'data_items' => ['Camerabeelden', 'Datum en tijdstip', 'Locatie van de opname'],
+            'special_data' => false,
+            'bsn' => false,
+            'systems' => [4],
+            'processors' => [2],
+            'receivers' => [5],
+            'tags' => [1, 5, 8],
+            'state' => 'in_review',
+            'review_offset_months' => 11,
+            'dpia' => true,
+            'outside_eu' => false,
+            'description' => 'Camerabeelden worden na 28 dagen automatisch verwijderd, tenzij zij nodig '
+                . 'zijn voor de afhandeling van een incident. Beelden worden alleen aan de politie '
+                . 'verstrekt na een rechtmatig vorderingsbevel.',
+        ],
+        [
+            'name' => 'Toegangsbeheer informatiesystemen',
+            'retention' => 'Logging 6 maanden; autorisatiegegevens tot 1 jaar na uitdiensttreding.',
+            'service' => 'Directie Informatievoorziening',
+            'goal' => 'Het toekennen, wijzigen en intrekken van toegangsrechten tot informatiesystemen '
+                . 'en het vastleggen van logging ten behoeve van informatiebeveiliging.',
+            'legal_base' => self::LEGAL_BASE_LEGITIMATE_INTEREST,
+            'stakeholder' => 'Medewerkers en ingehuurd personeel',
+            'data_items' => ['Gebruikersnaam', 'Functie en afdeling', 'Toegangsrechten', 'Inloggegevens'],
+            'special_data' => false,
+            'bsn' => false,
+            'systems' => [5, 1],
+            'processors' => [2],
+            'receivers' => [],
+            'tags' => [4, 8],
+            'state' => 'approved',
+            'review_offset_months' => 18,
+            'dpia' => false,
+            'outside_eu' => false,
+            'description' => 'Logging wordt uitsluitend gebruikt voor informatiebeveiliging en niet voor '
+                . 'de beoordeling van medewerkers.',
+        ],
+        [
+            'name' => 'Afhandelen vragen en klachten',
+            'retention' => '2 jaar na afhandeling van de melding.',
+            'service' => 'Directie Publieke Dienstverlening',
+            'goal' => 'Het in behandeling nemen en afhandelen van vragen, meldingen en klachten van '
+                . 'betrokkenen.',
+            'legal_base' => self::LEGAL_BASE_PUBLIC_TASK,
+            'stakeholder' => 'Personen die contact opnemen met de organisatie',
+            'data_items' => ['NAW-gegevens', 'Contactgegevens', 'Inhoud van de melding', 'Correspondentie'],
+            'special_data' => false,
+            'bsn' => false,
+            'systems' => [1, 6],
+            'processors' => [1],
+            'receivers' => [],
+            'tags' => [7, 9],
+            'state' => 'established',
+            'review_offset_months' => 20,
+            'dpia' => false,
+            'outside_eu' => false,
+            'description' => 'Meldingen worden na afhandeling nog twee jaar bewaard ten behoeve van '
+                . 'kwaliteitsverbetering en verantwoording.',
+        ],
+        [
+            'name' => 'Inkoop- en leveranciersadministratie',
+            'retention' => '7 jaar na afloop van het boekjaar, op grond van de fiscale bewaarplicht.',
+            'service' => 'Directie Financiën en Control',
+            'goal' => 'Het vastleggen van inkooporders, contracten en facturen en het uitvoeren van '
+                . 'de daarbij behorende betalingen.',
+            'legal_base' => self::LEGAL_BASE_AGREEMENT,
+            'stakeholder' => 'Contactpersonen bij leveranciers',
+            'data_items' => ['Naam en functie', 'Zakelijke contactgegevens', 'Bankrekeningnummer'],
+            'special_data' => false,
+            'bsn' => false,
+            'systems' => [7],
+            'processors' => [],
+            'receivers' => [6],
+            'tags' => [3],
+            'state' => 'established',
+            'review_offset_months' => 30,
+            'dpia' => false,
+            'outside_eu' => false,
+            'description' => 'Financiële gegevens worden zeven jaar bewaard op grond van de fiscale '
+                . 'bewaarplicht.',
+        ],
+        [
+            'name' => 'Klanttevredenheidsonderzoek',
+            'retention' => '12 maanden na afronding van het onderzoek.',
+            'service' => 'Directie Publieke Dienstverlening',
+            'goal' => 'Het meten van de tevredenheid over de dienstverlening ten behoeve van '
+                . 'kwaliteitsverbetering.',
+            'legal_base' => self::LEGAL_BASE_CONSENT,
+            'stakeholder' => 'Betrokkenen die een dienst hebben afgenomen',
+            'data_items' => ['E-mailadres', 'Gegeven antwoorden', 'Datum van deelname'],
+            'special_data' => false,
+            'bsn' => false,
+            'systems' => [2],
+            'processors' => [2],
+            'receivers' => [],
+            'tags' => [3, 7],
+            'state' => 'draft',
+            'review_offset_months' => 12,
+            'dpia' => false,
+            'outside_eu' => true,
+            'description' => 'De enquêtetool verwerkt gegevens op servers buiten de EER. Hiervoor zijn '
+                . 'standaardcontractbepalingen afgesloten en is een transfer impact assessment '
+                . 'uitgevoerd.',
+        ],
+        [
+            'name' => 'Archivering en informatiebeheer',
+            'retention' => 'Conform de vastgestelde selectielijst, varierend van 5 jaar tot blijvende bewaring.',
+            'service' => 'Directie Juridische Zaken',
+            'goal' => 'Het duurzaam bewaren en beheren van archiefbescheiden conform de geldende '
+                . 'selectielijst en bewaartermijnen.',
+            'legal_base' => self::LEGAL_BASE_LEGAL_OBLIGATION,
+            'stakeholder' => 'Alle betrokkenen van wie stukken zijn gearchiveerd',
+            'data_items' => ['Dossiergegevens', 'Correspondentie', 'Besluiten'],
+            'special_data' => false,
+            'bsn' => true,
+            'systems' => [3, 6],
+            'processors' => [3],
+            'receivers' => [],
+            'tags' => [9],
+            'state' => 'obsolete',
+            'review_offset_months' => 36,
+            'dpia' => false,
+            'outside_eu' => false,
+            'description' => 'Deze verwerking is opgegaan in de bredere verwerking informatiebeheer. '
+                . 'De vastgestelde versie is daarmee komen te vervallen.',
+        ],
+    ];
+
+    /**
+     * Processor-side records: processings the organisation carries out on
+     * behalf of another controller. A smaller set, since the register exists
+     * mainly to show that the distinction is modelled.
+     */
+    public const AVG_PROCESSOR_RECORDS = [
+        [
+            'name' => 'Salarisverwerking voor aangesloten stichtingen',
+            'goal' => 'Het verwerken van de salarisadministratie in opdracht van aangesloten '
+                . 'stichtingen die gebruikmaken van de gedeelde bedrijfsvoering.',
+            'controller' => 'Aangesloten stichtingen binnen het samenwerkingsverband',
+            'state' => 'established',
+            'description' => 'De verwerking vindt uitsluitend plaats op basis van een '
+                . 'verwerkersovereenkomst en schriftelijke instructies van de verantwoordelijke.',
+        ],
+        [
+            'name' => 'Hosting en beheer van het zaaksysteem',
+            'goal' => 'Het technisch beheren en hosten van het zaaksysteem waarin partnerorganisaties '
+                . 'hun eigen dossiers verwerken.',
+            'controller' => 'Partnerorganisaties met een aansluitovereenkomst',
+            'state' => 'in_review',
+            'description' => 'Beheerders hebben uitsluitend toegang tot persoonsgegevens voor zover '
+                . 'noodzakelijk voor technisch beheer. Toegang wordt gelogd.',
+        ],
+    ];
+
+    /**
+     * WPG records. Only relevant to organisations with a police or enforcement
+     * task, so a modest set on the municipality is enough to show the register
+     * exists and has its own field set.
+     */
+    public const WPG_RECORDS = [
+        [
+            'name' => 'Handhaving openbare ruimte door boa\'s',
+            'goal' => 'Het vastleggen van constateringen en opgemaakte processen-verbaal door '
+                . 'buitengewoon opsporingsambtenaren.',
+            'state' => 'established',
+            'description' => 'Gegevens worden verwerkt op grond van de Wet politiegegevens en zijn '
+                . 'uitsluitend toegankelijk voor daartoe geautoriseerde medewerkers.',
+        ],
+        [
+            'name' => 'Registratie van meldingen overlast',
+            'goal' => 'Het registreren en opvolgen van meldingen van overlast in de openbare ruimte.',
+            'state' => 'in_review',
+            'description' => 'Meldingen worden na afhandeling maximaal vijf jaar bewaard conform de '
+                . 'bewaartermijnen van de Wpg.',
+        ],
+    ];
+
+    /**
+     * Algorithm register entries. The states differ on purpose: one in
+     * production and published, one still in development, so the register can
+     * be shown to track algorithms across their lifecycle.
+     */
+    public const ALGORITHM_RECORDS = [
+        [
+            'name' => 'Risicoselectie bij aanvraagbeoordeling',
+            'theme' => 'Openbare orde en veiligheid',
+            'status' => 'In gebruik',
+            'category' => 'Impactvol algoritme',
+            'description' => 'Een op regels gebaseerd model dat aanvragen ordent op de kans dat '
+                . 'aanvullende controle nodig is, zodat behandelaars hun aandacht gericht kunnen '
+                . 'inzetten.',
+            'goal_and_impact' => 'Het doel is een efficiëntere inzet van behandelcapaciteit. Het '
+                . 'algoritme neemt geen besluit: het bepaalt uitsluitend de volgorde waarin '
+                . 'aanvragen door een behandelaar worden beoordeeld.',
+            'considerations' => 'Er is bewust gekozen voor een regelgebaseerd model in plaats van een '
+                . 'lerend model, zodat iedere uitkomst herleidbaar en uitlegbaar is aan de betrokkene.',
+            'human_intervention' => 'Elke aanvraag wordt door een medewerker beoordeeld. De medewerker '
+                . 'kan de volgorde negeren en legt afwijkingen vast.',
+            'risk_analysis' => 'Er is een DPIA en een mensenrechtentoets (IAMA) uitgevoerd. Het model '
+                . 'gebruikt geen gegevens over nationaliteit, etniciteit of postcode.',
+            'supplier' => 'In eigen beheer ontwikkeld',
+            'state' => 'established',
+            'published' => true,
+        ],
+        [
+            'name' => 'Automatische classificatie van inkomende post',
+            'theme' => 'Organisatie en bedrijfsvoering',
+            'status' => 'In ontwikkeling',
+            'category' => 'Overige algoritmes',
+            'description' => 'Een tekstclassificatiemodel dat inkomende berichten toewijst aan het '
+                . 'juiste behandelteam.',
+            'goal_and_impact' => 'Het doel is het verkorten van doorlooptijden door berichten direct '
+                . 'bij het juiste team te laten uitkomen. De impact op betrokkenen is beperkt: een '
+                . 'onjuiste toewijzing leidt tot een interne doorverwijzing.',
+            'considerations' => 'Overwogen is of handmatige triage volstaat. Gezien het volume is '
+                . 'gekozen voor ondersteuning door een model, met steekproefsgewijze controle.',
+            'human_intervention' => 'Behandelaars kunnen een toewijzing altijd corrigeren. Correcties '
+                . 'worden gebruikt om het model te verbeteren.',
+            'risk_analysis' => 'De DPIA is in concept gereed en wordt voor ingebruikname vastgesteld.',
+            'supplier' => 'Cloudbeheer Nederland B.V.',
+            'state' => 'draft',
+            'published' => false,
+        ],
+    ];
+
+    /**
+     * Data breach register. Spread across the lifecycle on purpose: one closed
+     * and reported to the supervisory authority, one still open, one assessed
+     * as not reportable — the three outcomes a privacy officer actually deals
+     * with.
+     */
+    public const DATA_BREACH_RECORDS = [
+        [
+            'name' => 'Verkeerd geadresseerde e-mail met deelnemerslijst',
+            'type' => 'Persoonsgegevens verstuurd aan verkeerde ontvanger',
+            'summary' => 'Een medewerker heeft een deelnemerslijst per e-mail verstuurd aan een '
+                . 'onjuiste ontvanger. De lijst bevatte namen en e-mailadressen van 42 personen.',
+            'involved_people' => '42 deelnemers aan een informatiebijeenkomst',
+            'estimated_risk' => 'Beperkt risico: het betreft geen bijzondere persoonsgegevens. De '
+                . 'ontvanger heeft schriftelijk bevestigd het bericht te hebben verwijderd.',
+            'measures' => 'De ontvanger is direct verzocht het bericht te verwijderen. Betrokkenen '
+                . 'zijn geïnformeerd. Er is een aanvullende instructie verspreid over het gebruik '
+                . 'van BCC bij groepsberichten.',
+            'ap_reported' => true,
+            'fg_reported' => true,
+            'reported_to_involved' => true,
+            'discovered_offset_days' => 45,
+            'closed' => true,
+        ],
+        [
+            'name' => 'Verlies van een onversleutelde USB-stick',
+            'type' => 'Verlies van gegevensdrager',
+            'summary' => 'Een medewerker is tijdens woon-werkverkeer een USB-stick verloren. Onbekend '
+                . 'is of de stick persoonsgegevens bevatte; de medewerker verklaart uitsluitend '
+                . 'werkdocumenten te hebben opgeslagen.',
+            'involved_people' => 'Onbekend, mogelijk enkele tientallen betrokkenen',
+            'estimated_risk' => 'Risico wordt onderzocht. Zolang de inhoud niet is vastgesteld, wordt '
+                . 'uitgegaan van een verhoogd risico.',
+            'measures' => 'Onderzoek naar de inhoud loopt. Vooruitlopend hierop is het gebruik van '
+                . 'niet-versleutelde gegevensdragers organisatiebreed geblokkeerd.',
+            'ap_reported' => false,
+            'fg_reported' => true,
+            'reported_to_involved' => false,
+            'discovered_offset_days' => 4,
+            'closed' => false,
+        ],
+        [
+            'name' => 'Inzage in dossier door onbevoegde medewerker',
+            'type' => 'Onbevoegde toegang tot persoonsgegevens',
+            'summary' => 'Uit logginganalyse bleek dat een medewerker een dossier heeft geraadpleegd '
+                . 'zonder dat daar een behandelrelatie voor bestond.',
+            'involved_people' => '1 betrokkene',
+            'estimated_risk' => 'Geen doorgifte aan derden vastgesteld. De gegevens zijn niet '
+                . 'gewijzigd of gekopieerd.',
+            'measures' => 'De autorisatie van de medewerker is ingetrokken en er heeft een gesprek '
+                . 'plaatsgevonden. De betrokkene is geïnformeerd. De logginganalyse wordt voortaan '
+                . 'maandelijks uitgevoerd.',
+            'ap_reported' => false,
+            'fg_reported' => true,
+            'reported_to_involved' => true,
+            'discovered_offset_days' => 120,
+            'closed' => true,
+        ],
+    ];
+
+    /**
+     * Documents. The expiry offsets drive the manual's "verlopen
+     * documenttermijnen" warnings: one already expired, one expiring shortly,
+     * the rest comfortably valid.
+     */
+    public const DOCUMENTS = [
+        [
+            'name' => 'DPIA Personeels- en salarisadministratie',
+            'type' => 'DPIA',
+            'location' => 'Documentbeheer — map Privacy/DPIA',
+            'expires_offset_months' => 9,
+        ],
+        [
+            'name' => 'DPIA Cameratoezicht',
+            'type' => 'DPIA',
+            'location' => 'Documentbeheer — map Privacy/DPIA',
+            'expires_offset_months' => -2,
+        ],
+        [
+            'name' => 'Verwerkersovereenkomst AFAS Software B.V.',
+            'type' => 'Verwerkersovereenkomst',
+            'location' => 'Contractbeheer — dossier leveranciers',
+            'expires_offset_months' => 1,
+        ],
+        [
+            'name' => 'Verwerkersovereenkomst Cloudbeheer Nederland B.V.',
+            'type' => 'Verwerkersovereenkomst',
+            'location' => 'Contractbeheer — dossier leveranciers',
+            'expires_offset_months' => 14,
+        ],
+        [
+            'name' => 'Informatiebeveiligingsbeleid',
+            'type' => 'Beveiligingsbeleid',
+            'location' => 'Intranet — Beleid en kaders',
+            'expires_offset_months' => 22,
+        ],
+        [
+            'name' => 'Bewaartermijnenbeleid en selectielijst',
+            'type' => 'Bewaartermijnenbeleid',
+            'location' => 'Intranet — Beleid en kaders',
+            'expires_offset_months' => 30,
+        ],
+    ];
+
+    /**
+     * Remarks left on records, and FG remarks. Written as the kind of note a
+     * reviewer really leaves, so the collaboration features read as used.
+     */
+    public const REMARKS = [
+        'Bewaartermijn afgestemd met de archivaris; selectielijst is leidend.',
+        'Verwerkersovereenkomst is getekend ontvangen en toegevoegd aan het dossier.',
+        'Na de laatste wijziging in het systeem opnieuw beoordeeld: geen gevolgen voor de grondslag.',
+        'Betrokkenen worden geïnformeerd via de privacyverklaring op de website.',
+    ];
+
+    /**
+     * FG remarks are visible only to the Functionaris Gegevensbescherming, so
+     * they read as supervisory notes rather than general comments.
+     */
+    public const FG_REMARKS = [
+        'Aandachtspunt: controleer bij de volgende review of de bewaartermijn nog aansluit op de '
+            . 'selectielijst.',
+        'De DPIA is uitgevoerd maar verloopt binnenkort. Tijdig laten actualiseren.',
+        'Grondslag gerechtvaardigd belang is onderbouwd met een belangenafweging. Akkoord.',
+    ];
+
+    /** Version-history notes shown in the approval trail. */
+    public const SNAPSHOT_NOTES = [
+        'Jaarlijkse review uitgevoerd, geen inhoudelijke wijzigingen.',
+        'Verwerker toegevoegd na aanbesteding.',
+        'Bewaartermijn aangepast conform de nieuwe selectielijst.',
+    ];
+
+    /** Reason recorded when a mandate holder declines a version. */
+    public const DECLINE_REASON = 'De omschrijving van de bewaartermijn is nog niet concreet genoeg. '
+        . 'Graag aanvullen met de exacte termijn per gegevenscategorie voordat ik akkoord geef.';
+}

--- a/src/cms/database/seeders/DemoLookups.php
+++ b/src/cms/database/seeders/DemoLookups.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Algorithm\AlgorithmPublicationCategory;
+use App\Models\Algorithm\AlgorithmStatus;
+use App\Models\Algorithm\AlgorithmTheme;
+use App\Models\ContactPersonPosition;
+use App\Models\DocumentType;
+
+/**
+ * The per-organisation lookup lists DemoSeeder creates up front.
+ *
+ * A plain array<string, mixed> would do the same job at runtime, but it hides
+ * every type from static analysis and turns each use site into an untyped
+ * offset lookup. Naming the fields keeps the seeder honest about what exists.
+ */
+final class DemoLookups
+{
+    /**
+     * @param array<string, DocumentType> $documentTypes keyed by name, so records can pick their type
+     * @param list<ContactPersonPosition> $contactPersonPositions
+     * @param array<string, AlgorithmTheme> $algorithmThemes
+     * @param array<string, AlgorithmStatus> $algorithmStatuses
+     * @param array<string, AlgorithmPublicationCategory> $algorithmCategories
+     */
+    public function __construct(
+        public array $documentTypes,
+        public array $contactPersonPositions,
+        public array $algorithmThemes,
+        public array $algorithmStatuses,
+        public array $algorithmCategories,
+    ) {
+    }
+}

--- a/src/cms/database/seeders/DemoRegisterSeeder.php
+++ b/src/cms/database/seeders/DemoRegisterSeeder.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\CoreEntityDataCollectionSource;
+use App\Enums\EntityNumberType;
+use App\Models\Algorithm\AlgorithmRecord;
+use App\Models\Avg\AvgProcessorProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Organisation;
+use App\Models\Snapshot;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\InReview;
+use App\Models\Wpg\WpgProcessingRecord;
+use App\Services\Snapshot\SnapshotDataFactory;
+use Carbon\CarbonInterface;
+
+use function count;
+use function now;
+
+/**
+ * The registers beyond AVG-verantwoordelijke: processor-side processings, WPG,
+ * algorithms and data breaches.
+ *
+ * Split from DemoSeeder because the two answer different questions. DemoSeeder
+ * builds an organisation's foundation - users, lookup lists, shared entities,
+ * and the main register with its version history. This class fills the
+ * remaining registers on top of that foundation, and only for the primary demo
+ * organisation.
+ */
+final class DemoRegisterSeeder
+{
+    use CreatesEntityNumbers;
+
+    public function __construct(
+        private readonly Organisation $organisation,
+        private readonly DemoLookups $lookups,
+        private readonly DemoRelatedEntities $related,
+        private readonly SnapshotDataFactory $snapshotDataFactory = new SnapshotDataFactory(),
+    ) {
+    }
+
+    /**
+     * @param list<Document> $documents
+     */
+    public function seed(array $documents): void
+    {
+        $this->createAvgProcessorRecords($this->organisation, $this->related);
+        $this->createWpgRecords($this->organisation);
+        $this->createAlgorithmRecords($this->organisation, $this->lookups, $documents);
+        $this->createDataBreachRecords($this->organisation, $this->related);
+    }
+
+    private function createAvgProcessorRecords(Organisation $organisation, DemoRelatedEntities $related): void
+    {
+        foreach (DemoContent::AVG_PROCESSOR_RECORDS as $definition) {
+            $record = AvgProcessorProcessingRecord::factory()
+                ->for($organisation)
+                ->recycle($organisation)
+                ->create([
+                    'import_id' => null,
+                    'name' => $definition['name'],
+                    'entity_number_id' => $this->createEntityNumber($organisation, EntityNumberType::REGISTER),
+                    'responsibility_distribution' => $definition['description'],
+                    'outside_eu' => false,
+                    'decision_making' => false,
+                    'review_at' => now()->addMonths(14)->toDateString(),
+                ]);
+
+            $record->responsibles()->attach($related->responsible->id);
+
+            $snapshot = $this->makeSnapshot(
+                $organisation,
+                $record,
+                $record->name,
+                1,
+                $definition['state'] === 'established' ? Established::class : InReview::class,
+            );
+
+            $this->snapshotDataFactory->createDataForSnapshot($snapshot->refresh());
+        }
+    }
+
+    private function createWpgRecords(Organisation $organisation): void
+    {
+        foreach (DemoContent::WPG_RECORDS as $definition) {
+            $record = WpgProcessingRecord::factory()->for($organisation)->recycle($organisation)->create([
+                'import_id' => null,
+                'name' => $definition['name'],
+                'data_collection_source' => CoreEntityDataCollectionSource::PRIMARY,
+                'entity_number_id' => $this->createEntityNumber($organisation, EntityNumberType::REGISTER),
+
+                'suspects' => true,
+                'victims' => false,
+                'convicts' => false,
+                'police_justice' => true,
+                'third_parties' => false,
+                'third_party_explanation' => null,
+
+                'pseudonymization' => null,
+                'has_security' => true,
+                'has_processors' => false,
+
+                'decision_making' => false,
+                'logic' => null,
+                'consequences' => null,
+
+                'explanation_available' => $definition['description'],
+                'explanation_provisioning' => 'Verstrekking vindt uitsluitend plaats aan daartoe '
+                    . 'bevoegde instanties op grond van de Wet politiegegevens.',
+                'explanation_transfer' => 'Er vindt geen doorgifte plaats naar landen buiten de EER.',
+
+                'review_at' => now()->addMonths(10)->toDateString(),
+            ]);
+
+            $snapshot = $this->makeSnapshot(
+                $organisation,
+                $record,
+                $record->name,
+                1,
+                $definition['state'] === 'established' ? Established::class : InReview::class,
+            );
+
+            $this->snapshotDataFactory->createDataForSnapshot($snapshot->refresh());
+        }
+    }
+
+    /**
+     * @param list<Document> $documents
+     */
+    private function createAlgorithmRecords(Organisation $organisation, DemoLookups $lookups, array $documents): void
+    {
+        foreach (DemoContent::ALGORITHM_RECORDS as $index => $definition) {
+            $record = AlgorithmRecord::factory()->for($organisation)->recycle($organisation)->create([
+                'import_id' => null,
+                'name' => $definition['name'],
+                'description' => $definition['description'],
+                'entity_number_id' => $this->createEntityNumber($organisation, EntityNumberType::REGISTER),
+
+                'algorithm_theme_id' => $lookups->algorithmThemes[$definition['theme']]->id,
+                'algorithm_status_id' => $lookups->algorithmStatuses[$definition['status']]->id,
+                'algorithm_publication_category_id' => $lookups->algorithmCategories[$definition['category']]->id,
+
+                'start_date' => now()->subYear(),
+                'end_date' => null,
+                'contact_data' => 'privacy@example.com',
+                'source_link' => null,
+                'public_page_link' => null,
+                'public_from' => $definition['published'] ? now()->subMonth() : null,
+
+                'resp_goal_and_impact' => $definition['goal_and_impact'],
+                'resp_considerations' => $definition['considerations'],
+                'resp_human_intervention' => $definition['human_intervention'],
+                'resp_risk_analysis' => $definition['risk_analysis'],
+                'resp_legal_base_title' => 'Algemene wet bestuursrecht',
+                'resp_legal_base' => 'De beoordeling van aanvragen vindt plaats op grond van de '
+                    . 'toepasselijke regelgeving en de daarop gebaseerde beleidsregels.',
+                'resp_legal_base_link' => null,
+                'resp_processor_registry_link' => null,
+                'resp_impact_tests' => $definition['published']
+                    ? 'DPIA en IAMA uitgevoerd en vastgesteld.'
+                    : 'DPIA in concept.',
+                'resp_impact_test_links' => null,
+                'resp_impact_tests_description' => null,
+
+                'oper_data_title' => 'Gebruikte gegevens',
+                'oper_data' => 'Het model gebruikt uitsluitend gegevens die de aanvrager zelf heeft '
+                    . 'verstrekt in het aanvraagformulier.',
+                'oper_links' => null,
+                'oper_technical_operation' => 'Het model past een vaste set beslisregels toe en kent '
+                    . 'op basis daarvan een prioriteit toe.',
+                'oper_supplier' => $definition['supplier'],
+                'oper_source_code_link' => null,
+
+                'meta_national_id' => null,
+                'meta_source_id' => null,
+                'meta_tags' => null,
+                'meta_date_of_development' => now()->subYears(2),
+                'meta_owner_algorithm' => 'Directie Informatievoorziening',
+                'meta_product_owner_algorithm' => 'Joost Bakker',
+
+                'impact_with_consequences' => false,
+                'impact_more_algorithms_applied' => false,
+                'impact_effect_on_outcome' => false,
+                'validation_answers_checked_by_product_owner' => $definition['published'],
+            ]);
+
+            if ($documents !== []) {
+                $record->documents()->attach($documents[$index % count($documents)]->id);
+            }
+
+            if ($definition['state'] === 'draft') {
+                continue;
+            }
+
+            $snapshot = $this->makeSnapshot($organisation, $record, $record->name, 1, Established::class);
+
+            $this->snapshotDataFactory->createDataForSnapshot($snapshot->refresh());
+        }
+    }
+
+    private function createDataBreachRecords(Organisation $organisation, DemoRelatedEntities $related): void
+    {
+        foreach (DemoContent::DATA_BREACH_RECORDS as $definition) {
+            $discoveredAt = now()->subDays($definition['discovered_offset_days']);
+
+            $record = DataBreachRecord::factory()->for($organisation)->recycle($organisation)->create([
+                'entity_number_id' => $this->createEntityNumber($organisation, EntityNumberType::DATABREACH),
+
+                'name' => $definition['name'],
+                'type' => $definition['type'],
+                'summary' => $definition['summary'],
+                'involved_people' => $definition['involved_people'],
+                'estimated_risk' => $definition['estimated_risk'],
+                'measures' => $definition['measures'],
+
+                'discovered_at' => $discoveredAt->toDateString(),
+                'started_at' => $discoveredAt->copy()->subDays(1)->toDateString(),
+                'ended_at' => $definition['closed'] ? $discoveredAt->copy()->addDays(1)->toDateString() : null,
+
+                'reported_at' => $discoveredAt->copy()->addDay()->toDateString(),
+                'ap_reported' => $definition['ap_reported'],
+                'ap_reported_at' => $definition['ap_reported']
+                    ? $discoveredAt->copy()->addDays(2)->toDateString()
+                    : null,
+                'fg_reported' => $definition['fg_reported'],
+                'reported_to_involved' => $definition['reported_to_involved'],
+
+                'completed_at' => $definition['closed']
+                    ? $discoveredAt->copy()->addDays(10)->toDateString()
+                    : null,
+            ]);
+
+            $record->responsibles()->attach($related->responsible->id);
+        }
+    }
+
+    /**
+     * Snapshot's $fillable covers only name, version and state; the rest is
+     * guarded and would be dropped silently by create(). Mirrors the helper in
+     * DemoSeeder so both classes produce identical, complete snapshots.
+     */
+    private function makeSnapshot(
+        Organisation $organisation,
+        AvgProcessorProcessingRecord|WpgProcessingRecord|AlgorithmRecord $source,
+        string $name,
+        int $version,
+        string $state,
+        ?CarbonInterface $replacedAt = null,
+    ): Snapshot {
+        $snapshot = new Snapshot();
+
+        $snapshot->forceFill([
+            'organisation_id' => $organisation->id,
+            'snapshot_source_id' => $source->id,
+            'snapshot_source_type' => $source::class,
+            'name' => $name,
+            'version' => $version,
+            'state' => $state,
+            'replaced_at' => $replacedAt,
+        ]);
+
+        $snapshot->save();
+
+        return $snapshot;
+    }
+}

--- a/src/cms/database/seeders/DemoRelatedEntities.php
+++ b/src/cms/database/seeders/DemoRelatedEntities.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Models\Avg\AvgResponsibleProcessingRecordService;
+use App\Models\ContactPerson;
+use App\Models\Processor;
+use App\Models\Receiver;
+use App\Models\Responsible;
+use App\Models\System;
+use App\Models\Tag;
+
+/**
+ * Entities shared between the demo records: created once per organisation and
+ * attached to the records that reference them, so the relation tables on a
+ * detail page show real cross-references rather than one-offs.
+ *
+ * The list-shaped fields are indexed by position, because DemoContent refers
+ * to them by index (a record naming systems [0, 5] means the first and sixth
+ * entry of DemoContent::SYSTEMS).
+ */
+final class DemoRelatedEntities
+{
+    /**
+     * @param array<string, AvgResponsibleProcessingRecordService> $services keyed by department name
+     * @param list<Tag> $tags
+     * @param list<System> $systems
+     * @param list<Processor> $processors
+     * @param list<Receiver> $receivers
+     * @param list<ContactPerson> $contactPersons
+     */
+    public function __construct(
+        public array $services,
+        public array $tags,
+        public array $systems,
+        public array $processors,
+        public array $receivers,
+        public Responsible $responsible,
+        public array $contactPersons,
+    ) {
+    }
+}

--- a/src/cms/database/seeders/DemoSeeder.php
+++ b/src/cms/database/seeders/DemoSeeder.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\Authorization\Role;
+use App\Enums\EntityNumberType;
+use App\Enums\RegisterLayout;
+use App\Models\Algorithm\AlgorithmPublicationCategory;
+use App\Models\Algorithm\AlgorithmStatus;
+use App\Models\Algorithm\AlgorithmTheme;
+use App\Models\Avg\AvgResponsibleProcessingRecordService;
+use App\Models\ContactPerson;
+use App\Models\ContactPersonPosition;
+use App\Models\Document;
+use App\Models\DocumentType;
+use App\Models\EntityNumberCounter;
+use App\Models\Organisation;
+use App\Models\Processor;
+use App\Models\PublicWebsiteTree;
+use App\Models\Receiver;
+use App\Models\Responsible;
+use App\Models\ResponsibleLegalEntity;
+use App\Models\System;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+use function now;
+use function sprintf;
+
+/**
+ * Demo data for sales meetings and demo deployments.
+ *
+ * Unlike TestDataSeeder, which generates faker content for local development,
+ * every string this seeder writes is hand-authored Dutch (see DemoContent).
+ * A demo gets clicked into: a prospect opens a record, scrolls to the third
+ * domain and reads whatever is there, so "deserunt quidem aspernatur" anywhere
+ * in the tree costs more than the seeder saved.
+ *
+ * The data is arranged around what needs demonstrating rather than around
+ * volume. In particular it guarantees:
+ *
+ *  - all four version states side by side (in review, approved, established,
+ *    obsolete), so the goedkeuringsproces can be shown without editing data;
+ *  - a version waiting on a mandate holder's signature, and one that was
+ *    declined with a reason, so both outcomes of the approval step are visible;
+ *  - documents already expired and about to expire, which drive the
+ *    "verlopen documenttermijnen" warnings;
+ *  - records due for periodic review, both overdue and upcoming;
+ *  - data breaches reported to the AP, still open, and assessed as not
+ *    reportable — the three real outcomes;
+ *  - one record with data processed outside the EER, to show that section
+ *    filled in rather than empty.
+ *
+ * Run against an empty database:
+ *   php artisan migrate:fresh
+ *   php artisan db:seed --class=DemoSeeder
+ *
+ * Deliberately not wired into DatabaseSeeder: demo content should never appear
+ * in local development or CI by accident.
+ */
+class DemoSeeder extends Seeder
+{
+    use CreatesEntityNumbers;
+    use WithoutModelEvents;
+
+    /**
+     * Shared password-less login is handled by OTP; every demo user gets a
+     * confirmed registration so any account can be logged into during a
+     * meeting without a device enrolment detour.
+     */
+    public function run(): void
+    {
+        foreach (DemoContent::ORGANISATIONS as $index => $definition) {
+            $organisation = $this->createOrganisation($definition);
+
+            // The first organisation is the one a demo opens on, so it gets the
+            // full spread of registers and states. The others exist to show
+            // multi-tenancy and the organisation switcher, and would only cost
+            // time to click through if they were equally deep.
+            $isPrimary = $index === 0;
+
+            $users = $this->createUsers($organisation, $isPrimary);
+            $lookups = $this->createLookupLists($organisation);
+            $related = $this->createRelatedEntities($organisation, $lookups);
+            $documents = $this->createDocuments($organisation, $lookups->documentTypes);
+
+            (new DemoAvgRegisterSeeder($organisation, $related, $users))->seed($documents, $isPrimary);
+
+            if ($isPrimary) {
+                (new DemoRegisterSeeder($organisation, $lookups, $related))->seed($documents);
+            }
+
+            $this->createPublicWebsiteTree($organisation);
+        }
+    }
+
+    /**
+     * @param array{name: string, slug: string, prefix: string, legal_entity: string, review_months: int, content: string} $definition
+     */
+    private function createOrganisation(array $definition): Organisation
+    {
+        $legalEntity = ResponsibleLegalEntity::factory()->create([
+            'name' => $definition['legal_entity'],
+        ]);
+
+        return Organisation::factory()->create([
+            'name' => $definition['name'],
+            'slug' => $definition['slug'],
+            'responsible_legal_entity_id' => $legalEntity->id,
+            'review_at_default_in_months' => $definition['review_months'],
+            'public_website_content' => $definition['content'],
+            // The demo runs behind whatever address the deployment happens to
+            // have, so no IP restriction: an allow-list that locks the sales
+            // engineer out mid-meeting is the worst possible failure here.
+            'allowed_ips' => '*.*.*.*',
+            'allowed_email_domains' => [],
+            'public_from' => now()->subMonth(),
+            'register_entity_number_counter_id' => EntityNumberCounter::factory([
+                'prefix' => $definition['prefix'],
+                'type' => EntityNumberType::REGISTER,
+                'number' => 1,
+            ]),
+            'databreach_entity_number_counter_id' => EntityNumberCounter::factory([
+                'prefix' => sprintf('%sD', $definition['prefix']),
+                'type' => EntityNumberType::DATABREACH,
+                'number' => 1,
+            ]),
+        ]);
+    }
+
+    /**
+     * @return array<string, User>
+     */
+    private function createUsers(Organisation $organisation, bool $isPrimary): array
+    {
+        $users = [];
+
+        foreach (DemoContent::USERS as $definition) {
+            $role = Role::from($definition['role']);
+
+            $user = User::factory()
+                ->hasAttached($organisation)
+                ->hasOrganisationRole($role, $organisation)
+                ->withValidOtpRegistration()
+                ->create([
+                    'name' => $definition['name'],
+                    'email' => sprintf('%s@%s.example.com', $definition['email'], $organisation->slug),
+                    // UserFactory randomises this, which would make the record
+                    // detail page render as steps or as one long page depending
+                    // on the run. Pin it so the demo is rehearsable.
+                    'register_layout' => RegisterLayout::STEPS,
+                ]);
+
+            $users[$definition['role']] = $user;
+        }
+
+        if ($isPrimary) {
+            // A single account holding every role, for the parts of a demo
+            // where switching users would only cost time. Kept off the other
+            // organisations so the roles-and-permissions story stays honest
+            // when the audience asks to see a restricted account.
+            $demo = User::factory()
+                ->hasAttached($organisation)
+                ->withValidOtpRegistration()
+                ->create([
+                    'name' => 'Demo Gebruiker',
+                    'email' => 'demo@example.com',
+                    'register_layout' => RegisterLayout::STEPS,
+                ]);
+
+            foreach (Role::organisationRoles() as $role) {
+                $demo->organisationRoles()->firstOrCreate([
+                    'organisation_id' => $organisation->id,
+                    'role' => $role->value,
+                ]);
+            }
+
+            $demo->globalRoles()->firstOrCreate(['role' => Role::FUNCTIONAL_MANAGER->value]);
+
+            $users['demo'] = $demo;
+        }
+
+        return $users;
+    }
+
+    /**
+     * Lookup lists are per-organisation, so each demo organisation needs its
+     * own set: without them the dropdowns on the detail pages are empty.
+     */
+    private function createLookupLists(Organisation $organisation): DemoLookups
+    {
+        $documentTypes = [];
+
+        foreach (DemoContent::DOCUMENT_TYPES as $name) {
+            $documentTypes[$name] = DocumentType::factory()->for($organisation)->create([
+                'name' => $name,
+            ]);
+        }
+
+        $positions = [];
+
+        foreach (DemoContent::CONTACT_POSITIONS as $name) {
+            $positions[] = ContactPersonPosition::factory()->for($organisation)->create([
+                'name' => $name,
+                'enabled' => true,
+            ]);
+        }
+
+        $themes = [];
+        $statuses = [];
+        $categories = [];
+
+        foreach (['Openbare orde en veiligheid', 'Organisatie en bedrijfsvoering', 'Zorg en gezondheid'] as $name) {
+            $themes[$name] = AlgorithmTheme::factory()->for($organisation)->create([
+                'name' => $name,
+                'enabled' => true,
+            ]);
+        }
+
+        foreach (['In gebruik', 'In ontwikkeling', 'Buiten gebruik'] as $name) {
+            $statuses[$name] = AlgorithmStatus::factory()->for($organisation)->create([
+                'name' => $name,
+                'enabled' => true,
+            ]);
+        }
+
+        foreach (['Impactvol algoritme', 'Overige algoritmes'] as $name) {
+            $categories[$name] = AlgorithmPublicationCategory::factory()->for($organisation)->create([
+                'name' => $name,
+                'enabled' => true,
+            ]);
+        }
+
+        return new DemoLookups(
+            documentTypes: $documentTypes,
+            contactPersonPositions: $positions,
+            algorithmThemes: $themes,
+            algorithmStatuses: $statuses,
+            algorithmCategories: $categories,
+        );
+    }
+
+    /**
+     * Entities shared across records: services, tags, systems, processors,
+     * receivers and responsibles. Created once per organisation and attached
+     * to the records that use them, so the relation tables at the bottom of a
+     * detail page show real cross-references rather than one-offs.
+     */
+    private function createRelatedEntities(Organisation $organisation, DemoLookups $lookups): DemoRelatedEntities
+    {
+        $services = [];
+
+        foreach (DemoContent::SERVICES as $name) {
+            $services[$name] = AvgResponsibleProcessingRecordService::factory()->for($organisation)->create([
+                'name' => $name,
+                'enabled' => true,
+            ]);
+        }
+
+        $tags = [];
+
+        foreach (DemoContent::TAGS as $name) {
+            $tags[] = Tag::factory()->for($organisation)->create([
+                'name' => $name,
+            ]);
+        }
+
+        $systems = [];
+
+        foreach (DemoContent::SYSTEMS as $description) {
+            $systems[] = System::factory()->for($organisation)->create([
+                'description' => $description,
+                'import_id' => null,
+            ]);
+        }
+
+        $processors = [];
+
+        foreach (DemoContent::PROCESSORS as $definition) {
+            $processors[] = Processor::factory()
+                ->for($organisation)
+                ->recycle($organisation)
+                ->withAddress()
+                ->create([
+                    'name' => $definition['name'],
+                    'email' => $definition['email'],
+                    'phone' => $definition['phone'],
+                    'import_id' => null,
+                ]);
+        }
+
+        $receivers = [];
+
+        foreach (DemoContent::RECEIVERS as $description) {
+            $receivers[] = Receiver::factory()->for($organisation)->create([
+                'description' => $description,
+                'import_id' => null,
+            ]);
+        }
+
+        $responsible = Responsible::factory()
+            ->for($organisation)
+            ->recycle($organisation)
+            ->withAddress()
+            ->create([
+                'name' => $organisation->name,
+                'import_id' => null,
+            ]);
+
+        $contactPersons = [];
+
+        foreach (['Sanne de Groot', 'Hans Willems'] as $name) {
+            $contactPersons[] = ContactPerson::factory()
+                ->for($organisation)
+                ->recycle($organisation)
+                ->recycle($lookups->contactPersonPositions[0])
+                ->withAddress()
+                ->create([
+                    'name' => $name,
+                    'import_id' => null,
+                ]);
+        }
+
+        return new DemoRelatedEntities(
+            services: $services,
+            tags: $tags,
+            systems: $systems,
+            processors: $processors,
+            receivers: $receivers,
+            responsible: $responsible,
+            contactPersons: $contactPersons,
+        );
+    }
+
+    /**
+     * @param array<string, DocumentType> $documentTypes
+     *
+     * @return list<Document>
+     */
+    private function createDocuments(Organisation $organisation, array $documentTypes): array
+    {
+        $documents = [];
+
+        foreach (DemoContent::DOCUMENTS as $definition) {
+            $expiresAt = now()->addMonths($definition['expires_offset_months']);
+
+            $documents[] = Document::factory()
+                ->for($organisation)
+                ->for($documentTypes[$definition['type']])
+                ->create([
+                    'name' => $definition['name'],
+                    'location' => $definition['location'],
+                    'expires_at' => $expiresAt,
+                // Warn a month ahead, so the document expiring next month shows
+                // as an active warning during the demo rather than silently.
+                    'notify_at' => $expiresAt->copy()->subMonth(),
+                ]);
+        }
+
+        return $documents;
+    }
+
+    private function createPublicWebsiteTree(Organisation $organisation): void
+    {
+        PublicWebsiteTree::factory()
+            ->recycle($organisation)
+            ->create([
+                'title' => $organisation->name,
+                'slug' => $organisation->slug,
+                'public_from' => now()->subMonth(),
+            ]);
+    }
+}


### PR DESCRIPTION
## Wat

Een hand-geschreven Nederlandstalige demo-seeder voor sales-meetings en demo-deployments. Draai los van `TestDataSeeder`:

```bash
php artisan migrate:fresh
php artisan db:seed --class=DemoSeeder
```

## Waarom

`TestDataSeeder` genereert faker-content (lorem ipsum, willekeurige woorden). Prima voor lokale ontwikkeling, maar in een demo wordt er *doorheen geklikt*: een prospect opent een verwerking, scrolt naar het derde domein en leest wat daar staat. Faker-latijn achter de derde tab ondermijnt het hele verhaal. Deze seeder schrijft alle zichtbare content expliciet uit.

## Wat er wordt aangemaakt

**Drie neutrale organisaties** (Stichting Zorggroep Noorderbrug, Gemeente Westerdam, Waarborgfonds Meridiaan) — zodat multi-tenancy en de organisatie-switcher te demonstreren zijn. De eerste is volledig gevuld; de andere twee dragen een kortere set zodat de tenant echt oogt zonder aandacht op te eisen. De content (personeelsadministratie, cameratoezicht, toegangsbeheer, datalekafhandeling) is sector-neutraal en leest plausibel voor zowel overheid als private registerhouders.

**Elke functie uit de handleiding heeft data in de juiste staat klaarstaan:**

- **Goedkeuringsproces** — alle vier versiestatussen naast elkaar (in review / goedgekeurd / vastgesteld / vervallen), één versie die op een akkoord van een mandaathouder wacht, en één die met een onderbouwde reden is afgewezen. Het akkoordspoor wordt geschreven zoals de applicatie het zelf schrijft.
- **Documenttermijnen** — documenten die al verlopen zijn en die binnenkort verlopen, wat de waarschuwingen aanstuurt.
- **Periodieke review** — verwerkingen zowel over tijd als aankomend.
- **Datalekregister** — drie lekken: gemeld bij de AP, nog open, en beoordeeld als niet-meldplichtig.
- **Algoritmes, WPG, AVG-verwerker** registers gevuld; FG-opmerkingen, opmerkingen, betrokkenen met bewaartermijnen, en verwerking buiten de EER allemaal ingevuld.

**Eén account per rol** (plus `demo@example.com` met alle rollen), zodat elke functie te tonen is vanuit het account dat die handeling echt zou uitvoeren.

## Ontwerpkeuzes

- **Volledig hand-geschreven** — content in `DemoContent.php`, structuur in de seeder-klassen. Geen hernoemde faker-output.
- **Gepubliceerde versie-content** gebruikt de eigen `SnapshotDataFactory` van de applicatie, zodat de versie-detailpagina en de publieke pagina echte gegenereerde Nederlandse tekst tonen in plaats van lorem ipsum.
- **Niet aan `DatabaseSeeder` gekoppeld** — demo-content kan lokale ontwikkeling of CI nooit per ongeluk vervuilen.
- Opgesplitst in kleine klassen (`DemoSeeder`, `DemoAvgRegisterSeeder`, `DemoRegisterSeeder`, twee value objects, één trait) om onder de complexiteitsdrempel te blijven.

## Getest

- Seedt schoon vanaf een lege database (~1s), exit 0.
- `phpcs`, `phpstan` (level uit `phpstan.neon.dist`) en `phpmd` alle drie schoon over alle nieuwe bestanden.
- Elke registerpagina en de versie-detailpagina gerenderd als ingelogde gebruiker — geen faker-latijn in enig zichtbaar veld.
- Bestaande `TestDataSeeder` en `ScreenshotSeeder` draaien nog steeds (puur additief, geen bestaande bestanden gewijzigd).

> Let op: de publieke *statische website* wordt door een aparte build-stap gegenereerd, niet door deze app, dus die valt buiten scope — maar de snapshot-data die hij consumeert is nu wel echt.
