### PR TITLE
feat: show deployment version in footer + meta tag

### DIFF
--- a/scripts/create-release.sh
+++ b/scripts/create-release.sh
@@ -41,6 +41,19 @@ Installation Instructions:
 EOF
 cp ../../.db_requirements ./
 
+# Stamp the deployment version into the app (overwrites the committed dev defaults).
+GIT_COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+cat >"config/version.php" <<EOF
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => '$RELEASE_NAME',
+    'sha' => '$GIT_COMMIT_SHORT',
+];
+EOF
+
 # Prepare static-website
 cp -R ../static-website/ ./
 echo "{ \"version\": \"$RELEASE_NAME\", \"git_ref\": \"$GIT_COMMIT\"}" >./static-website/static/version.json

--- a/src/cms/app/Providers/FilamentServiceProvider.php
+++ b/src/cms/app/Providers/FilamentServiceProvider.php
@@ -71,6 +71,20 @@ class FilamentServiceProvider extends PanelProvider
                 return view('filament.topbar.organisation_name');
             },
         );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::FOOTER,
+            static function (): View {
+                return view('filament.footer');
+            },
+        );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::HEAD_END,
+            static function (): View {
+                return view('filament.version_meta');
+            },
+        );
     }
 
     /**

--- a/src/cms/config/version.php
+++ b/src/cms/config/version.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+// Deployment version, overwritten with build numbers by scripts/create-release.sh
+// when the release archive is built. Keep these as literal values (no env()) so
+// they survive `php artisan config:cache`.
+return [
+    'label' => 'dev',
+    'sha' => null,
+];

--- a/src/cms/resources/views/filament/footer.blade.php
+++ b/src/cms/resources/views/filament/footer.blade.php
@@ -1,0 +1,9 @@
+<div class="fi-footer flex justify-center px-6 py-4 text-xs text-gray-500 dark:text-gray-400">
+    <span>
+        <a href="https://openvwr.nl" target="_blank" rel="noopener noreferrer" class="hover:underline">OpenVWR</a>
+        by
+        <a href="https://sourcehaven.nl" target="_blank" rel="noopener noreferrer" class="hover:underline">Sourcehaven B.V.</a>
+        <span class="mx-1">&middot;</span>
+        {{ config('version.label') }}
+    </span>
+</div>

--- a/src/cms/resources/views/filament/version_meta.blade.php
+++ b/src/cms/resources/views/filament/version_meta.blade.php
@@ -1,0 +1,6 @@
+@php
+    $label = config('version.label');
+    $sha = config('version.sha');
+    $version = $sha ? sprintf('%s (%s)', $label, $sha) : $label;
+@endphp
+<meta name="app-version" content="{{ $version }}">


### PR DESCRIPTION
Adds a discreet, branded footer that also surfaces the deployed build, so we can see at a glance which version is live.

## What renders
- **Footer** (all pages, incl. login): `OpenVWR by Sourcehaven B.V. · <version>` — the names link to openvwr.nl / sourcehaven.nl. Muted, centered.
- **Meta tag** (authenticated pages only): `<meta name="app-version" content="<version> (<sha>)">` — machine-readable, for monitoring / deploy verification.

## Scoping (verified against Filament's layouts)
- `FOOTER` hook renders on both the login (simple) and authed layouts → branding everywhere, short label only, **no SHA**.
- `HEAD_END` hook renders **only** on the authed layout → the **git SHA stays behind auth**, never on the login page.

## Version source
- New committed `config/version.php` holds literal values (`label`, `sha`) with a `dev` default — config-cache safe, no `env()`.
- `scripts/create-release.sh` overwrites it with the real release name + short SHA when building the archive.
- Locally shows `dev`; a release build shows e.g. `openvwr-cms-v2.4.1 (9d09506)`.

## Checks
- phpcs `-n` and phpstan both pass on the changed files.