### PR TITLE
fix: default login-link to admin@example.com

### DIFF
--- a/justfile
+++ b/justfile
@@ -97,8 +97,8 @@ dev-shell:
 dev-reset:
     cd src/cms && composer run reset
 
-# Print a passwordless login link for local dev (default: demo@example.com)
-login-link email="demo@example.com":
+# Print a passwordless login link for local dev (default: admin@example.com)
+login-link email="admin@example.com":
     cd src/cms && php artisan dev:login-link --email={{email}}
 
 # Build frontend assets


### PR DESCRIPTION
`just login-link` (no args) failed with `No user found with email demo@example.com`.

The default was `demo@example.com`, which only exists in `DemoSeeder`. The local DB is built from `TestDataSeeder` (the default in `DatabaseSeeder`), which never creates that user.

Changed the default to `admin@example.com` — the hardcoded superuser created at `TestDataSeeder.php:114` (name `'Admin'` → slug `admin@example.com`), holding all roles.