### PR TITLE
feat: versie transitie-dropdown met direct vaststellen vanuit review

### DIFF
--- a/src/cms/app/Filament/Actions/SnapshotTransition/SnapshotTransitionAction.php
+++ b/src/cms/app/Filament/Actions/SnapshotTransition/SnapshotTransitionAction.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Filament\Actions\SnapshotTransition;
 
 use App\Facades\Authorization;
+use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Models\Snapshot;
 use App\Models\States\SnapshotState;
 use App\Services\Snapshot\SnapshotStateTransitionService;
 use Filament\Actions\Action;
+use Livewire\Component;
 
 use function __;
 use function sprintf;
@@ -26,6 +28,9 @@ abstract class SnapshotTransitionAction extends Action
                 $snapshotState,
             ): void {
                 $snapshotStateTransitionService->transitionToSnapshotState($snapshot, $snapshotState);
+            })
+            ->after(static function (Component $livewire): void {
+                $livewire->dispatch(ViewSnapshot::REFRESH_LIVEWIRE_COMPONENT);
             })
             ->requiresConfirmation();
     }

--- a/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
+++ b/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
@@ -42,28 +42,9 @@ class SnapshotStatusFlow extends ViewEntry
      */
     public static function buildFlow(Snapshot $snapshot): array
     {
-        // The first time each state was reached, keyed by state name.
-        /** @var array<string, SnapshotTransition> $reachedAt */
-        $reachedAt = [];
-        foreach ($snapshot->snapshotTransitions as $transition) {
-            $stateName = $transition->state::$name;
-            if (!array_key_exists($stateName, $reachedAt)) {
-                $reachedAt[$stateName] = $transition;
-            }
-        }
-
+        $reachedAt = self::reachedTransitions($snapshot);
         $currentState = $snapshot->state::$name;
-
-        // The furthest position the line has progressed to. The current state is
-        // always treated as reached (see below), so when it is on the line it is
-        // the furthest point; otherwise fall back to the last recorded station.
-        $furthestReachedIndex = 0;
-        foreach (self::MAIN_LINE as $index => $stateClass) {
-            $stateName = $stateClass::$name;
-            if ($currentState === $stateName || array_key_exists($stateName, $reachedAt)) {
-                $furthestReachedIndex = $index;
-            }
-        }
+        $furthestReachedIndex = self::furthestReachedIndex($currentState, $reachedAt);
 
         $stations = [];
         foreach (self::MAIN_LINE as $index => $stateClass) {
@@ -88,6 +69,44 @@ class SnapshotStatusFlow extends ViewEntry
         }
 
         return ['stations' => $stations, 'obsolete' => $obsolete];
+    }
+
+    /**
+     * The first time each state was reached, keyed by state name.
+     *
+     * @return array<string, SnapshotTransition>
+     */
+    private static function reachedTransitions(Snapshot $snapshot): array
+    {
+        $reachedAt = [];
+        foreach ($snapshot->snapshotTransitions as $transition) {
+            $stateName = $transition->state::$name;
+            if (!array_key_exists($stateName, $reachedAt)) {
+                $reachedAt[$stateName] = $transition;
+            }
+        }
+
+        return $reachedAt;
+    }
+
+    /**
+     * The furthest position the line has progressed to. The current state is
+     * always treated as reached, so when it is on the line it is the furthest
+     * point; otherwise fall back to the last recorded station.
+     *
+     * @param array<string, SnapshotTransition> $reachedAt
+     */
+    private static function furthestReachedIndex(string $currentState, array $reachedAt): int
+    {
+        $furthestReachedIndex = 0;
+        foreach (self::MAIN_LINE as $index => $stateClass) {
+            $stateName = $stateClass::$name;
+            if ($currentState === $stateName || array_key_exists($stateName, $reachedAt)) {
+                $furthestReachedIndex = $index;
+            }
+        }
+
+        return $furthestReachedIndex;
     }
 
     /**

--- a/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
+++ b/src/cms/app/Filament/Infolists/Components/SnapshotStatusFlow.php
@@ -6,9 +6,6 @@ namespace App\Filament\Infolists\Components;
 
 use App\Models\Snapshot;
 use App\Models\SnapshotTransition;
-use App\Models\States\Snapshot\Approved;
-use App\Models\States\Snapshot\Established;
-use App\Models\States\Snapshot\InReview;
 use App\Models\States\Snapshot\Obsolete;
 use App\Models\States\SnapshotState;
 use Filament\Infolists\Components\ViewEntry;
@@ -26,14 +23,11 @@ use function sprintf;
 class SnapshotStatusFlow extends ViewEntry
 {
     /**
-     * The main line, in order. Obsolete is deliberately not on it: it is a
-     * branch drawn off to the side only when the snapshot actually reached it.
+     * The main line, in order: the shared forward happy path from the state
+     * model. Obsolete is deliberately not on it — it is a branch drawn off to the
+     * side only when the snapshot actually reached it.
      */
