### PR TITLE
feat: snapshot status flow timeline

### DIFF
--- a/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
+++ b/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Infolists\Components;
+
+use App\Models\Snapshot;
+use App\Models\SnapshotTransition;
+use App\Models\States\Snapshot\Approved;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\InReview;
+use App\Models\States\Snapshot\Obsolete;
+use App\Models\States\SnapshotState;
+use Filament\Infolists\Components\ViewEntry;
+
+use function __;
+use function array_key_exists;
+use function sprintf;
+
+/**
+ * Metro-line style status flow for a snapshot: the happy path
+ * (In review -> Goedgekeurd -> Vastgesteld) as a line of stations, with
+ * Vervallen as a branch reachable from any state. Each reached station shows
+ * when it was reached and by whom, taken from the recorded state transitions.
+ */
+class SnapshotStatusFlow extends ViewEntry
+{
+    /**
+     * The main line, in order. Obsolete is deliberately not on it: it is a
+     * branch drawn off to the side only when the snapshot actually reached it.
+     */
+    private const MAIN_LINE = [
+        InReview::class,
+        Approved::class,
+        Established::class,
+    ];
+
+    public static function make(string $name = 'status_flow'): static
+    {
+        return parent::make($name)
+            ->hiddenLabel()
+            ->view('filament.infolists.components.entries.snapshot_status_flow')
+            ->state(static fn (Snapshot $snapshot): array => self::buildFlow($snapshot));
+    }
+
+    /**
+     * @return array{stations: list<array<string, mixed>>, obsolete: array<string, mixed>|null}
+     */
+    private static function buildFlow(Snapshot $snapshot): array
+    {
+        // The first time each state was reached, keyed by state name.
+        /** @var array<string, SnapshotTransition> $reachedAt */
+        $reachedAt = [];
+        foreach ($snapshot->snapshotTransitions as $transition) {
+            $stateName = $transition->state::$name;
+            if (!array_key_exists($stateName, $reachedAt)) {
+                $reachedAt[$stateName] = $transition;
+            }
+        }
+
+        $currentState = $snapshot->state::$name;
+
+        $stations = [];
+        foreach (self::MAIN_LINE as $index => $stateClass) {
+            $stateName = $stateClass::$name;
+            $transition = $reachedAt[$stateName] ?? null;
+            // A snapshot always starts in review even before any transition is
+            // recorded, so the first station counts as reached by default.
+            $reached = $transition !== null || $index === 0;
+
+            $stations[] = self::station($stateClass, $reached, $currentState === $stateName, $transition);
+        }
+
+        $obsolete = null;
+        if ($currentState === Obsolete::$name) {
+            $obsolete = self::station(Obsolete::class, true, true, $reachedAt[Obsolete::$name] ?? null);
+        }
+
+        return ['stations' => $stations, 'obsolete' => $obsolete];
+    }
+
+    /**
+     * @param class-string<SnapshotState> $stateClass
+     *
+     * @return array<string, mixed>
+     */
+    private static function station(
+        string $stateClass,
+        bool $reached,
+        bool $current,
+        ?SnapshotTransition $transition,
+    ): array {
+        return [
+            'label' => __(sprintf('snapshot_state.label.%s', $stateClass::$name)),
+            'color' => $stateClass::$color->value,
+            'reached' => $reached,
+            'current' => $current,
+            'reached_at' => $transition?->created_at,
+            'reached_by' => $transition?->creator?->name,
+        ];
+    }
+}

--- a/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
+++ b/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
@@ -46,7 +46,7 @@ class SnapshotStatusFlow extends ViewEntry
     /**
      * @return array{stations: list<array<string, mixed>>, obsolete: array<string, mixed>|null}
      */
