### PR TITLE
fix: check out real ref for dev build, not version label

### DIFF
--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -11,16 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.VERSION }}
+      sha: ${{ steps.version.outputs.SHA }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Get version string
         id: version
-        run: echo "VERSION=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+        run: |
+          echo "VERSION=dev-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "SHA=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
   build:
     needs: version
     uses: ./.github/workflows/build-release.yml
     with:
+      # dev-<sha> is only a label; check out the actual commit, not a ref by that name.
       version: ${{ needs.version.outputs.version }}
+      ref: ${{ needs.version.outputs.sha }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -4,7 +4,12 @@ on:
   workflow_call:
     inputs:
       version:
+        description: "Package label baked into the archive (e.g. dev-<sha> or v20260721)"
         required: true
+        type: string
+      ref:
+        description: "Git ref to check out. Defaults to `version` for tag builds; the dev path passes a real SHA."
+        required: false
         type: string
     outputs:
       archive:
@@ -28,10 +33,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          # Build the requested version, not the triggering ref. On a
-          # dispatched run the triggering ref is the branch, which would
-          # otherwise package current main under the tag's name.
-          ref: ${{ inputs.version }}
+          # Build the requested ref, not the triggering ref. On a dispatched
+          # run the triggering ref is the branch, which would otherwise package
+          # current main under the tag's name. `version` is only a label baked
+          # into the archive and may not be a real ref (e.g. dev-<sha>), so
+          # tag builds fall back to it while the dev path passes a SHA.
+          ref: ${{ inputs.ref || inputs.version }}
 
       - name: Install just
         uses: extractions/setup-just@v2


### PR DESCRIPTION
## Problem

**Build Dev Release** failed on every push to main. The `version` job produces a package *label* `dev-<sha>`, which `build-release.yml` then passed to `actions/checkout` as `ref`. No branch/tag named `dev-<sha>` exists, so checkout failed:

```
git fetch … origin +refs/heads/dev-952957c*:… → exit code 1
The process '/usr/bin/git' failed with exit code 1
```

It worked for `tag-release.yml`/`release.yml` only because there the version coincidentally *is* a real tag.

## Fix

Separate the two concepts:
- `build-release.yml` gains an optional `ref` input; checkout uses `ref: ${{ inputs.ref || inputs.version }}`, so tag builds keep falling back to `version`.
- `build-dev.yml` now also outputs the full commit `SHA` and passes it as `ref`, keeping `dev-<sha>` purely as the archive label.

`tag-release.yml` and `release.yml` are unchanged — they pass no `ref` and continue to build the tag.

The `ref` value comes only from a trusted in-repo `git rev-parse HEAD` (or a tag name), never from event payloads.