### PR TITLE
ci: composer audit gate, dependabot composer updates, dompdf patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,8 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Europe/Amsterdam"
+    # Majors are proposed too, but ungrouped: one breaking major in a
+    # grouped PR would otherwise block every other update in it.
     groups:
       minor-and-patch:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,6 +43,27 @@ updates:
       - "dependencies"
       - "npm"
 
+  # CMS composer dependencies
+  - package-ecosystem: "composer"
+    directory: "/src/cms"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Amsterdam"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps(cms)"
+    labels:
+      - "dependencies"
+      - "composer"
+
   # Docker base images
   - package-ecosystem: "docker"
     directory: "/src/cms"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Composer install
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
+      - name: Composer audit
+        run: composer audit --no-interaction --locked
+
       - name: Prepare application
         run: php artisan key:generate
 

--- a/src/cms/composer.lock
+++ b/src/cms/composer.lock
@@ -1240,16 +1240,16 @@
         },
         {
             "name": "dompdf/dompdf",
-            "version": "v3.1.5",
+            "version": "v3.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dompdf/dompdf.git",
-                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
-                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/6d4b4eb8500f7a786da8868ba463a71b725a4005",
+                "reference": "6d4b4eb8500f7a786da8868ba463a71b725a4005",
                 "shasum": ""
             },
             "require": {
@@ -1298,9 +1298,9 @@
             "homepage": "https://github.com/dompdf/dompdf",
             "support": {
                 "issues": "https://github.com/dompdf/dompdf/issues",
-                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.6"
             },
-            "time": "2026-03-03T13:54:37+00:00"
+            "time": "2026-07-20T12:29:38+00:00"
         },
         {
             "name": "dompdf/php-font-lib",
@@ -7969,76 +7969,6 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v7.4.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -15807,6 +15737,76 @@
                 }
             ],
             "time": "2026-05-20T14:07:29+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-deepclone",


### PR DESCRIPTION
## What

Closes the SCA gap raised as **finding 2** of the IB-review on #54:

> `composer.json` — Nieuwe dependency `jfcherng/php-diff` (+3 transitief) toegevoegd zonder SCA/`composer audit`-stap in CI; repo-breed pre-existent gat, door deze PR wel vergroot.

Raised on #54 but repo-wide and pre-existing, so it lands here on a fresh branch off `main`. Three commits, one root cause.

## 1. Dependabot was not watching composer

This turned out to be the actual reason the gap existed. `.github/dependabot.yml` covered **npm ×2, docker, and github-actions — but not composer**. The PHP dependencies were the one part of the stack nobody was watching, which is exactly where the advisories accumulated.

Added a `composer` ecosystem entry for `/src/cms`, mirroring the existing npm entries: weekly Monday schedule, minor+patch grouped, `deps(cms)` prefix.

Note this composes with the existing `dependabot-auto-merge.yml`, which approves and auto-merges Dependabot PRs on green — so composer updates will now flow through that same path.

## 2. The audit gate does not pass on main as-is

`composer audit` currently exits **1** on `main`. Six open advisories, all in `dompdf/dompdf <3.1.6`:

| Severity | CVE |
|---|---|
| medium | CVE-2026-59943, CVE-2026-59942, CVE-2026-59941, CVE-2026-56722 |
| low | CVE-2026-55555, CVE-2026-55554 |

Notably **none** are in `jfcherng/php-diff` — the dependency that prompted the finding is clean. These were disclosed 2026-07-22 against a lockfile nobody had touched: precisely the case a PR-time gate catches and a manual check does not.

So the step alone would red-line CI. This bumps `dompdf/dompdf` 3.1.5 → 3.1.6, clearing all six. It is a transitive dep of `barryvdh/laravel-dompdf` constrained `^3.0`, so **`composer.json` is unchanged and only `composer.lock` moves** — one version bump plus package reordering.

## 3. The CI step

`composer audit --no-interaction --locked`, immediately after `composer install`.

**Why unconditional rather than path-filtered:** advisories are published against dependencies you *already* have — this PR is the proof. A `paths: composer.lock` filter would have stayed silent through all six disclosures and only fired whenever someone next touched a dependency, surfacing on an unrelated PR. The check reads the lockfile against a cached DB in well under a second, against a ~7 minute job.

**Tradeoff worth knowing:** a newly-disclosed advisory turns *every* open PR red, including unrelated ones. That's intended — it's how the team finds out within a day. If it proves disruptive, the fix is a severity threshold or a scheduled job that files an issue; not path filtering.

**Why both this and Dependabot:** they do different jobs. Dependabot *proposes a fix* after the fact; the audit gate *blocks a merge* carrying a known-vulnerable lockfile. The auto-merge workflow makes the gate load-bearing — it's what stops a bad lockfile going in if an advisory lands between PR open and merge.

## Verification

- `composer audit --locked` exits **1** on the pre-bump lockfile and **0** after — confirmed by stashing and re-running, so the gate demonstrably gates rather than passing vacuously
- `.github/dependabot.yml` parses; all five ecosystem entries resolve, and `composer.json`/`composer.lock` are both present at `/src/cms`
- phpstan: no errors · phpcs: 0 errors
- No test covers the PDF export path (`ExportToPdfAction` is its only consumer), so the suite would not have caught a dompdf regression. Smoke-tested the upgrade directly: renders a valid `%PDF-` document.