-    private static function buildFlow(Snapshot $snapshot): array
+    public static function buildFlow(Snapshot $snapshot): array
     {
         // The first time each state was reached, keyed by state name.
         /** @var array<string, SnapshotTransition> $reachedAt */
@@ -64,11 +64,14 @@ class SnapshotStatusFlow extends ViewEntry
         foreach (self::MAIN_LINE as $index => $stateClass) {
             $stateName = $stateClass::$name;
             $transition = $reachedAt[$stateName] ?? null;
+            $isCurrent = $currentState === $stateName;
             // A snapshot always starts in review even before any transition is
-            // recorded, so the first station counts as reached by default.
-            $reached = $transition !== null || $index === 0;
+            // recorded, so the first station counts as reached by default. The
+            // current station is always reached too: a state can be set directly
+            // (e.g. seeded data) without a recorded transition.
+            $reached = $transition !== null || $index === 0 || $isCurrent;
 
-            $stations[] = self::station($stateClass, $reached, $currentState === $stateName, $transition);
+            $stations[] = self::station($stateClass, $reached, $isCurrent, $transition);
         }
 
         $obsolete = null;

--- a/src/cms/app/Filament/Infolists/Tabs/Snapshot/ViewInfoTab.php
+++ b/src/cms/app/Filament/Infolists/Tabs/Snapshot/ViewInfoTab.php
@@ -11,6 +11,7 @@ use App\Facades\Authentication;
 use App\Facades\Authorization;
 use App\Facades\DateFormat;
 use App\Filament\Infolists\Components\SnapshotStateEntry;
+use App\Filament\Infolists\Components\SnapshotStatusFlow;
 use App\Filament\Infolists\Components\SnapshotUrlEntry;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Models\Snapshot;
@@ -43,11 +44,20 @@ class ViewInfoTab extends Tab
         return parent::make($label)
             ->icon('heroicon-o-information-circle')
             ->schema([
+                self::getStatusFlowSection(),
                 self::getPropertiesSection(),
                 self::getPublicDataSection(),
                 self::getPrivateDataSection(),
                 self::getRelatedSnapshotSourcesSection(),
                 self::getApprovalSection(),
+            ]);
+    }
+
+    private static function getStatusFlowSection(): Section
+    {
+        return Section::make(__('snapshot.status_flow'))
+            ->schema([
+                SnapshotStatusFlow::make(),
             ]);
     }
 

--- a/src/cms/app/Models/Snapshot.php
+++ b/src/cms/app/Models/Snapshot.php
@@ -119,6 +119,7 @@ class Snapshot extends Model implements HasStatesContract, TenantAware
     public function snapshotTransitions(): HasMany
     {
         return $this->hasMany(SnapshotTransition::class)
+            ->with('creator')
             ->oldest();
     }
 }

--- a/src/cms/app/Models/Snapshot.php
+++ b/src/cms/app/Models/Snapshot.php
@@ -22,6 +22,7 @@ use Carbon\CarbonImmutable;
 use Database\Factories\SnapshotFactory;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -43,6 +44,7 @@ use Spatie\ModelStates\HasStatesContract;
  * @property-read SnapshotData|null $snapshotData
  * @property-read (SnapshotSource&Model)|null $snapshotSource
  * @property-read RelatedSnapshotSourceCollection $relatedSnapshotSources
+ * @property-read Collection<int, SnapshotTransition> $snapshotTransitions
  */
 #[ScopedBy([OrderByCreatedAtAscScope::class])]
 #[UseEloquentBuilder(SnapshotBuilder::class)]
@@ -109,5 +111,14 @@ class Snapshot extends Model implements HasStatesContract, TenantAware
     public function relatedSnapshotSources(): HasMany
     {
         return $this->hasMany(RelatedSnapshotSource::class);
+    }
+
+    /**
+     * @return HasMany<SnapshotTransition, $this>
+     */
+    public function snapshotTransitions(): HasMany
+    {
+        return $this->hasMany(SnapshotTransition::class)
+            ->oldest();
     }
 }

