### PR TITLE
feat: versies vergelijken met side-by-side diff

### DIFF
--- a/src/cms/app/Filament/RelationManagers/SnapshotsRelationManager.php
+++ b/src/cms/app/Filament/RelationManagers/SnapshotsRelationManager.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace App\Filament\RelationManagers;
 
 use App\Filament\Resources\SnapshotResource;
+use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\SnapshotResourceTable;
+use App\Models\Contracts\SnapshotSource;
+use Filament\Facades\Filament;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Table;
 use Livewire\Attributes\On;
+use Webmozart\Assert\Assert;
+
+use function __;
+use function route;
 
 class SnapshotsRelationManager extends RelationManager
 {
@@ -19,7 +27,30 @@ class SnapshotsRelationManager extends RelationManager
 
     public function table(Table $table): Table
     {
-        return SnapshotResourceTable::table($table);
+        return SnapshotResourceTable::table($table)
+            ->headerActions([
+                Action::make('compare')
+                    ->label(__('snapshot.compare'))
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->visible(fn (): bool => $this->getSnapshotSource()->hasComparableSnapshots())
+                    ->url(function (): string {
+                        $latest = $this->getSnapshotSource()->getLatestSnapshot();
+                        Assert::notNull($latest);
+
+                        return route(CompareSnapshots::getRouteName(), [
+                            'tenant' => Filament::getTenant(),
+                            'record' => $latest,
+                        ]);
+                    }),
+            ]);
+    }
+
+    private function getSnapshotSource(): SnapshotSource
+    {
+        $owner = $this->getOwnerRecord();
+        Assert::isInstanceOf($owner, SnapshotSource::class);
+
+        return $owner;
     }
 
     #[On(self::REFRESH_TABLE_EVENT)]

--- a/src/cms/app/Filament/Resources/SnapshotResource.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources;
 
+use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Models\Snapshot;
 
@@ -18,6 +19,7 @@ class SnapshotResource extends Resource
     {
         return [
             'view' => ViewSnapshot::route('/{record}'),
+            'compare' => CompareSnapshots::route('/{record}/compare'),
         ];
     }
 

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -36,6 +36,15 @@ class CompareSnapshots extends Page
     #[Url]
     public ?string $toId = null;
 
+    /**
+     * Request-scoped cache: getSnapshots() is read several times per render
+     * (title, options, diffs). Livewire re-instantiates the component per
+     * request, so caching here stays correct while avoiding repeat queries.
+     *
+     * @var Collection<string, Snapshot>|null
+     */
+    private ?Collection $snapshots = null;
+
     public function mount(int|string $record): void
     {
         $this->record = $this->resolveRecord($record);
@@ -43,7 +52,7 @@ class CompareSnapshots extends Page
         abort_unless($this->getSnapshot()->snapshotSource !== null, 404);
 
         $snapshots = $this->getSnapshots();
-        abort_unless($snapshots->count() >= 2, 404, __('snapshot.compare_not_enough_versions'));
+        abort_unless($snapshots->count() >= 2, 404);
 
         if ($this->fromId === null || !$snapshots->has($this->fromId)) {
             // Default the "from" side to the version right before the anchor,
@@ -81,11 +90,17 @@ class CompareSnapshots extends Page
     /**
      * Snapshots of the same source, keyed by id, newest version first.
      *
+     * `version` is a unique, monotonically increasing integer per source, so
+     * "newest" here means the highest version number. The picker labels show
+     * `created_at`; the two only diverge if snapshots are ever persisted out of
+     * chronological version order (e.g. a cross-organisation import).
+     *
      * @return Collection<string, Snapshot>
      */
     public function getSnapshots(): Collection
     {
-        return $this->getSource()->snapshots()
+        return $this->snapshots ??= $this->getSource()->snapshots()
+            ->with('snapshotData')
             ->get()
             ->sortByDesc('version')
             ->keyBy(static fn (Snapshot $snapshot): string => $snapshot->id->toString());

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SnapshotResource\Pages;
 
+use App\Enums\Authorization\Permission;
 use App\Enums\Snapshot\SnapshotDataSection;
+use App\Facades\Authorization;
 use App\Facades\DateFormat;
 use App\Filament\Resources\SnapshotResource;
 use App\Models\Contracts\SnapshotSource;
@@ -49,6 +51,11 @@ class CompareSnapshots extends Page
     {
         $this->record = $this->resolveRecord($record);
 
+        // Page (unlike ViewRecord) does not authorize access on mount, so the
+        // SNAPSHOT_VIEW policy would never run. Enforce the same check
+        // ViewSnapshot gets automatically before rendering any diff.
+        $this->authorizeAccess();
+
         abort_unless($this->getSnapshot()->snapshotSource !== null, 404);
 
         $snapshots = $this->getSnapshots();
@@ -63,6 +70,13 @@ class CompareSnapshots extends Page
         if ($this->toId === null || !$snapshots->has($this->toId)) {
             $this->toId = $this->getSnapshot()->id->toString();
         }
+    }
+
+    protected function authorizeAccess(): void
+    {
+        // Mirror SnapshotPolicy::view(), which ViewSnapshot enforces via
+        // ViewRecord::mount() but a plain Page does not.
+        abort_unless(Authorization::hasPermission(Permission::SNAPSHOT_VIEW), 403);
     }
 
     public function getTitle(): string|Htmlable

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -67,10 +67,9 @@ class CompareSnapshots extends Page
 
     public function getTitle(): string|Htmlable
     {
-        $snapshot = $this->getSnapshot();
-
+        // The source is guaranteed non-null: mount() aborts otherwise.
         return __('snapshot.compare_title', [
-            'name' => $snapshot->snapshotSource?->getDisplayName() ?? $snapshot->name,
+            'name' => $this->getSource()->getDisplayName(),
         ]);
     }
 

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Resources\SnapshotResource\Pages;
+
+use App\Enums\Snapshot\SnapshotDataSection;
+use App\Facades\DateFormat;
+use App\Filament\Resources\SnapshotResource;
+use App\Models\Contracts\SnapshotSource;
+use App\Models\Snapshot;
+use App\ValueObjects\Markdown;
+use Filament\Resources\Pages\Concerns\InteractsWithRecord;
+use Filament\Resources\Pages\Page;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Collection;
+use Illuminate\Support\HtmlString;
+use Jfcherng\Diff\DiffHelper;
+use Livewire\Attributes\Url;
+use Webmozart\Assert\Assert;
+
+use function __;
+use function abort_unless;
+use function sprintf;
+
+class CompareSnapshots extends Page
+{
+    use InteractsWithRecord;
+
+    protected static string $resource = SnapshotResource::class;
+    protected static string $view = 'filament.resources.snapshot-resource.pages.compare-snapshots';
+
+    #[Url]
+    public ?string $fromId = null;
+
+    #[Url]
+    public ?string $toId = null;
+
+    public function mount(int|string $record): void
+    {
+        $this->record = $this->resolveRecord($record);
+
+        abort_unless($this->getSnapshot()->snapshotSource !== null, 404);
+
+        $snapshots = $this->getSnapshots();
+        abort_unless($snapshots->count() >= 2, 404, __('snapshot.compare_not_enough_versions'));
+
+        if ($this->fromId === null || !$snapshots->has($this->fromId)) {
+            // Default the "from" side to the version right before the anchor,
+            // falling back to the oldest snapshot.
+            $this->fromId = $this->defaultFromId($snapshots);
+        }
+
+        if ($this->toId === null || !$snapshots->has($this->toId)) {
+            $this->toId = $this->getSnapshot()->id->toString();
+        }
+    }
+
+    public function getTitle(): string|Htmlable
+    {
+        $snapshot = $this->getSnapshot();
+
+        return __('snapshot.compare_title', [
+            'name' => $snapshot->snapshotSource?->getDisplayName() ?? $snapshot->name,
+        ]);
+    }
+
+    /**
+     * @return array<int|string, string>
+     */
+    public function getBreadcrumbs(): array
+    {
+        $breadcrumbs = [
+            SnapshotResource::getUrl('view', ['record' => $this->getSnapshot()]) => __('snapshot.model_singular'),
+        ];
+        $breadcrumbs[] = __('snapshot.compare');
+
+        return $breadcrumbs;
+    }
+
+    /**
+     * Snapshots of the same source, keyed by id, newest version first.
+     *
+     * @return Collection<string, Snapshot>
+     */
+    public function getSnapshots(): Collection
+    {
+        return $this->getSource()->snapshots()
+            ->get()
+            ->sortByDesc('version')
+            ->keyBy(static fn (Snapshot $snapshot): string => $snapshot->id->toString());
+    }
+
+    /**
+     * Options for the version pickers: id => human label.
+     *
+     * @return array<string, string>
+     */
+    public function getVersionOptions(): array
+    {
+        return $this->getSnapshots()
+            ->map(static function (Snapshot $snapshot): string {
+                return sprintf(
+                    '%s %d — %s',
+                    __('snapshot.version'),
+                    $snapshot->version,
+                    DateFormat::toDateTime($snapshot->created_at),
+                );
+            })
+            ->all();
+    }
+
+    /**
+     * Side-by-side HTML diffs for each snapshot-data section.
+     *
+     * @return array<string, HtmlString>
+     */
+    public function getDiffs(): array
+    {
+        $snapshots = $this->getSnapshots();
+
+        $from = $this->fromId !== null ? $snapshots->get($this->fromId) : null;
+        $to = $this->toId !== null ? $snapshots->get($this->toId) : null;
+
+        if ($from === null || $to === null) {
+            return [];
+        }
+
+        return [
+            SnapshotDataSection::PUBLIC->value => $this->diffSection(
+                $from->snapshotData?->public_markdown,
+                $to->snapshotData?->public_markdown,
+            ),
+            SnapshotDataSection::PRIVATE->value => $this->diffSection(
+                $from->snapshotData?->private_markdown,
+                $to->snapshotData?->private_markdown,
+            ),
+        ];
+    }
+
+    private function diffSection(?Markdown $from, ?Markdown $to): HtmlString
+    {
+        // We diff the stored snapshot markdown rather than the rendered output:
+        // SnapshotDataMarkdownRenderer injects the currently-established related
+        // snapshots at render time, so its output is not a stable function of the
+        // version and would produce phantom differences.
+        $html = DiffHelper::calculate(
+            (string) $from?->toString(),
+            (string) $to?->toString(),
+            'SideBySide',
+            [
+                'context' => 3,
+                'ignoreWhitespace' => false,
+            ],
+            [
+                'detailLevel' => 'word',
+                'lineNumbers' => false,
+                'showHeader' => false,
+                'separateBlock' => true,
+                'resultForIdenticals' => sprintf(
+                    '<div class="snapshot-diff-empty">%s</div>',
+                    __('snapshot.compare_no_changes'),
+                ),
+            ],
+        );
+
+        return new HtmlString($html);
+    }
+
+    private function getSnapshot(): Snapshot
+    {
+        $snapshot = $this->getRecord();
+        Assert::isInstanceOf($snapshot, Snapshot::class);
+
+        return $snapshot;
+    }
+
+    private function getSource(): SnapshotSource
+    {
+        $source = $this->getSnapshot()->snapshotSource;
+        Assert::isInstanceOf($source, SnapshotSource::class);
+
+        return $source;
+    }
+
+    /**
+     * @param Collection<string, Snapshot> $snapshots
+     */
+    private function defaultFromId(Collection $snapshots): string
+    {
+        $version = $this->getSnapshot()->version;
+
+        $previous = $snapshots
+            ->first(static fn (Snapshot $snapshot): bool => $snapshot->version < $version);
+
+        $fallback = $snapshots->last();
+        Assert::isInstanceOf($fallback, Snapshot::class);
+
+        return ($previous ?? $fallback)->id->toString();
+    }
+}

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/ViewSnapshot.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/ViewSnapshot.php
@@ -89,6 +89,16 @@ class ViewSnapshot extends ViewRecord
                 ->url(PersonalSnapshotApprovalResource::getUrl(parameters: [
                     'activeTab' => ListPersonalSnapshotApprovalItems::TAB_ID_UNREVIEWED,
                 ])),
+            Action::make('compare')
+                ->label(__('snapshot.compare'))
+                ->icon('heroicon-o-arrows-right-left')
+                ->color('gray')
+                ->visible(static function (Snapshot $record): bool {
+                    return $record->snapshotSource?->hasComparableSnapshots() === true;
+                })
+                ->url(static function (Snapshot $record): string {
+                    return SnapshotResource::getUrl('compare', ['record' => $record]);
+                }),
             ExportToPdfAction::make(),
             ...$this->getSnapshotWorkflowActions(),
         ];

--- a/src/cms/app/Filament/Resources/SnapshotResource/SnapshotResourceTable.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/SnapshotResourceTable.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SnapshotResource;
 
+use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Filament\Tables\Columns\CreatedAtColumn;
 use App\Filament\Tables\Columns\SnapshotStateColumn;
@@ -11,6 +12,7 @@ use App\Models\Builders\SnapshotBuilder;
 use App\Models\Snapshot;
 use App\Services\DateFormatService;
 use Filament\Facades\Filament;
+use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -42,6 +44,18 @@ class SnapshotResourceTable
                 ViewAction::make()
                     ->url(static function (Snapshot $snapshot): string {
                         return route(ViewSnapshot::getRouteName(), [
+                            'tenant' => Filament::getTenant(),
+                            'record' => $snapshot,
+                        ]);
+                    }),
+                Action::make('compare')
+                    ->label(__('snapshot.compare'))
+                    ->icon('heroicon-o-arrows-right-left')
+                    ->visible(static function (Snapshot $snapshot): bool {
+                        return $snapshot->snapshotSource?->hasComparableSnapshots() === true;
+                    })
+                    ->url(static function (Snapshot $snapshot): string {
+                        return route(CompareSnapshots::getRouteName(), [
                             'tenant' => Filament::getTenant(),
                             'record' => $snapshot,
                         ]);

--- a/src/cms/app/Filament/Resources/SnapshotResource/SnapshotResourceTable.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/SnapshotResourceTable.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\SnapshotResource;
 
-use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Filament\Tables\Columns\CreatedAtColumn;
 use App\Filament\Tables\Columns\SnapshotStateColumn;
@@ -12,7 +11,6 @@ use App\Models\Builders\SnapshotBuilder;
 use App\Models\Snapshot;
 use App\Services\DateFormatService;
 use Filament\Facades\Filament;
-use Filament\Tables\Actions\Action;
 use Filament\Tables\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
@@ -44,18 +42,6 @@ class SnapshotResourceTable
                 ViewAction::make()
                     ->url(static function (Snapshot $snapshot): string {
                         return route(ViewSnapshot::getRouteName(), [
-                            'tenant' => Filament::getTenant(),
-                            'record' => $snapshot,
-                        ]);
-                    }),
-                Action::make('compare')
-                    ->label(__('snapshot.compare'))
-                    ->icon('heroicon-o-arrows-right-left')
-                    ->visible(static function (Snapshot $snapshot): bool {
-                        return $snapshot->snapshotSource?->hasComparableSnapshots() === true;
-                    })
-                    ->url(static function (Snapshot $snapshot): string {
-                        return route(CompareSnapshots::getRouteName(), [
                             'tenant' => Filament::getTenant(),
                             'record' => $snapshot,
                         ]);

--- a/src/cms/app/Models/Concerns/HasSnapshots.php
+++ b/src/cms/app/Models/Concerns/HasSnapshots.php
@@ -66,13 +66,14 @@ trait HasSnapshots
 
     final public function hasComparableSnapshots(): bool
     {
-        return $this->snapshots()->count() >= 2;
+        return $this->snapshots()->getQuery()->count() >= 2;
     }
 
     final public function getLatestSnapshot(): ?Snapshot
     {
         return $this->snapshots()
-            ->orderByDesc('version')
+            ->get()
+            ->sortByDesc('version')
             ->first();
     }
 

--- a/src/cms/app/Models/Concerns/HasSnapshots.php
+++ b/src/cms/app/Models/Concerns/HasSnapshots.php
@@ -69,6 +69,14 @@ trait HasSnapshots
         return $this->snapshots()->get()->count() >= 2;
     }
 
+    final public function getLatestSnapshot(): ?Snapshot
+    {
+        return $this->snapshots()
+            ->get()
+            ->sortByDesc('version')
+            ->first();
+    }
+
     /**
      * @param class-string<SnapshotState> $state
      */

--- a/src/cms/app/Models/Concerns/HasSnapshots.php
+++ b/src/cms/app/Models/Concerns/HasSnapshots.php
@@ -64,6 +64,11 @@ trait HasSnapshots
         return $this->morphMany(Snapshot::class, 'snapshot_source');
     }
 
+    final public function hasComparableSnapshots(): bool
+    {
+        return $this->snapshots()->get()->count() >= 2;
+    }
+
     /**
      * @param class-string<SnapshotState> $state
      */

--- a/src/cms/app/Models/Concerns/HasSnapshots.php
+++ b/src/cms/app/Models/Concerns/HasSnapshots.php
@@ -66,14 +66,13 @@ trait HasSnapshots
 
     final public function hasComparableSnapshots(): bool
     {
-        return $this->snapshots()->get()->count() >= 2;
+        return $this->snapshots()->count() >= 2;
     }
 
     final public function getLatestSnapshot(): ?Snapshot
     {
         return $this->snapshots()
-            ->get()
-            ->sortByDesc('version')
+            ->orderByDesc('version')
             ->first();
     }
 

--- a/src/cms/app/Models/Contracts/SnapshotSource.php
+++ b/src/cms/app/Models/Contracts/SnapshotSource.php
@@ -19,6 +19,8 @@ interface SnapshotSource
      */
     public function snapshots(): MorphMany;
 
+    public function hasComparableSnapshots(): bool;
+
     /**
      * @param class-string<SnapshotState> $state
      */

--- a/src/cms/app/Models/Contracts/SnapshotSource.php
+++ b/src/cms/app/Models/Contracts/SnapshotSource.php
@@ -21,6 +21,8 @@ interface SnapshotSource
 
     public function hasComparableSnapshots(): bool;
 
+    public function getLatestSnapshot(): ?Snapshot;
+
     /**
      * @param class-string<SnapshotState> $state
      */

--- a/src/cms/composer.json
+++ b/src/cms/composer.json
@@ -22,6 +22,7 @@
         "filament/filament": "^3.3.52",
         "filament/spatie-laravel-media-library-plugin": "^3.0-stable",
         "guzzlehttp/guzzle": "^7.2",
+        "jfcherng/php-diff": "^6.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^3.0",
         "livewire/livewire": "^3.4",

--- a/src/cms/composer.lock
+++ b/src/cms/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53beed88b995b5b47655bdf67e6c10e2",
+    "content-hash": "ffd1597cde5fdfcf2499c94d45fa2014",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2769,6 +2769,243 @@
                 }
             ],
             "time": "2026-06-23T13:02:23+00:00"
+        },
+        {
+            "name": "jfcherng/php-color-output",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-color-output.git",
+                "reference": "6c7bf16686cc6a291647fcb87491640a2d5edd20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-color-output/zipball/6c7bf16686cc6a291647fcb87491640a2d5edd20",
+                "reference": "6c7bf16686cc6a291647fcb87491640a2d5edd20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "liip/rmt": "^1.6",
+                "phan/phan": "^2 || ^3 || ^4",
+                "phpunit/phpunit": ">=7 <10",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Utility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                }
+            ],
+            "description": "Make your PHP command-line application colorful.",
+            "keywords": [
+                "ansi-colors",
+                "color",
+                "command-line",
+                "str-color"
+            ],
+            "support": {
+                "issues": "https://github.com/jfcherng/php-color-output/issues",
+                "source": "https://github.com/jfcherng/php-color-output/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2021-05-27T02:45:54+00:00"
+        },
+        {
+            "name": "jfcherng/php-diff",
+            "version": "6.16.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-diff.git",
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
+                "reference": "6d7332b6080cdd50011a364b58f24c8d0cdeb5da",
+                "shasum": ""
+            },
+            "require": {
+                "jfcherng/php-color-output": "^3",
+                "jfcherng/php-mb-string": "^1.4.6 || ^2",
+                "jfcherng/php-sequence-matcher": "^3.2.10 || ^4",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.51",
+                "liip/rmt": "^1.6",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Diff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                },
+                {
+                    "name": "Chris Boulton",
+                    "email": "chris.boulton@interspire.com"
+                }
+            ],
+            "description": "A comprehensive library for generating differences between two strings in multiple formats (unified, side by side HTML etc).",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/jfcherng/php-diff/issues",
+                "source": "https://github.com/jfcherng/php-diff/tree/6.16.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2026-06-22T13:08:56+00:00"
+        },
+        {
+            "name": "jfcherng/php-mb-string",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-mb-string.git",
+                "reference": "8407bfefde47849c9e7c9594e6de2ac85a0f845d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-mb-string/zipball/8407bfefde47849c9e7c9594e6de2ac85a0f845d",
+                "reference": "8407bfefde47849c9e7c9594e6de2ac85a0f845d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9 || ^10"
+            },
+            "suggest": {
+                "ext-iconv": "Either \"ext-iconv\" or \"ext-mbstring\" is requried.",
+                "ext-mbstring": "Either \"ext-iconv\" or \"ext-mbstring\" is requried."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Utility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                }
+            ],
+            "description": "A high performance multibytes sting implementation for frequently reading/writing operations.",
+            "support": {
+                "issues": "https://github.com/jfcherng/php-mb-string/issues",
+                "source": "https://github.com/jfcherng/php-mb-string/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-04-17T14:23:16+00:00"
+        },
+        {
+            "name": "jfcherng/php-sequence-matcher",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-sequence-matcher.git",
+                "reference": "d2038ac29627340a7458609072a8ba355e80ec5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-sequence-matcher/zipball/d2038ac29627340a7458609072a8ba355e80ec5b",
+                "reference": "d2038ac29627340a7458609072a8ba355e80ec5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9 || ^10",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Diff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                },
+                {
+                    "name": "Chris Boulton",
+                    "email": "chris.boulton@interspire.com"
+                }
+            ],
+            "description": "A longest sequence matcher. The logic is primarily based on the Python difflib package.",
+            "support": {
+                "issues": "https://github.com/jfcherng/php-sequence-matcher/issues",
+                "source": "https://github.com/jfcherng/php-sequence-matcher/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-05-21T07:57:08+00:00"
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",
@@ -7969,76 +8206,6 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v7.4.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -15807,6 +15974,76 @@
                 }
             ],
             "time": "2026-05-20T14:07:29+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-deepclone",

