### PR TITLE
feat: link document name to its screen, add download icon for attachments

### DIFF
--- a/src/cms/app/Filament/Forms/Components/RelationTable.php
+++ b/src/cms/app/Filament/Forms/Components/RelationTable.php
@@ -46,12 +46,12 @@ class RelationTable extends Select
     /** @var class-string<Model> */
     protected string $relatedModel;
 
-    /** @var array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}> */
+    /** @var array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null), download?: Closure(Model): (string|null)}> */
     protected array $tableColumns = [];
 
     /**
      * @param class-string<Model> $model
-     * @param array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}> $columns
+     * @param array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null), download?: Closure(Model): (string|null)}> $columns
      * @param array<Component> $createForm the schema for the inline "create new" modal
      */
     public static function makeForRelationship(
@@ -199,7 +199,7 @@ class RelationTable extends Select
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null), download?: Closure(Model): (string|null)}>
      */
     public function getTableColumns(): array
     {

--- a/src/cms/app/Filament/Forms/Components/RelationTableColumns.php
+++ b/src/cms/app/Filament/Forms/Components/RelationTableColumns.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Forms\Components;
 
 use App\Enums\Media\MediaGroup;
+use App\Filament\Resources\DocumentResource;
 use App\Models\Algorithm\AlgorithmRecord;
 use App\Models\Avg\AvgProcessorProcessingRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
@@ -36,7 +37,7 @@ class RelationTableColumns
     /**
      * @param class-string<Model> $model
      *
-     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null), download?: Closure(Model): (string|null)}>
      */
     public static function for(string $model): array
     {
@@ -57,7 +58,7 @@ class RelationTableColumns
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null), download?: Closure(Model): (string|null)}>
      */
     private static function documents(): array
     {
@@ -65,8 +66,9 @@ class RelationTableColumns
             [
                 'label' => __('document.name'),
                 'get' => static fn (Model $record): string => self::as($record, Document::class)->name,
-                // When the document has an uploaded file, its name links to the download.
-                'href' => static fn (Model $record): ?string => self::as($record, Document::class)
+                'href' => static fn (Model $record): string => DocumentResource::getUrl('view', ['record' => $record]),
+                // When the document has an uploaded file, a download icon follows the name.
+                'download' => static fn (Model $record): ?string => self::as($record, Document::class)
                     ->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->getFullUrl(),
             ],
             [

--- a/src/cms/resources/lang/nl/general.php
+++ b/src/cms/resources/lang/nl/general.php
@@ -28,6 +28,7 @@ return [
     'delete' => 'Verwijderen',
     'deleted' => 'Verwijderd',
     'disabled' => 'Uitgeschakeld',
+    'download' => 'Downloaden',
     'enabled' => 'Ingeschakeld',
     'error' => 'Fout',
     'export' => 'Exporteren',

--- a/src/cms/resources/views/filament/forms/components/relation-table.blade.php
+++ b/src/cms/resources/views/filament/forms/components/relation-table.blade.php
@@ -38,20 +38,27 @@
                                     @php
                                         $value = $column['get']($record);
                                         $href = isset($column['href']) ? $column['href']($record) : null;
+                                        $download = isset($column['download']) ? $column['download']($record) : null;
                                     @endphp
                                     <td class="px-3 py-2 text-sm text-gray-950 dark:text-white">
                                         @if (filled($value) && filled($href))
                                             <a
                                                 href="{{ $href }}"
-                                                target="_blank"
-                                                rel="noopener"
-                                                class="fi-link inline-flex items-center gap-1 text-primary-600 hover:underline dark:text-primary-400"
-                                            >
-                                                {{ $value }}
-                                                <x-heroicon-m-arrow-down-tray class="h-4 w-4" />
-                                            </a>
+                                                class="fi-link text-primary-600 hover:underline dark:text-primary-400"
+                                            >{{ $value }}</a>
                                         @else
                                             {{ $value }}
+                                        @endif
+                                        @if (filled($download))
+                                            <a
+                                                href="{{ $download }}"
+                                                download
+                                                title="{{ __('general.download') }}"
+                                                class="ms-1 inline-flex rounded-md p-1 align-middle text-gray-400 transition hover:bg-gray-50 hover:text-primary-600 dark:hover:bg-white/5 dark:hover:text-primary-400"
+                                            >
+                                                <x-heroicon-m-arrow-down-tray class="h-4 w-4" />
+                                                <span class="sr-only">{{ __('general.download') }}</span>
+                                            </a>
                                         @endif
                                     </td>
                                 @endforeach

--- a/src/cms/tests/Feature/Filament/Forms/Components/RelationTableTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/RelationTableTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\Media\MediaGroup;
 use App\Filament\Forms\Components\RelationTable;
 use App\Filament\Resources\AlgorithmRecordResource\Pages\EditAlgorithmRecord;
+use App\Filament\Resources\DocumentResource;
 use App\Models\Algorithm\AlgorithmRecord;
 use App\Models\Document;
 use Illuminate\Support\Facades\Storage;
@@ -31,7 +32,7 @@ it('shows the linked documents as table rows', function (): void {
         });
 });
 
-it('links a document name to its file when the document has an attachment', function (): void {
+it('links a document name to its screen and adds a download icon when it has an attachment', function (): void {
     Storage::fake('filament');
     Storage::fake('media-library');
 
@@ -55,8 +56,11 @@ it('links a document name to its file when the document has an attachment', func
         ->createLivewireTestable(EditAlgorithmRecord::class, [
             'record' => $algorithmRecord->getRouteKey(),
         ])
-        ->assertSeeHtml('href="' . $downloadUrl . '"')
-        ->assertDontSeeHtml('>' . $withoutFile->name . '</a>');
+        // Both names link to the document's own screen.
+        ->assertSeeHtml('href="' . DocumentResource::getUrl('view', ['record' => $withFile, 'tenant' => $organisation]) . '"')
+        ->assertSeeHtml('href="' . DocumentResource::getUrl('view', ['record' => $withoutFile, 'tenant' => $organisation]) . '"')
+        // Only the document with an attachment gets the direct-download icon.
+        ->assertSeeHtml('href="' . $downloadUrl . '"');
 });
 
 it('links a document when it is selected and saved', function (): void {


### PR DESCRIPTION
In the linked-documents table, the name now always links to the document view screen. When the document has an attached file, a small download icon follows the name and triggers a direct download.