--- a/src/cms/resources/lang/nl/snapshot.php
+++ b/src/cms/resources/lang/nl/snapshot.php
@@ -23,6 +23,7 @@ return [
     'url' => 'Url',
 
     'back_to' => 'Terug naar :resource',
+    'status_flow' => 'Statusverloop',
     'properties' => 'Gegevens',
     'public_data' => 'Publieke gegevens',
     'private_data' => 'Private gegevens',

--- a/src/cms/resources/views/filament/infolists/components/entries/snapshot_status_flow.blade.php
+++ b/src/cms/resources/views/filament/infolists/components/entries/snapshot_status_flow.blade.php
@@ -1,0 +1,98 @@
+@php
+    use App\Facades\DateFormat;
+
+    /** @var array{stations: array<int, array<string, mixed>>, obsolete: array<string, mixed>|null} $flow */
+    $flow = $getState();
+
+    // Render every station left-to-right, including the Obsolete branch when
+    // present, so the connector logic stays a single loop.
+    $stations = $flow['stations'];
+    if ($flow['obsolete'] !== null) {
+        $stations[] = $flow['obsolete'];
+    }
+
+    // Only the active (current) station is coloured; reached-but-past stations
+    // are neutral, and not-yet-reached stations are faint. Colours come from
+    // Filament's CSS custom properties (bg-{color}-500 utilities are not all
+    // generated, so info/success would otherwise render transparent).
+    $currentColor = static function (array $s): string {
+        return "rgb(var(--{$s['color']}-500))";
+    };
+@endphp
+
+<div class="fi-snapshot-status-flow w-full overflow-x-auto py-2">
+    <ol class="flex min-w-full" role="list">
+        @foreach ($stations as $index => $station)
+            @php
+                $reached = $station['reached'];
+                $current = $station['current'];
+            @endphp
+
+            {{-- Connector from the previous station, aligned to the dot centre
+                 (dot is h-8 = 2rem, so its centre is 1rem from the top). --}}
+            @if ($index > 0)
+                <li aria-hidden="true" class="flex-1 min-w-6 px-1" style="padding-top: calc(1rem - 2px);">
+                    <span
+                        @class([
+                            'block h-1 w-full rounded-full',
+                            'bg-gray-300 dark:bg-gray-600' => $reached,
+                            'bg-gray-200 dark:bg-white/10' => ! $reached,
+                        ])
+                    ></span>
+                </li>
+            @endif
+
+            {{-- Station --}}
+            <li class="flex flex-col items-center shrink-0 w-28 text-center">
+                <span
+                    @class([
+                        'flex h-8 w-8 items-center justify-center rounded-full',
+                        // Past (reached, not current): neutral filled.
+                        'bg-gray-300 dark:bg-gray-600' => $reached && ! $current,
+                        // Not reached yet: faint outline.
+                        'bg-gray-200 dark:bg-white/10' => ! $reached,
+                        // Current: coloured + ring.
+                        'ring-4 ring-offset-2 ring-offset-white dark:ring-offset-gray-900' => $current,
+                    ])
+                    @if ($current)
+                        style="background: {{ $currentColor($station) }}; --tw-ring-color: {{ $currentColor($station) }};"
+                    @endif
+                >
+                    @if ($reached)
+                        <x-filament::icon
+                            :icon="$current ? 'heroicon-m-map-pin' : ($station['color'] === 'gray' ? 'heroicon-m-x-mark' : 'heroicon-m-check')"
+                            @class([
+                                'h-5 w-5',
+                                'text-white' => $current,
+                                'text-gray-600 dark:text-gray-200' => ! $current,
+                            ])
+                        />
+                    @endif
+                </span>
+
+                <span
+                    @class([
+                        'mt-2 text-sm',
+                        'font-semibold' => $current,
+                        'font-medium text-gray-700 dark:text-gray-300' => $reached && ! $current,
+                        'font-medium text-gray-400 dark:text-gray-500' => ! $reached,
+                    ])
+                    @if ($current) style="color: {{ $currentColor($station) }};" @endif
+                >
+                    {{ $station['label'] }}
+                </span>
+
+                @if ($reached && $station['reached_at'])
+                    <span class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                        {{ DateFormat::toDateTime($station['reached_at']) }}
+                    </span>
+                    @if ($station['reached_by'])
+                        <span class="text-xs text-gray-400 dark:text-gray-500">
+                            {{ $station['reached_by'] }}
+                        </span>
+                    @endif
+                @endif
+            </li>
+        @endforeach
+    </ol>
+</div>

--- a/src/cms/tests/Feature/Filament/Infolists/Components/SnapshotStatusFlowTest.php
+++ b/src/cms/tests/Feature/Filament/Infolists/Components/SnapshotStatusFlowTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Infolists\Components\SnapshotStatusFlow;
+use App\Models\Snapshot;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\Obsolete;
+use App\Models\States\SnapshotState;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+it('marks the current station as reached even without a recorded transition', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => Established::class,
+        ]);
+
+    $flow = SnapshotStatusFlow::buildFlow($snapshot);
+
+    $established = collect($flow['stations'])
+        ->firstWhere('current', true);
+
+    expect($established)->not->toBeNull()
+        ->and($established['reached'])->toBeTrue();
+});
+
+it('marks the obsolete branch as reached and current when obsolete', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => Obsolete::class,
+        ]);
+
+    $flow = SnapshotStatusFlow::buildFlow($snapshot);
+
+    expect($flow['obsolete'])->not->toBeNull()
+        ->and($flow['obsolete']['reached'])->toBeTrue()
+        ->and($flow['obsolete']['current'])->toBeTrue()
+        // No main-line station is current when the snapshot is obsolete.
+        ->and(collect($flow['stations'])->firstWhere('current', true))->toBeNull();
+});
+
+it('only marks the first station reached for a fresh in-review snapshot', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => SnapshotState::DEFAULT_STATE,
+        ]);
+
+    $flow = SnapshotStatusFlow::buildFlow($snapshot);
+
+    $reached = collect($flow['stations'])->where('reached', true);
+
+    expect($reached)->toHaveCount(1)
+        ->and($flow['stations'][0]['reached'])->toBeTrue()
+        ->and($flow['stations'][0]['current'])->toBeTrue();
+});

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/ViewSnapshotTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/ViewSnapshotTest.php
@@ -13,10 +13,12 @@ use App\Models\Snapshot;
 use App\Models\SnapshotApproval;
 use App\Models\SnapshotApprovalLog;
 use App\Models\SnapshotData;