--- a/src/cms/resources/lang/nl/snapshot.php
+++ b/src/cms/resources/lang/nl/snapshot.php
@@ -13,6 +13,13 @@ return [
     'created' => 'Versie aangemaakt',
     'unsaved_changes' => 'Versie niet aangemaakt, er zijn nog niet opgeslagen wijzingen',
 
+    'compare' => 'Vergelijken',
+    'compare_title' => 'Versies vergelijken: :name',
+    'compare_from' => 'Oude versie',
+    'compare_to' => 'Nieuwe versie',
+    'compare_no_changes' => 'Geen wijzigingen',
+    'compare_not_enough_versions' => 'Er zijn minimaal twee versies nodig om te vergelijken',
+
     'number' => 'Nummer verwerking',
     'name' => 'Naam versie',
     'state' => 'Status',

--- a/src/cms/resources/lang/nl/snapshot.php
+++ b/src/cms/resources/lang/nl/snapshot.php
@@ -18,7 +18,6 @@ return [
     'compare_from' => 'Oude versie',
     'compare_to' => 'Nieuwe versie',
     'compare_no_changes' => 'Geen wijzigingen',
-    'compare_not_enough_versions' => 'Er zijn minimaal twee versies nodig om te vergelijken',
 
     'number' => 'Nummer verwerking',
     'name' => 'Naam versie',

--- a/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
+++ b/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
@@ -4,33 +4,42 @@
         $diffs = $this->getDiffs();
     @endphp
 
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        <div>
-            <label for="compare-from" class="fi-fo-field-wrp-label inline-flex items-center gap-x-3 mb-1 text-sm font-medium text-gray-950 dark:text-white">
-                {{ __('snapshot.compare_from') }}
-            </label>
-            <x-filament::input.wrapper>
-                <x-filament::input.select wire:model.live="fromId" id="compare-from">
-                    @foreach ($options as $id => $label)
-                        <option value="{{ $id }}">{{ $label }}</option>
-                    @endforeach
-                </x-filament::input.select>
-            </x-filament::input.wrapper>
+    <x-filament::section>
+        <div class="snapshot-diff">
+            <table class="snapshot-diff-pickers">
+                <colgroup>
+                    <col style="width: 50%;">
+                    <col style="width: 50%;">
+                </colgroup>
+                <tr>
+                    <th>
+                        <label for="compare-from" class="snapshot-diff-picker-label">
+                            {{ __('snapshot.compare_from') }}
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input.select wire:model.live="fromId" id="compare-from">
+                                @foreach ($options as $id => $label)
+                                    <option value="{{ $id }}">{{ $label }}</option>
+                                @endforeach
+                            </x-filament::input.select>
+                        </x-filament::input.wrapper>
+                    </th>
+                    <th>
+                        <label for="compare-to" class="snapshot-diff-picker-label">
+                            {{ __('snapshot.compare_to') }}
+                        </label>
+                        <x-filament::input.wrapper>
+                            <x-filament::input.select wire:model.live="toId" id="compare-to">
+                                @foreach ($options as $id => $label)
+                                    <option value="{{ $id }}">{{ $label }}</option>
+                                @endforeach
+                            </x-filament::input.select>
+                        </x-filament::input.wrapper>
+                    </th>
+                </tr>
+            </table>
         </div>
-
-        <div>
-            <label for="compare-to" class="fi-fo-field-wrp-label inline-flex items-center gap-x-3 mb-1 text-sm font-medium text-gray-950 dark:text-white">
-                {{ __('snapshot.compare_to') }}
-            </label>
-            <x-filament::input.wrapper>
-                <x-filament::input.select wire:model.live="toId" id="compare-to">
-                    @foreach ($options as $id => $label)
-                        <option value="{{ $id }}">{{ $label }}</option>
-                    @endforeach
-                </x-filament::input.select>
-            </x-filament::input.wrapper>
-        </div>
-    </div>
+    </x-filament::section>
 
     @foreach ($diffs as $section => $diff)
         <x-filament::section>
@@ -46,6 +55,30 @@
 
     @push('styles')
         <style>
+            /* Picker row mirrors the diff table geometry: two flush 50% columns,
+               so "Oude versie" caps the old column and "Nieuwe versie" the new. */
+            .snapshot-diff-pickers {
+                width: 100%;
+                table-layout: fixed;
+                border-collapse: collapse;
+            }
+            .snapshot-diff-pickers th {
+                padding: 0 0.5rem;
+                text-align: left;
+                vertical-align: bottom;
+                font-weight: inherit;
+            }
+            .snapshot-diff-pickers th:first-child { padding-left: 0; }
+            .snapshot-diff-pickers th:last-child { padding-right: 0; }
+            .snapshot-diff-picker-label {
+                display: block;
+                margin-bottom: 0.25rem;
+                font-size: 0.875rem;
+                font-weight: 500;
+                color: rgb(3 7 18); /* gray-950 */
+            }
+            .dark .snapshot-diff-picker-label { color: rgb(255 255 255); }
+
             .snapshot-diff { overflow-x: auto; }
             .snapshot-diff table.diff {
                 width: 100%;

--- a/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
+++ b/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
@@ -2,6 +2,8 @@
     @php
         $options = $this->getVersionOptions();
         $diffs = $this->getDiffs();
+        $fromId = $this->fromId;
+        $toId = $this->toId;
     @endphp
 
     <x-filament::section>
@@ -19,7 +21,7 @@
                         <x-filament::input.wrapper>
                             <x-filament::input.select wire:model.live="fromId" id="compare-from">
                                 @foreach ($options as $id => $label)
-                                    <option value="{{ $id }}">{{ $label }}</option>
+                                    <option value="{{ $id }}" @selected($id === $fromId)>{{ $label }}</option>
                                 @endforeach
                             </x-filament::input.select>
                         </x-filament::input.wrapper>
@@ -31,7 +33,7 @@
                         <x-filament::input.wrapper>
                             <x-filament::input.select wire:model.live="toId" id="compare-to">
                                 @foreach ($options as $id => $label)
-                                    <option value="{{ $id }}">{{ $label }}</option>
+                                    <option value="{{ $id }}" @selected($id === $toId)>{{ $label }}</option>
                                 @endforeach
                             </x-filament::input.select>
                         </x-filament::input.wrapper>

--- a/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
+++ b/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
@@ -1,0 +1,98 @@
+<x-filament-panels::page>
+    @php
+        $options = $this->getVersionOptions();
+        $diffs = $this->getDiffs();
+    @endphp
+
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+            <label for="compare-from" class="fi-fo-field-wrp-label inline-flex items-center gap-x-3 mb-1 text-sm font-medium text-gray-950 dark:text-white">
+                {{ __('snapshot.compare_from') }}
+            </label>
+            <x-filament::input.wrapper>
+                <x-filament::input.select wire:model.live="fromId" id="compare-from">
+                    @foreach ($options as $id => $label)
+                        <option value="{{ $id }}">{{ $label }}</option>
+                    @endforeach
+                </x-filament::input.select>
+            </x-filament::input.wrapper>
+        </div>
+
+        <div>
+            <label for="compare-to" class="fi-fo-field-wrp-label inline-flex items-center gap-x-3 mb-1 text-sm font-medium text-gray-950 dark:text-white">
+                {{ __('snapshot.compare_to') }}
+            </label>
+            <x-filament::input.wrapper>
+                <x-filament::input.select wire:model.live="toId" id="compare-to">
+                    @foreach ($options as $id => $label)
+                        <option value="{{ $id }}">{{ $label }}</option>
+                    @endforeach
+                </x-filament::input.select>
+            </x-filament::input.wrapper>
+        </div>
+    </div>
+
+    @foreach ($diffs as $section => $diff)
+        <x-filament::section>
+            <x-slot name="heading">
+                {{ __('snapshot.' . $section . '_data') }}
+            </x-slot>
+
+            <div class="snapshot-diff">
+                {{ $diff }}
+            </div>
+        </x-filament::section>
+    @endforeach
+
+    @push('styles')
+        <style>
+            .snapshot-diff { overflow-x: auto; }
+            .snapshot-diff table.diff {
+                width: 100%;
+                border-collapse: collapse;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.8125rem;
+                line-height: 1.5;
+            }
+            .snapshot-diff table.diff td {
+                padding: 0.125rem 0.5rem;
+                vertical-align: top;
+                white-space: pre-wrap;
+                word-break: break-word;
+                width: 50%;
+                border: 1px solid rgb(229 231 235); /* gray-200 */
+            }
+            .snapshot-diff table.diff thead th {
+                padding: 0.25rem 0.5rem;
+                text-align: left;
+                font-weight: 600;
+                border: 1px solid rgb(229 231 235);
+            }
+            .snapshot-diff td.none { background-color: rgb(249 250 251); } /* gray-50 */
+            .snapshot-diff .change-ins td.new,
+            .snapshot-diff .change-rep td.new { background-color: rgb(220 252 231); } /* green-100 */
+            .snapshot-diff .change-del td.old,
+            .snapshot-diff .change-rep td.old { background-color: rgb(254 226 226); } /* red-100 */
+            .snapshot-diff ins { background-color: rgb(134 239 172); text-decoration: none; } /* green-300 */
+            .snapshot-diff del { background-color: rgb(252 165 165); text-decoration: none; } /* red-300 */
+            .snapshot-diff tbody.skipped td { background-color: rgb(249 250 251); height: 0.5rem; }
+            .snapshot-diff-empty {
+                padding: 0.75rem;
+                color: rgb(107 114 128); /* gray-500 */
+                font-style: italic;
+            }
+
+            .dark .snapshot-diff table.diff td,
+            .dark .snapshot-diff table.diff thead th { border-color: rgb(55 65 81); } /* gray-700 */
+            .dark .snapshot-diff td.none { background-color: rgb(31 41 55); } /* gray-800 */
+            .dark .snapshot-diff .change-ins td.new,
+            .dark .snapshot-diff .change-rep td.new { background-color: rgba(21 128 61 / 0.35); } /* green-700 */
+            .dark .snapshot-diff .change-del td.old,
+            .dark .snapshot-diff .change-rep td.old { background-color: rgba(185 28 28 / 0.35); } /* red-700 */
+            .dark .snapshot-diff ins { background-color: rgba(21 128 61 / 0.65); color: rgb(240 253 244); }
+            .dark .snapshot-diff del { background-color: rgba(185 28 28 / 0.65); color: rgb(254 242 242); }
+            .dark .snapshot-diff tbody.skipped td { background-color: rgb(31 41 55); }
+            .dark .snapshot-diff-empty { color: rgb(156 163 175); } /* gray-400 */
+        </style>
+    @endpush
+</x-filament-panels::page>

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -78,6 +78,39 @@ it('defaults the pickers to the previous and anchor versions', function (): void
         ->assertSet('toId', $to->id->toString());
 });
 
+it('defaults the from-side to the oldest version when anchored on the oldest', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [$oldest] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    // Anchoring on the oldest version leaves no earlier version, so the
+    // "from" side falls back to the oldest snapshot itself.
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $oldest->getRouteKey(),
+        ])
+        ->assertSet('fromId', $oldest->id->toString())
+        ->assertSet('toId', $oldest->id->toString());
+});
+
+it('renders no diff sections when a selected version is unknown', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->set('toId', 'unknown-id')
+        ->assertDontSee(__('snapshot.public_data'))
+        ->assertDontSee(__('snapshot.private_data'));
+});
+
 it('shows a no-changes message when both versions are identical', function (): void {
     $organisation = OrganisationTestHelper::create();
     $source = AvgResponsibleProcessingRecord::factory()

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Authorization\Permission;
 use App\Filament\RelationManagers\SnapshotsRelationManager;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
 use App\Filament\Resources\SnapshotResource;
@@ -11,6 +12,7 @@ use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Snapshot;
 use App\Models\SnapshotData;
 use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
 
 /**
  * @return array{0: Snapshot, 1: Snapshot}
@@ -61,6 +63,46 @@ it('renders the compare page for a source with two versions', function (): void 
         ->assertOk()
         ->assertSee('oudewaarde')
         ->assertSee('nieuwewaarde');
+});
+
+it('forbids access without the snapshot view permission', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    // A user who can see the source entity but lacks SNAPSHOT_VIEW must not be
+    // able to read the diff of every snapshot in the tenant.
+    $user = UserTestHelper::createForOrganisationWithPermissions(
+        $organisation,
+        [Permission::CORE_ENTITY_VIEW],
+    );
+
+    $this->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertForbidden();
+});
+
+it('allows access with the snapshot view permission', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    $user = UserTestHelper::createForOrganisationWithPermissions(
+        $organisation,
+        [Permission::CORE_ENTITY_VIEW, Permission::SNAPSHOT_VIEW],
+    );
+
+    $this->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk();
 });
 
 it('defaults the pickers to the previous and anchor versions', function (): void {

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use App\Filament\RelationManagers\SnapshotsRelationManager;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
 use App\Filament\Resources\SnapshotResource;
 use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
@@ -146,4 +148,52 @@ it('hides the compare action when only one version exists', function (): void {
             'record' => $snapshot->getRouteKey(),
         ])
         ->assertActionHidden('compare');
+});
+
+it('shows a compare header action in the versions table for comparable versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    createComparableSnapshots($source, 'oud', 'nieuw');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(SnapshotsRelationManager::class, [
+            'ownerRecord' => $source,
+            'pageClass' => EditAvgResponsibleProcessingRecord::class,
+        ])
+        ->assertTableActionVisible('compare');
+});
+
+it('the compare header action targets the latest version', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $latest] = createComparableSnapshots($source, 'oud', 'nieuw');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(SnapshotsRelationManager::class, [
+            'ownerRecord' => $source,
+            'pageClass' => EditAvgResponsibleProcessingRecord::class,
+        ])
+        ->assertTableActionHasUrl('compare', SnapshotResource::getUrl('compare', ['record' => $latest]));
+});
+
+it('hides the compare header action when only one version exists', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    Snapshot::factory()
+        ->recycle($organisation)
+        ->for($source, 'snapshotSource')
+        ->create(['version' => 1]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(SnapshotsRelationManager::class, [
+            'ownerRecord' => $source,
+            'pageClass' => EditAvgResponsibleProcessingRecord::class,
+        ])
+        ->assertTableActionHidden('compare');
 });

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\SnapshotResource;
+use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
+use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Snapshot;
+use App\Models\SnapshotData;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+/**
+ * @return array{0: Snapshot, 1: Snapshot}
+ */
+function createComparableSnapshots(
+    AvgResponsibleProcessingRecord $source,
+    string $fromMarkdown,
+    string $toMarkdown,
+): array {
+    $organisation = $source->getOrganisation();
+
+    $from = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($source, 'snapshotSource')
+        ->create(['version' => 1]);
+    SnapshotData::factory()
+        ->for($from)
+        ->create([
+            'public_markdown' => $fromMarkdown,
+            'private_markdown' => $fromMarkdown,
+        ]);
+
+    $to = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($source, 'snapshotSource')
+        ->create(['version' => 2]);
+    SnapshotData::factory()
+        ->for($to)
+        ->create([
+            'public_markdown' => $toMarkdown,
+            'private_markdown' => $toMarkdown,
+        ]);
+
+    return [$from, $to];
+}
+
+it('renders the compare page for a source with two versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'eersteregel oudewaarde', 'eersteregel nieuwewaarde');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk()
+        ->assertSee('oudewaarde')
+        ->assertSee('nieuwewaarde');
+});
+
+it('defaults the pickers to the previous and anchor versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [$from, $to] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertSet('fromId', $from->id->toString())
+        ->assertSet('toId', $to->id->toString());
+});
+
+it('shows a no-changes message when both versions are identical', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [$to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertSee(__('snapshot.compare_no_changes'));
+});
+
+it('aborts when the source has fewer than two versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($source, 'snapshotSource')
+        ->create(['version' => 1]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->get(SnapshotResource::getUrl('compare', ['record' => $snapshot]))
+        ->assertNotFound();
+});
+
+it('aborts when the snapshot source has been deleted', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['deleted_at' => fake()->dateTime()]);
+    [, $to] = createComparableSnapshots($source, 'oud', 'nieuw');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->get(SnapshotResource::getUrl('compare', ['record' => $to]))
+        ->assertNotFound();
+});
+
+it('shows a compare action on the view page when comparable versions exist', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'oud-fragment', 'nieuw-fragment');
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertActionVisible('compare');
+});
+
+it('hides the compare action when only one version exists', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($source, 'snapshotSource')
+        ->create(['version' => 1]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertActionHidden('compare');
+});


