### PR TITLE
ci: build and publish release inline from tag-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,11 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
-  # Tags pushed by tag-release.yml use GITHUB_TOKEN, and GitHub does not
-  # fire workflows for token-created events. Without this, tagging never
-  # builds a release. Dispatch also lets a failed build be re-run.
+  # tag-release.yml builds and publishes inline when it creates a tag, so the
+  # normal path does not rely on this workflow. This manual dispatch stays as an
+  # escape hatch to (re)build and publish an existing tag — e.g. after a failed
+  # build, or a tag pushed by hand. There is no `push: tags` trigger because
+  # tags pushed with GITHUB_TOKEN do not fire workflow events anyway.
   workflow_dispatch:
     inputs:
       tag:
@@ -21,7 +20,7 @@ jobs:
   build:
     uses: ./.github/workflows/build-release.yml
     with:
-      version: ${{ inputs.tag || github.ref_name }}
+      version: ${{ inputs.tag }}
 
   publish:
     needs: build
@@ -36,8 +35,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:
-          # On dispatch github.ref_name is the branch, not the tag, so the
-          # release must be pinned to the requested tag explicitly.
-          tag_name: ${{ inputs.tag || github.ref_name }}
+          tag_name: ${{ inputs.tag }}
           files: "*.tar.gz"
           generate_release_notes: true

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -9,9 +9,14 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,17 +36,47 @@ jobs:
           echo "Generated version: ${VERSION}"
 
       - name: Create and push tag
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a ${{ steps.version.outputs.VERSION }} -m "Release ${{ steps.version.outputs.VERSION }}"
-          git push origin ${{ steps.version.outputs.VERSION }}
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
 
       - name: Summary
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
         run: |
           echo "### Release Tagged :rocket:" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${{ steps.version.outputs.VERSION }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`$VERSION\`" >> $GITHUB_STEP_SUMMARY
           echo "**Alpha:** ${{ inputs.alpha }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "The release workflow will now build and publish this version." >> $GITHUB_STEP_SUMMARY
+          echo "The build and publish jobs will now package and release this version." >> $GITHUB_STEP_SUMMARY
+
+  # Build and publish inline rather than relying on the tag push to trigger
+  # release.yml: tags pushed with GITHUB_TOKEN do not fire `on: push` events,
+  # so a chained trigger would never run.
+  build:
+    needs: tag
+    uses: ./.github/workflows/build-release.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}
+
+  publish:
+    needs: [tag, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          pattern: openvwr-*
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.tag.outputs.version }}
+          files: "*.tar.gz"
+          generate_release_notes: true


### PR DESCRIPTION
## Probleem

`tag-release.yml` pusht de tag met `GITHUB_TOKEN`, en GitHub vuurt geen workflow-events af voor token-gemaakte pushes. Daardoor triggerde de `on: push: tags`-trigger van `release.yml` nooit — een getagde release werd wel getagd, maar nooit gebouwd of gepubliceerd tenzij iemand `release.yml` handmatig dispatchte.

Zichtbaar in de runs: `Tag Release` draaide meerdere keren succesvol, maar `Release` is maar één keer gedraaid, en dat was een handmatige dispatch. Tag `v20260722` bestond op de remote zonder bijbehorende Release-run.

## Fix (Optie A — workflows aan elkaar knopen)

`tag-release.yml` bouwt en publiceert nu zelf, in plaats van te vertrouwen op de tag-push als trigger:

- `tag`-job exporteert de versie als output.
- Nieuwe `build`-job hergebruikt `build-release.yml` (dezelfde builder als voorheen).
- Nieuwe `publish`-job maakt de GitHub Release met release notes.

Alles binnen `GITHUB_TOKEN` — geen PAT of extra secret nodig.

`release.yml` behoudt zijn `workflow_dispatch` als escape hatch om een bestaande tag opnieuw te bouwen/publiceren. De dode `push: tags`-trigger is verwijderd (die vuurde toch nooit), en de daardoor overbodige `|| github.ref_name`-fallbacks zijn opgeschoond.

Ook: tag-interpolaties in `run:`-blokken verplaatst naar `env:` (injection-veilige stijl), en `permissions: contents: write` expliciet gemaakt omdat `publish` een Release aanmaakt.

## Getest

- YAML van beide workflows valideert.
- De losstaande fix voor `v20260722` heb ik al handmatig gedispatcht zodat de release van vandaag eruit is; deze PR zorgt dat het voortaan automatisch gebeurt.