+use App\Models\SnapshotTransition;
 use App\Models\States\Snapshot\Approved;
 use App\Models\States\Snapshot\Established;
 use App\Models\States\Snapshot\InReview;
 use App\Models\States\Snapshot\Obsolete;
+use App\Models\User;
 use App\Models\Wpg\WpgProcessingRecord;
 use Tests\Helpers\Model\OrganisationTestHelper;
 use Tests\Helpers\Model\UserTestHelper;
@@ -639,4 +641,50 @@ it('does not show button to view all snapshot approvales if no permission', func
             'record' => $snapshot->getRouteKey(),
         ])
         ->assertActionDisabled('approve_view_all');
+});
+
+it('shows the status flow with the reached states and who reached them', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = User::factory()->create(['name' => 'Statuswijziger']);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => Established::class,
+        ]);
+
+    // A recorded happy-path history: reached In review, Goedgekeurd and
+    // Vastgesteld, the last of which is the current state.
+    foreach ([InReview::class, Approved::class, Established::class] as $state) {
+        SnapshotTransition::factory()
+            ->recycle($snapshot)
+            ->recycle($user)
+            ->create(['state' => $state]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertSee(__('snapshot.status_flow'))
+        ->assertSeeInOrder([
+            __('snapshot_state.label.in_review'),
+            __('snapshot_state.label.approved'),
+            __('snapshot_state.label.established'),
+        ])
+        ->assertSee('Statuswijziger');
+});
+
+it('shows the obsolete branch in the status flow when a snapshot is obsolete', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => Obsolete::class,
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertSee(__('snapshot_state.label.obsolete'));
 });

--- a/src/cms/tests/Feature/Models/SnapshotTest.php
+++ b/src/cms/tests/Feature/Models/SnapshotTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Organisation;
 use App\Models\Snapshot;
+use App\Models\SnapshotTransition;
+use Carbon\CarbonImmutable;
 
 it('belongs to an organisation', function (): void {
     $snapshot = Snapshot::factory()->create();
@@ -52,4 +54,17 @@ it('will not return the snapshotSource if deleted', function (): void {
 
     expect($snapshot->snapshotSource)
         ->toBeNull();
+});
+
+it('returns its transitions oldest first', function (): void {
+    $snapshot = Snapshot::factory()->create();
+
+    $newer = SnapshotTransition::factory()->recycle($snapshot)->create();
+    $newer->forceFill(['created_at' => CarbonImmutable::create(2024, 5, 1)])->saveQuietly();
+
+    $older = SnapshotTransition::factory()->recycle($snapshot)->create();
+    $older->forceFill(['created_at' => CarbonImmutable::create(2024, 1, 1)])->saveQuietly();
+
+    expect($snapshot->snapshotTransitions->pluck('id')->map->toString()->all())
+        ->toBe([$older->id->toString(), $newer->id->toString()]);
 });


### PR DESCRIPTION
## What

Adds a "Statusverloop" metro-line diagram to the top of the snapshot **Info** tab, visualising the state a snapshot has moved through.

- Stations for the happy path: **In review → Goedgekeurd → Vastgesteld**, plus **Vervallen** as an off-ramp branch shown only when the snapshot became obsolete.
- Only the **active** state is coloured (ring + pin); past states are neutral with a check; not-yet-reached states are faint.
- Each reached station shows **when** it was reached and **by whom**, from the recorded `SnapshotTransition` history.

## How

- `SnapshotStatusFlow` infolist component computes station data from the snapshot's transitions.
- Blade view renders the line; station colours are driven from Filament's CSS custom properties (the `bg-{color}-500` utilities are not all generated for `info`/`success`, which would otherwise render transparent). Theme-aware and horizontally scrollable so it never overflows.
- Added an ordered `snapshotTransitions` relation on `Snapshot`.

## Notes

- The existing "Statuswijzigingen" (History) tab still shows the chronological table; this is the visual, at-a-glance counterpart on the Info tab.
- The demo seeder sets snapshot state directly and does not record transitions, so seeded snapshots show stations-by-state but without timestamps. Backfilling seeder transitions can be a follow-up.

phpstan + phpcs pass.