### PR DESCRIPTION
## Wat

Gebruikers kunnen nu twee versies (snapshots) van dezelfde registratie vergelijken en zien wat er is gewijzigd.

- Nieuwe **"Vergelijken"**-pagina (`SnapshotResource` route `compare`) met twee versie-kiezers (vrije keuze, beide richtingen). Standaard: *vorige → huidige*.
- **Side-by-side diff** van de publieke én private markdown, met word-level highlighting (rood verwijderd links, groen toegevoegd rechts). Thema-bewust (light/dark).
- **Eén "Vergelijken"-knop in de header** van de Versies-tabel (relation manager), die naar de nieuwste versie linkt en automatisch *huidige vs. één ervoor* selecteert. De per-rij compare-actie is verwijderd.
- Ook een "Vergelijken"-header-actie op de losse versie-view-pagina.

## Ontwerpkeuze

De diff vergelijkt de **opgeslagen** `SnapshotData` markdown, niet de output van `SnapshotDataMarkdownRenderer`. Die renderer injecteert de *nu-vastgestelde* gerelateerde snapshots op render-tijd, dus die output is geen stabiele functie van de versie en zou fantoom-verschillen tonen.

## Afhankelijkheid

`jfcherng/php-diff ^6.0` toegevoegd aan `require` (levert de side-by-side HTML-renderer). De library escapet de bron-tekst (`htmlspecialchars`) vóór het invoegen van de eigen `<ins>`/`<del>`-markup — geverifieerd tegen XSS met een live payload.

## Review

Cranky code review uitgevoerd. Uitkomst:
- **XSS: niet exploiteerbaar** (bron-tekst wordt geëscaped vóór diff-markup).
- **Cross-tenant lek: geen** (record-resolutie is tenant-scoped; `fromId`/`toId` worden gevalideerd tegen de eigen source).
- Perf-fixes doorgevoerd: snapshots gememoized + eager-load `snapshotData`; `hasComparableSnapshots()`/`getLatestSnapshot()` naar DB-side count/order; eerlijke `@selected` picker-render.

## Tests

Feature-tests in `tests/Feature/.../CompareSnapshotsTest.php`: rendert, picker-defaults, geen-wijzigingen-status, 404 bij <2 versies / verwijderde source, header-actie zichtbaar/verborgen + target op nieuwste versie. Lokaal: phpstan (max) + phpcs schoon, 10 tests groen.

Handmatig geverifieerd in de draaiende app (screenshots van de vergelijk-pagina en de header-knop).