-    private const MAIN_LINE = [
-        InReview::class,
-        Approved::class,
-        Established::class,
-    ];
+    private const MAIN_LINE = SnapshotState::FORWARD_LINE;
 
     public static function make(string $name = 'status_flow'): static
     {
@@ -60,6 +54,17 @@ class SnapshotStatusFlow extends ViewEntry
 
         $currentState = $snapshot->state::$name;
 
+        // The furthest position the line has progressed to. The current state is
+        // always treated as reached (see below), so when it is on the line it is
+        // the furthest point; otherwise fall back to the last recorded station.
+        $furthestReachedIndex = 0;
+        foreach (self::MAIN_LINE as $index => $stateClass) {
+            $stateName = $stateClass::$name;
+            if ($currentState === $stateName || array_key_exists($stateName, $reachedAt)) {
+                $furthestReachedIndex = $index;
+            }
+        }
+
         $stations = [];
         foreach (self::MAIN_LINE as $index => $stateClass) {
             $stateName = $stateClass::$name;
@@ -70,13 +75,16 @@ class SnapshotStatusFlow extends ViewEntry
             // current station is always reached too: a state can be set directly
             // (e.g. seeded data) without a recorded transition.
             $reached = $transition !== null || $index === 0 || $isCurrent;
+            // A station the line moved past but never reached was skipped (e.g.
+            // established straight from review), as opposed to one not reached yet.
+            $skipped = !$reached && $index < $furthestReachedIndex;
 
-            $stations[] = self::station($stateClass, $reached, $isCurrent, $transition);
+            $stations[] = self::station($stateClass, $reached, $isCurrent, $skipped, $transition);
         }
 
         $obsolete = null;
         if ($currentState === Obsolete::$name) {
-            $obsolete = self::station(Obsolete::class, true, true, $reachedAt[Obsolete::$name] ?? null);
+            $obsolete = self::station(Obsolete::class, true, true, false, $reachedAt[Obsolete::$name] ?? null);
         }
 
         return ['stations' => $stations, 'obsolete' => $obsolete];
@@ -91,6 +99,7 @@ class SnapshotStatusFlow extends ViewEntry
         string $stateClass,
         bool $reached,
         bool $current,
+        bool $skipped,
         ?SnapshotTransition $transition,
     ): array {
         return [
@@ -98,6 +107,7 @@ class SnapshotStatusFlow extends ViewEntry
             'color' => $stateClass::$color->value,
             'reached' => $reached,
             'current' => $current,
+            'skipped' => $skipped,
             'reached_at' => $transition?->created_at,
             'reached_by' => $transition?->creator?->name,
         ];

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/ViewSnapshot.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/ViewSnapshot.php
@@ -18,6 +18,7 @@ use App\Filament\Resources\SnapshotResource;
 use App\Models\Snapshot;
 use App\Models\States\SnapshotState;
 use Filament\Actions\Action;
+use Filament\Actions\ActionGroup;
 use Filament\Facades\Filament;
 use Filament\Infolists\Components\Tabs;
 use Filament\Infolists\Infolist;
@@ -30,6 +31,7 @@ use Spatie\ModelStates\Exceptions\InvalidConfig;
 use Webmozart\Assert\Assert;
 
 use function __;
+use function sprintf;
 
 class ViewSnapshot extends ViewRecord
 {
@@ -130,7 +132,12 @@ class ViewSnapshot extends ViewRecord
     }
 
     /**
-     * @return array<Action>
+     * A single dropdown grouping every reachable transition. The trigger is
+     * labelled with the snapshot's current state; opening it lists the possible
+     * transitions, including forward states that skip intermediate steps (each
+     * item is only shown when the user has the target state's permission).
+     *
+     * @return array<Action|ActionGroup>
      *
      * @throws InvalidConfig
      */
@@ -138,11 +145,10 @@ class ViewSnapshot extends ViewRecord
     {
         /** @var Snapshot $snapshot */
         $snapshot = $this->record;
-        /** @var array<int, string> $transitionableStates */
-        $transitionableStates = $snapshot->state->transitionableStates();
+        $currentState = $snapshot->state;
 
         $actions = [];
-        foreach ($transitionableStates as $transitionableState) {
+        foreach ($currentState->orderedTransitionableStates() as $transitionableState) {
             /** @var SnapshotState $snapshotState */
             $snapshotState = SnapshotState::make($transitionableState, $snapshot);
             $action = $snapshotState::getAction();
@@ -150,7 +156,16 @@ class ViewSnapshot extends ViewRecord
             $actions[] = $action::makeForSnapshotState($snapshot, $snapshotState);
         }
 
-        return $actions;
+        if ($actions === []) {
+            return [];
+        }
+
+        return [
+            ActionGroup::make($actions)
+                ->label(__(sprintf('snapshot_state.label.%s', $currentState::$name)))
+                ->color($currentState::$color->value)
+                ->button(),
+        ];
     }
 
     public static function getNext(Snapshot $current): ?Snapshot

--- a/src/cms/app/Models/States/SnapshotState.php
+++ b/src/cms/app/Models/States/SnapshotState.php
@@ -19,6 +19,10 @@ use Spatie\ModelStates\Exceptions\InvalidConfig;
 use Spatie\ModelStates\State;
 use Spatie\ModelStates\StateConfig;
 
+use function usort;
+
+use const PHP_INT_MAX;
+
 /**
  * @extends State<Snapshot>
  */
@@ -26,6 +30,17 @@ abstract class SnapshotState extends State
 {
     public const DEFAULT_STATE = InReview::class;
     public const OBSOLETE_STATE = Obsolete::class;
+
+    /**
+     * The forward "happy path", in display order. Used to order the transition
+     * menu and the status-flow diagram consistently. Obsolete is not on it: it is
+     * a branch shown after the line, from any non-obsolete state.
+     */
+    public const FORWARD_LINE = [
+        InReview::class,
+        Approved::class,
+        Established::class,
+    ];
 
     public static StateColor $color = StateColor::GRAY;
     public static string $name = 'none';
@@ -35,6 +50,41 @@ abstract class SnapshotState extends State
      * @return class-string<SnapshotTransitionAction>
      */
     abstract public static function getAction(): string;
+
+    /**
+     * The states this snapshot may transition to, ordered for the transition
+     * menu: forward along FORWARD_LINE, then obsolete. Reachability comes from the
+     * state machine itself (transitionableStates() honours the allowTransition
+     * edges and their guards); this only imposes a stable display order.
+     *
+     * @return array<int, string>
+     */
+    public function orderedTransitionableStates(): array
+    {
+        /** @var array<int, string> $states */
+        $states = $this->transitionableStates();
+
+        usort($states, static function (string $a, string $b): int {
+            return self::lineOrder($a) <=> self::lineOrder($b);
+        });
+
+        return $states;
+    }
+
+    /**
+     * Display rank of a state: its position on FORWARD_LINE, with anything off
+     * the line (obsolete) sorted last.
+     */
+    private static function lineOrder(string $stateName): int
+    {
+        foreach (self::FORWARD_LINE as $index => $stateClass) {
+            if ($stateClass::$name === $stateName) {
+                return $index;
+            }
+        }
+
+        return PHP_INT_MAX;
+    }
 
     /**
      * @throws InvalidConfig
@@ -51,6 +101,10 @@ abstract class SnapshotState extends State
         $config->ignoreSameState();
         $config->allowTransition(InReview::class, Approved::class, ApprovedTransition::class);
         $config->allowTransition(Approved::class, Established::class, EstablishedTransition::class);
+        // Direct skip: an authorised user may establish straight from review,
+        // bypassing approval. It only sets established_at (via EstablishedTransition)
+        // and deliberately does not notify approvers or record an approved step.
+        $config->allowTransition(InReview::class, Established::class, EstablishedTransition::class);
         $config->allowTransition(InReview::class, Obsolete::class, ObsoleteTransition::class);
         $config->allowTransition(Approved::class, Obsolete::class, ObsoleteTransition::class);
         $config->allowTransition(Established::class, Obsolete::class, ObsoleteTransition::class);

--- a/src/cms/app/Observers/SnapshotObserver.php
+++ b/src/cms/app/Observers/SnapshotObserver.php
@@ -8,7 +8,6 @@ use App\Config\Config;
 use App\Events\StaticWebsite\BuildEvent;
 use App\Models\Contracts\Reviewable;
 use App\Models\Snapshot;
-use App\Models\States\Snapshot\Approved;
 use App\Models\States\Snapshot\Established;
 use App\Models\States\Snapshot\Obsolete;
 use App\ValueObjects\CalendarDate;
@@ -28,9 +27,9 @@ class SnapshotObserver
         $currentState = $snapshot->state;
 
         if ($currentState instanceof Established) {
-            if ($originalState instanceof Approved) {
-                $this->dispatchBuildEvent();
-            }
+            // Publish whenever a snapshot becomes established, whether it went
+            // through approval or was established straight from review.
+            $this->dispatchBuildEvent();
 
             $this->setReviewAt($snapshot);
         }

--- a/src/cms/resources/lang/nl/snapshot.php
+++ b/src/cms/resources/lang/nl/snapshot.php
@@ -35,6 +35,7 @@ return [
 
     'back_to' => 'Terug naar :resource',
     'status_flow' => 'Statusverloop',
+    'status_flow_skipped' => 'Overgeslagen',
     'properties' => 'Gegevens',
     'public_data' => 'Publieke gegevens',
     'private_data' => 'Private gegevens',

--- a/src/cms/resources/views/filament/infolists/components/entries/snapshot_status_flow.blade.php
+++ b/src/cms/resources/views/filament/infolists/components/entries/snapshot_status_flow.blade.php
@@ -26,17 +26,21 @@
             @php
                 $reached = $station['reached'];
                 $current = $station['current'];
+                $skipped = $station['skipped'] ?? false;
             @endphp
 
             {{-- Connector from the previous station, aligned to the dot centre
-                 (dot is h-8 = 2rem, so its centre is 1rem from the top). --}}
+                 (dot is h-8 = 2rem, so its centre is 1rem from the top). A dashed
+                 connector leads into a skipped station to signal the jump. --}}
             @if ($index > 0)
                 <li aria-hidden="true" class="flex-1 min-w-6 px-1" style="padding-top: calc(1rem - 2px);">
                     <span
                         @class([
-                            'block h-1 w-full rounded-full',
-                            'bg-gray-300 dark:bg-gray-600' => $reached,
-                            'bg-gray-200 dark:bg-white/10' => ! $reached,
+                            'block h-1 w-full',
+                            'rounded-full bg-gray-300 dark:bg-gray-600' => $reached,
+                            'rounded-full bg-gray-200 dark:bg-white/10' => ! $reached && ! $skipped,
+                            // Skipped: dashed line instead of a solid bar.
+                            'border-t-2 border-dashed border-gray-300 dark:border-gray-600' => $skipped,
                         ])
                     ></span>
                 </li>
@@ -49,8 +53,10 @@
                         'flex h-8 w-8 items-center justify-center rounded-full',
                         // Past (reached, not current): neutral filled.
                         'bg-gray-300 dark:bg-gray-600' => $reached && ! $current,
+                        // Skipped: faint dashed outline, no fill.
+                        'border-2 border-dashed border-gray-300 dark:border-gray-600' => $skipped,
                         // Not reached yet: faint outline.
-                        'bg-gray-200 dark:bg-white/10' => ! $reached,
+                        'bg-gray-200 dark:bg-white/10' => ! $reached && ! $skipped,
                         // Current: coloured + ring.
                         'ring-4 ring-offset-2 ring-offset-white dark:ring-offset-gray-900' => $current,
                     ])
@@ -91,6 +97,10 @@
                             {{ $station['reached_by'] }}
                         </span>
                     @endif
+                @elseif ($skipped)
+                    <span class="mt-0.5 text-xs italic text-gray-400 dark:text-gray-500">
+                        {{ __('snapshot.status_flow_skipped') }}
+                    </span>
                 @endif
             </li>
         @endforeach

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/ViewSnapshotTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/ViewSnapshotTest.php
@@ -688,3 +688,146 @@ it('shows the obsolete branch in the status flow when a snapshot is obsolete', f
         ])
         ->assertSee(__('snapshot_state.label.obsolete'));
 });
+
+it('offers a forward skip transition when the user has the target permission', function (): void {
+    // Target-only gating: the established permission alone unlocks the skip from
+    // review, without the (bypassed) approve permission.
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisationWithPermissions($organisation, [
+        Permission::SNAPSHOT_VIEW,
+        Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
+    ]);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => InReview::class,
+        ]);
+
+    $this->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertActionExists(sprintf('snapshot_transition_to_%s', Established::$name));
+});
+
+it('hides a forward skip transition when the user lacks the target permission', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisationWithPermissions($organisation, [
+        Permission::SNAPSHOT_VIEW,
+        Permission::SNAPSHOT_STATE_TO_APPROVE,
+    ]);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => InReview::class,
+        ]);
+
+    $this->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertActionHidden(sprintf('snapshot_transition_to_%s', Established::$name));
+});
+
+it('establishes straight from review when the skip transition is triggered from the page', function (): void {
+    // Target-only gating: establishing from review needs only the established
+    // permission, not the bypassed approve permission.
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisationWithPermissions($organisation, [
+        Permission::SNAPSHOT_VIEW,
+        Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
+    ]);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => InReview::class,
+        ]);
+
+    $this->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->callAction(sprintf('snapshot_transition_to_%s', Established::$name));
+
+    expect($snapshot->refresh()->state)->toBeInstanceOf(Established::class);
+
+    // The bypassed approval step is not recorded: only established.
+    $recordedStates = SnapshotTransition::where('snapshot_id', $snapshot->id)
+        ->get()
+        ->map(static fn (SnapshotTransition $transition): string => $transition->state::$name)
+        ->all();
+    expect($recordedStates)
+        ->toContain(Established::$name)
+        ->not->toContain(Approved::$name);
+});
+
+it('replaces the transition button with the next one after transitioning', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => InReview::class,
+        ]);
+    SnapshotApproval::factory()->create([
+        'snapshot_id' => $snapshot->id,
+        'status' => SnapshotApprovalStatus::APPROVED,
+    ]);
+
+    // The transition action dispatches the refresh event that re-renders the
+    // page, so the header rebuilds itself against the new state instead of
+    // keeping the stale "Goedkeuren" button.
+    $component = $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertActionExists(sprintf('snapshot_transition_to_%s', Approved::$name))
+        ->callAction(sprintf('snapshot_transition_to_%s', Approved::$name))
+        ->assertDispatched(ViewSnapshot::REFRESH_LIVEWIRE_COMPONENT);
+
+    // After the re-render the approve transition is gone (no longer valid from
+    // the approved state), while the onward transitions remain.
+    $component->dispatch(ViewSnapshot::REFRESH_LIVEWIRE_COMPONENT)
+        ->assertActionDoesNotExist(sprintf('snapshot_transition_to_%s', Approved::$name))
+        ->assertActionExists(sprintf('snapshot_transition_to_%s', Established::$name));
+});
+
+it('marks a bypassed station as skipped in the status flow', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = User::factory()->create(['name' => 'Statuswijziger']);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => Established::class,
+        ]);
+
+    // History of a direct establish-from-review: only In review and Vastgesteld
+    // were recorded, Goedgekeurd was skipped.
+    foreach ([InReview::class, Established::class] as $state) {
+        SnapshotTransition::factory()
+            ->recycle($snapshot)
+            ->recycle($user)
+            ->create(['state' => $state]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertSee(__('snapshot_state.label.approved'))
+        ->assertSee(__('snapshot.status_flow_skipped'));
+});
+
+it('does not mark a not-yet-reached station as skipped', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create([
+            'state' => InReview::class,
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewSnapshot::class, [
+            'record' => $snapshot->getRouteKey(),
+        ])
+        ->assertDontSee(__('snapshot.status_flow_skipped'));
+});

--- a/src/cms/tests/Feature/Models/States/SnapshotStateTest.php
+++ b/src/cms/tests/Feature/Models/States/SnapshotStateTest.php
@@ -50,6 +50,8 @@ it('allows the transitions', function (string $state, string $newState): void {
 })->with([
     [InReview::class, Approved::class],
     [Approved::class, Established::class],
+    // Direct skip: establish straight from review, bypassing approval.
+    [InReview::class, Established::class],
     [InReview::class, Obsolete::class],
     [Approved::class, Obsolete::class],
     [Established::class, Obsolete::class],
@@ -69,7 +71,6 @@ it('does not allow the transitions', function (string $state, string $newState):
     expect($snapshot->state)
         ->toBeInstanceOf($newState);
 })->throws(TransitionNotFound::class)->with([
-    [InReview::class, Established::class],
     [Approved::class, InReview::class],
     [Established::class, InReview::class],
     [Obsolete::class, InReview::class],

--- a/src/cms/tests/Feature/Observers/SnapshotObserverTest.php
+++ b/src/cms/tests/Feature/Observers/SnapshotObserverTest.php
@@ -44,6 +44,7 @@ it(
 )->with([
     'old in_review, new approved' => [InReview::class, Approved::class, false],
     'old approved, new established' => [Approved::class, Established::class, true],
+    'old in_review, new established' => [InReview::class, Established::class, true],
     'old in_review, new obsolete' => [InReview::class, Obsolete::class, false],
     'old approved, new obsolete' => [Approved::class, Obsolete::class, false],
     'old established, new obsolete' => [Established::class, Obsolete::class, true],

--- a/src/cms/tests/Feature/Services/Snapshot/SnapshotStateTransitionServiceTest.php
+++ b/src/cms/tests/Feature/Services/Snapshot/SnapshotStateTransitionServiceTest.php
@@ -6,15 +6,19 @@ use App\Enums\Authorization\Role;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Organisation;
 use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\SnapshotTransition;
 use App\Models\States\Snapshot\Approved;
 use App\Models\States\Snapshot\Established;
 use App\Models\States\Snapshot\InReview;
 use App\Models\States\Snapshot\Obsolete;
 use App\Models\States\SnapshotState;
 use App\Models\User;
+use App\Notifications\SnapshotApprovalSignRequest;
 use App\Services\Snapshot\SnapshotStateTransitionService;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Notification;
 
 it('makes previous snapshots (only of the same state) obsolete', function (): void {
     Event::fake();
@@ -188,4 +192,123 @@ it('can transition even if snapshotSource is deleted', function (): void {
     $snapshotStateTransitionService->transitionToSnapshotState($snapshot, $snapshotState);
     expect($snapshot->refresh()->replaced_at)
         ->not()->toBeNull();
+});
+
+it('establishes straight from review without recording an approved step', function (): void {
+    Event::fake();
+
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()
+        ->hasOrganisationRole(Role::PRIVACY_OFFICER, $organisation)
+        ->create();
+    $this->be($user);
+    CarbonImmutable::setTestNow('2026-07-23 12:00:00');
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->create([
+            'state' => InReview::class,
+            'established_at' => null,
+        ]);
+
+    /** @var SnapshotState $established */
+    $established = SnapshotState::make(Established::class, $snapshot);
+
+    $snapshotStateTransitionService = $this->app->get(SnapshotStateTransitionService::class);
+    $snapshotStateTransitionService->transitionToSnapshotState($snapshot, $established);
+
+    // Reached established and stamped established_at...
+    expect($snapshot->refresh()->state)->toBeInstanceOf(Established::class)
+        ->and($snapshot->established_at?->toDateTimeString())->toBe('2026-07-23 12:00:00');
+
+    // ...but the bypassed approval step leaves no history row: only established.
+    $recordedStates = SnapshotTransition::where('snapshot_id', $snapshot->id)
+        ->get()
+        ->map(static fn (SnapshotTransition $transition): string => $transition->state::$name)
+        ->all();
+    expect($recordedStates)
+        ->toContain(Established::$name)
+        ->not->toContain(Approved::$name);
+
+    CarbonImmutable::setTestNow();
+});
+
+it('does not notify approvers when establishing straight from review', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()
+        ->hasOrganisationRole(Role::PRIVACY_OFFICER, $organisation)
+        ->create();
+    $this->be($user);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->create([
+            'state' => InReview::class,
+        ]);
+    $approver = User::factory()
+        ->hasAttached($organisation)
+        ->create();
+    SnapshotApproval::factory()
+        ->for($snapshot)
+        ->for($approver, 'assignedTo')
+        ->create();
+
+    /** @var SnapshotState $established */
+    $established = SnapshotState::make(Established::class, $snapshot);
+
+    // Fake only from here so the approval-created observer notification (part of
+    // fixture setup) is not counted: we assert purely about the transition.
+    Notification::fake();
+
+    $snapshotStateTransitionService = $this->app->get(SnapshotStateTransitionService::class);
+    $snapshotStateTransitionService->transitionToSnapshotState($snapshot, $established);
+
+    // Skipping approval must not send the sign request that the approved step
+    // would otherwise trigger.
+    Notification::assertNotSentTo($approver, SnapshotApprovalSignRequest::class);
+});
+
+it('does notify approvers on a normal transition to approved', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()
+        ->hasOrganisationRole(Role::PRIVACY_OFFICER, $organisation)
+        ->create();
+    $this->be($user);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->create([
+            'state' => InReview::class,
+        ]);
+    $approver = User::factory()
+        ->hasAttached($organisation)
+        ->create();
+    SnapshotApproval::factory()
+        ->for($snapshot)
+        ->for($approver, 'assignedTo')
+        ->create();
+
+    /** @var SnapshotState $approved */
+    $approved = SnapshotState::make(Approved::class, $snapshot);
+
+    // Fake only from here so the approval-created observer notification is not
+    // counted: we assert purely about the transition's own notification.
+    Notification::fake();
+
+    $snapshotStateTransitionService = $this->app->get(SnapshotStateTransitionService::class);
+    $snapshotStateTransitionService->transitionToSnapshotState($snapshot, $approved);
+
+    Notification::assertSentTo($approver, SnapshotApprovalSignRequest::class);
 });


