### PR TITLE
fix: deterministic snapshot faker state assignment

### DIFF
--- a/src/cms/app/Faker/SnapshotProvider.php
+++ b/src/cms/app/Faker/SnapshotProvider.php
@@ -11,7 +11,6 @@ use Closure;
 use Faker\Provider\Miscellaneous;
 use Webmozart\Assert\Assert;
 
-use function array_key_exists;
 use function in_array;
 use function sprintf;
 
@@ -26,21 +25,6 @@ class SnapshotProvider extends Miscellaneous
     public function snapshotState(array $excluded = []): Closure
     {
         return function (array $attributes) use ($excluded): string {
-            /** @var class-string<SnapshotState> $state */
-            $state = SnapshotState::all()
-                ->reject(static function (string $state) use ($excluded) {
-                    if ($state === Obsolete::class) {
-                        return false;
-                    }
-
-                    return in_array($state, $excluded, true);
-                })
-                ->random();
-
-            if ($state === SnapshotState::OBSOLETE_STATE) {
-                return $state;
-            }
-
             $snapshotSourceId = $attributes['snapshot_source_id'];
             $snapshotSourceType = $attributes['snapshot_source_type'];
 
@@ -48,7 +32,20 @@ class SnapshotProvider extends Miscellaneous
             Assert::isInstanceOf($snapshotSourceId, UuidInterface::class);
 
             $group = sprintf('%s-%s', $snapshotSourceType, $snapshotSourceId->toString());
-            if (array_key_exists($group, $this->groups) && in_array($state, $this->groups[$group], true)) {
+            $used = $this->groups[$group] ?? [];
+
+            /** @var class-string<SnapshotState>|null $state */
+            $state = SnapshotState::all()
+                ->reject(static function (string $state) use ($excluded, $used) {
+                    if ($state === Obsolete::class) {
+                        return true;
+                    }
+
+                    return in_array($state, $excluded, true) || in_array($state, $used, true);
+                })
+                ->first();
+
+            if ($state === null) {
                 return SnapshotState::OBSOLETE_STATE;
             }
 


### PR DESCRIPTION
## What

Fixes a flaky test in `SnapshotProviderTest` (`each state can only occur once, except obsolete`) that intermittently failed with `Undefined array key "in_review"` — seen on unrelated PR #50's CI run.

## Root cause

`SnapshotProvider::snapshotState()` picked each snapshot's state with `->random()`, then downgraded to obsolete if that state was already used in the group. The test creates 25–50 snapshots and asserts each of the three non-obsolete states (`in_review`, `established`, `approved`) occurs **exactly once**. Nothing guaranteed `random()` would select all three within that count, so a state could simply never be picked, leaving its key undefined.

## Fix

Assign states deterministically: pick the first non-obsolete state (in registration order) that is neither excluded nor already used in the group, falling back to obsolete when none remain. This guarantees each non-obsolete state appears exactly once per source when enough snapshots are created — matching the behaviour the test documents — while keeping all prior semantics (excluded states never returned, obsolete fills the remainder).

## Testing

- `SnapshotProviderTest` now passes deterministically (ran repeatedly).
- Full snapshot-related suite green (82 tests / 112 assertions): models, `HasSnapshots`, transition actions, transition service, faker.
- phpcs clean.