### PR DESCRIPTION
## Wat

De statuswijziging-knoppen op een versie zijn vervangen door één transitie-gerichte dropdown, en een bevoegde gebruiker kan nu tussenstappen overslaan.

### Wijzigingen
- **Transitie-dropdown**: de losse knoppen zijn nu één `ActionGroup` (split/dropdown) in de header. De trigger toont de huidige status; het menu toont de mogelijke transities.
- **Bug: knop ververst zichzelf**: na een transitie werd de knop niet vervangen door de volgende. De transitie-actie dispatcht nu `REFRESH_LIVEWIRE_COMPONENT` (zoals de goedkeur-acties al deden), zodat de header opnieuw opbouwt.
- **Direct vaststellen vanuit review** (skip): nieuwe directe `in_review → established` edge. Zet alleen `established_at`, **schrijft geen approved-stap** en **stuurt geen goedkeuringsnotificatie** — goedkeuring wordt bewust overgeslagen.
- **Rechten (target-only)**: een transitie vereist alleen het recht van de doelstatus, consistent met het bestaande systeem (`transitionableStates()` is de bron van waarheid).
- **Statusverloop**: een overgeslagen station wordt nu eerlijk getoond als *Overgeslagen* (gestippeld, zonder datum/gebruiker), niet alsof het is doorlopen.

## Tests
- Skip naar established: alleen established-historieregel, `established_at` gezet, géén goedkeuringsnotificatie; normale approved-transitie notificeert wel.
- Rechten: skip zichtbaar met alleen `to_established`, verborgen zonder.
- Statusverloop markeert een omzeild station als overgeslagen; een nog-niet-bereikt station niet.
- Volledige betrokken suite groen (153 tests).

🤖 Generated with [Claude Code](https://claude.ai/code)