### PR TITLE
feat: checksum-based media re-copy on cross-org overwrite

### DIFF
--- a/src/cms/app/Transfer/Export/EntitySerializer.php
+++ b/src/cms/app/Transfer/Export/EntitySerializer.php
@@ -162,7 +162,7 @@ class EntitySerializer
     }
 
     /**
-     * @return list<array<string, string>>
+     * @return list<array<string, ?string>>
      */
     private function serializeMedia(Document $document): array
     {
@@ -175,6 +175,9 @@ class EntitySerializer
                 'file_name' => $mediaItem->file_name,
                 'name' => $mediaItem->name,
                 'mime_type' => $mediaItem->mime_type,
+                // sha256 of the file bytes. Carried so a re-copy can tell whether the
+                // destination file already matches the source without moving any bytes.
+                'content_hash' => $mediaItem->content_hash,
                 'zip_path' => sprintf('media/%s/%s', $mediaItem->uuid, $mediaItem->file_name),
             ];
         }

--- a/src/cms/app/Transfer/Import/BundleImporter.php
+++ b/src/cms/app/Transfer/Import/BundleImporter.php
@@ -70,6 +70,7 @@ class BundleImporter
         private readonly ImportMatcher $importMatcher,
         private readonly RelationRestorer $relationRestorer,
         private readonly AttributeRemapper $attributeRemapper,
+        private readonly DocumentMediaImporter $documentMediaImporter,
     ) {
     }
 
@@ -259,8 +260,8 @@ class BundleImporter
         $this->written[$id] = true;
         $result->overwritten++;
 
-        if ($existing instanceof Document && $existing->media->isEmpty()) {
-            $this->importMedia($existing, $entity, $mediaResolver);
+        if ($existing instanceof Document) {
+            $this->documentMediaImporter->sync($existing, $entity, $mediaResolver);
         }
     }
 
@@ -295,7 +296,7 @@ class BundleImporter
         $result->created++;
 
         if ($model instanceof Document) {
-            $this->importMedia($model, $entity, $mediaResolver);
+            $this->documentMediaImporter->import($model, $entity, $mediaResolver);
         }
     }
 
@@ -381,43 +382,5 @@ class BundleImporter
         }
 
         $relation->updateOrCreate([], $type === TransferEntityType::ADDRESS ? $attributes : ['body' => $body]);
-    }
-
-    /**
-     * @param array<string, mixed> $entity
-     */
-    private function importMedia(Document $document, array $entity, MediaResolver $mediaResolver): void
-    {
-        $mediaItems = $entity['media'] ?? [];
-
-        if (!is_array($mediaItems)) {
-            return;
-        }
-
-        foreach ($mediaItems as $mediaItem) {
-            if (!is_array($mediaItem)) {
-                continue;
-            }
-
-            $fileName = $mediaItem['file_name'] ?? null;
-            $collectionName = $mediaItem['collection_name'] ?? null;
-
-            if (!is_string($fileName) || !is_string($collectionName)) {
-                continue;
-            }
-
-            $contents = $mediaResolver->resolve($mediaItem);
-
-            if ($contents === null) {
-                continue;
-            }
-
-            $name = $mediaItem['name'] ?? null;
-
-            $document->addMediaFromString($contents)
-                ->usingFileName($fileName)
-                ->usingName(is_string($name) ? $name : $fileName)
-                ->toMediaCollection($collectionName);
-        }
     }
 }

--- a/src/cms/app/Transfer/Import/DocumentMediaImporter.php
+++ b/src/cms/app/Transfer/Import/DocumentMediaImporter.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Transfer\Import;
+
+use App\Enums\Media\MediaGroup;
+use App\Models\Document;
+
+use function in_array;
+use function is_array;
+use function is_string;
+
+/**
+ * Writes a document's attachments during an import/copy. Splits two cases: a freshly
+ * created document takes all the source's media, while an overwritten one only re-imports
+ * when the bytes actually changed (compared by content_hash) — leaving matching files in
+ * place so a re-copy of unchanged content moves no bytes.
+ */
+readonly class DocumentMediaImporter
+{
+    public function __construct(
+        private MediaHashes $mediaHashes,
+    ) {
+    }
+
+    /**
+     * Attach all of the source's media to a newly created document.
+     *
+     * @param array<string, mixed> $entity
+     */
+    public function import(Document $document, array $entity, MediaResolver $mediaResolver): void
+    {
+        $this->addMedia($document, $entity, $mediaResolver);
+    }
+
+    /**
+     * Bring an overwritten document's attachments in line with the source. When the
+     * destination already holds exactly the source's files the bytes are left untouched;
+     * otherwise the affected collections are cleared and re-imported so a changed source
+     * file is not left stale.
+     *
+     * @param array<string, mixed> $entity
+     */
+    public function sync(Document $document, array $entity, MediaResolver $mediaResolver): void
+    {
+        if ($this->mediaHashes->match($document, $entity)) {
+            return;
+        }
+
+        foreach ($this->incomingCollections($entity) as $collection) {
+            $document->clearMediaCollection($collection);
+        }
+
+        $this->addMedia($document, $entity, $mediaResolver);
+    }
+
+    /**
+     * @param array<string, mixed> $entity
+     */
+    private function addMedia(Document $document, array $entity, MediaResolver $mediaResolver): void
+    {
+        $mediaItems = $entity['media'] ?? [];
+
+        if (!is_array($mediaItems)) {
+            return;
+        }
+
+        foreach ($mediaItems as $mediaItem) {
+            $this->addMediaItem($document, $mediaItem, $mediaResolver);
+        }
+    }
+
+    private function addMediaItem(Document $document, mixed $mediaItem, MediaResolver $mediaResolver): void
+    {
+        if (!is_array($mediaItem)) {
+            return;
+        }
+
+        $fileName = $mediaItem['file_name'] ?? null;
+        $collectionName = $mediaItem['collection_name'] ?? null;
+
+        if (!is_string($fileName) || !is_string($collectionName)) {
+            return;
+        }
+
+        $contents = $mediaResolver->resolve($mediaItem);
+
+        if ($contents === null) {
+            return;
+        }
+
+        $name = $mediaItem['name'] ?? null;
+
+        $document->addMediaFromString($contents)
+            ->usingFileName($fileName)
+            ->usingName(is_string($name) ? $name : $fileName)
+            ->toMediaCollection($collectionName);
+    }
+
+    /**
+     * Collections touched by the incoming media block. Only these are cleared before
+     * re-import, so attachments the source did not carry are left in place. Falls back to
+     * attachments so an empty source media block still clears a stale destination file.
+     *
+     * @param array<string, mixed> $entity
+     *
+     * @return list<string>
+     */
+    private function incomingCollections(array $entity): array
+    {
+        $mediaItems = $entity['media'] ?? [];
+
+        if (!is_array($mediaItems)) {
+            return [MediaGroup::ATTACHMENTS->value];
+        }
+
+        $collections = [];
+
+        foreach ($mediaItems as $mediaItem) {
+            $collection = is_array($mediaItem) ? ($mediaItem['collection_name'] ?? null) : null;
+
+            if (is_string($collection) && !in_array($collection, $collections, true)) {
+                $collections[] = $collection;
+            }
+        }
+
+        return $collections === [] ? [MediaGroup::ATTACHMENTS->value] : $collections;
+    }
+}

--- a/src/cms/app/Transfer/Import/MediaHashes.php
+++ b/src/cms/app/Transfer/Import/MediaHashes.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Transfer\Import;
+
+use App\Models\Document;
+
+use function is_array;
+use function is_string;
+use function sort;
+
+/**
+ * Compares a document's attachments by content_hash. Both the transfer bundle (a
+ * serialized media block) and a live destination document expose their files' sha256
+ * hashes; matching those tells a re-copy whether the bytes already agree without moving
+ * any. A null/missing hash on either side is treated as "unknown, may differ" so callers
+ * fall back to re-importing rather than wrongly assuming the files are identical.
+ */
+final readonly class MediaHashes
+{
+    /**
+     * True when the destination document already carries exactly the source's attachments.
+     *
+     * @param array<string, mixed> $entity a serialized bundle entity (see EntitySerializer)
+     */
+    public function match(Document $document, array $entity): bool
+    {
+        $source = $this->fromMediaBlock($entity['media'] ?? []);
+        $destination = $this->fromDocument($document);
+
+        if ($source === null || $destination === null) {
+            return false;
+        }
+
+        sort($source);
+        sort($destination);
+
+        return $source === $destination;
+    }
+
+    /**
+     * Content hashes from a serialized media block, or null when any entry lacks a usable
+     * hash.
+     *
+     * @return ?list<string>
+     */
+    public function fromMediaBlock(mixed $mediaItems): ?array
+    {
+        if (!is_array($mediaItems)) {
+            return null;
+        }
+
+        $hashes = [];
+
+        foreach ($mediaItems as $mediaItem) {
+            $hash = is_array($mediaItem) ? ($mediaItem['content_hash'] ?? null) : null;
+
+            if (!is_string($hash) || $hash === '') {
+                return null;
+            }
+
+            $hashes[] = $hash;
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * Content hashes of a live document's attachments, or null when any lacks a usable hash.
+     *
+     * @return ?list<string>
+     */
+    public function fromDocument(Document $document): ?array
+    {
+        $hashes = [];
+
+        foreach ($document->media as $mediaItem) {
+            $hash = $mediaItem->content_hash;
+
+            if (!is_string($hash) || $hash === '') {
+                return null;
+            }
+
+            $hashes[] = $hash;
+        }
+
+        return $hashes;
+    }
+}

--- a/src/cms/app/Transfer/Import/PreviewBuilder.php
+++ b/src/cms/app/Transfer/Import/PreviewBuilder.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Transfer\Import;
 
+use App\Models\Document;
 use App\Models\Organisation;
 use App\Transfer\ConflictStrategy;
 use App\Transfer\TransferEntityType;
+use Illuminate\Database\Eloquent\Model;
 use Webmozart\Assert\Assert;
 
 use function is_string;
@@ -23,6 +25,7 @@ readonly class PreviewBuilder
     public function __construct(
         private ImportMatcher $importMatcher,
         private EditDetector $editDetector,
+        private MediaHashes $mediaHashes,
     ) {
     }
 
@@ -61,7 +64,11 @@ readonly class PreviewBuilder
         $name = $entity['name'] ?? null;
 
         $hasMatch = $match !== null;
-        $edited = $match !== null && $this->editDetector->isEditedSinceSync($match);
+        // A copy counts as changed when it was edited locally since sync, or when its
+        // attachment no longer matches the source file (a document whose only difference is
+        // its binary content). Either way the user should be asked rather than told "identiek".
+        $edited = $match !== null
+            && ($this->editDetector->isEditedSinceSync($match) || $this->mediaDiffersFromSource($match, $entity));
         // An existing copy that has not been edited since it was last synced is identical to
         // the source: copying it again would be a no-op, so it is skipped and not offered as a
         // choice. Only edited copies need a decision from the user.
@@ -79,6 +86,23 @@ readonly class PreviewBuilder
             'needs_decision' => $edited,
             'strategy' => $this->defaultStrategy($hasMatch),
         ];
+    }
+
+    /**
+     * True when the destination document's attachments no longer match the source's, by
+     * content_hash. EditDetector only sees local edits; source-file drift is a separate
+     * signal, checked here where both the source (the bundle entity) and the destination
+     * document are in hand.
+     *
+     * @param array<string, mixed> $entity
+     */
+    private function mediaDiffersFromSource(Model $match, array $entity): bool
+    {
+        if (!$match instanceof Document) {
+            return false;
+        }
+
+        return !$this->mediaHashes->match($match, $entity);
     }
 
     private function defaultStrategy(bool $hasMatch): ?string

--- a/src/cms/tests/Feature/Transfer/DocumentMediaImporterTest.php
+++ b/src/cms/tests/Feature/Transfer/DocumentMediaImporterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Media\MediaGroup;
+use App\Models\Document;
+use App\Models\Organisation;
+use App\Transfer\Import\DocumentMediaImporter;
+use App\Transfer\Import\MediaResolver;
+use Illuminate\Support\Facades\Storage;
+
+function nullMediaResolver(): MediaResolver
+{
+    return new class implements MediaResolver {
+        /**
+         * @param array<mixed> $mediaItem
+         */
+        public function resolve(array $mediaItem): ?string
+        {
+            return null;
+        }
+    };
+}
+
+it('clears the attachments collection on sync when the source media block is malformed', function (): void {
+    Storage::fake('media-library');
+
+    $document = Document::factory()->for(Organisation::factory())->create();
+    $document->addMediaFromString('stale')
+        ->usingFileName('old.txt')
+        ->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+
+    // A non-array media block matches nothing (so sync proceeds) and yields no collection
+    // names, so the fallback clears attachments — the stale file must not survive.
+    app(DocumentMediaImporter::class)->sync($document, ['media' => 'nope'], nullMediaResolver());
+
+    expect($document->refresh()->load('media')->media)->toHaveCount(0);
+});

--- a/src/cms/tests/Feature/Transfer/DocumentTransferTest.php
+++ b/src/cms/tests/Feature/Transfer/DocumentTransferTest.php
@@ -7,8 +7,10 @@ use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Document;
 use App\Models\Organisation;
 use App\Models\User;
+use App\Transfer\Export\BundleBuilder;
 use App\Transfer\Export\BundleExporter;
 use App\Transfer\Import\BundleImporter;
+use App\Transfer\Import\PreviewBuilder;
 use App\Transfer\TransferEntityType;
 use Illuminate\Support\Facades\Storage;
 
@@ -102,4 +104,145 @@ it('imports media onto an overwritten document that has none yet', function (): 
 
     $existing->refresh()->load('media');
     expect($existing->media->first()?->file_name)->toBe('beleid.txt');
+});
+
+it('refreshes a stale attachment on overwrite when the source file changed', function (): void {
+    Storage::fake('filament');
+    Storage::fake('media-library');
+
+    $sourceOrganisation = Organisation::factory()->create();
+    $destinationOrganisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $importer = app(BundleImporter::class);
+
+    // First copy: destination gets the original file bytes.
+    [$firstPath, $firstPlan, $document] = createExportedDocumentBundle($sourceOrganisation);
+    $importer->importZip(Storage::disk('filament')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
+
+    $copy = Document::query()->whereBelongsTo($destinationOrganisation)->where('name', 'Beleid')->firstOrFail();
+    expect($copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->getPathRelativeToRoot())
+        ->and(Storage::disk('media-library')->get($copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)->getPathRelativeToRoot()))
+        ->toBe('text bytes');
+
+    // Source file changes; re-export and overwrite the existing copy.
+    $document->clearMediaCollection(MediaGroup::ATTACHMENTS->value);
+    $document->addMediaFromString('updated bytes')
+        ->usingFileName('beleid.txt')
+        ->usingName('Beleidsdocument')
+        ->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+
+    $secondPath = app(BundleExporter::class)->export(
+        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
+        [AvgResponsibleProcessingRecord::query()->whereBelongsTo($sourceOrganisation)->firstOrFail()->id->toString()],
+        ['documents' => [$document->id->toString()]],
+        $sourceOrganisation,
+    );
+
+    $overwritePlan = [
+        AvgResponsibleProcessingRecord::query()->whereBelongsTo($sourceOrganisation)->firstOrFail()->id->toString()
+            => ['selected' => true, 'strategy' => 'overwrite'],
+        $document->id->toString() => ['selected' => true, 'strategy' => 'overwrite'],
+    ];
+
+    $result = $importer->importZip(Storage::disk('filament')->path($secondPath), $overwritePlan, $destinationOrganisation, $user);
+
+    expect($result->overwritten)->toBe(2);
+
+    $copy->refresh()->load('media');
+    $media = $copy->getFirstMedia(MediaGroup::ATTACHMENTS->value);
+    expect($media)->not->toBeNull()
+        ->and($copy->media)->toHaveCount(1)
+        ->and(Storage::disk('media-library')->get($media->getPathRelativeToRoot()))->toBe('updated bytes');
+});
+
+it('leaves an unchanged attachment in place on overwrite', function (): void {
+    Storage::fake('filament');
+    Storage::fake('media-library');
+
+    $sourceOrganisation = Organisation::factory()->create();
+    $destinationOrganisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $importer = app(BundleImporter::class);
+
+    [$firstPath, $firstPlan] = createExportedDocumentBundle($sourceOrganisation);
+    $importer->importZip(Storage::disk('filament')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
+
+    $copy = Document::query()->whereBelongsTo($destinationOrganisation)->where('name', 'Beleid')->firstOrFail();
+    $originalUuid = $copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->uuid;
+
+    // Overwrite again from the identical source: the file bytes match by content_hash,
+    // so the existing media row is kept rather than cleared and re-added.
+    $overwritePlan = $firstPlan;
+    foreach (array_keys($overwritePlan) as $id) {
+        $overwritePlan[$id]['strategy'] = 'overwrite';
+    }
+
+    $importer->importZip(Storage::disk('filament')->path($firstPath), $overwritePlan, $destinationOrganisation, $user);
+
+    $copy->refresh()->load('media');
+    expect($copy->media)->toHaveCount(1)
+        ->and($copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->uuid)->toBe($originalUuid);
+});
+
+/**
+ * @return array{Organisation, Organisation, Document, AvgResponsibleProcessingRecord}
+ */
+function copyDocumentOnceForPreview(): array
+{
+    $source = Organisation::factory()->create();
+    $destination = Organisation::factory()->create();
+    $user = User::factory()->create();
+
+    [$path, $plan, $document] = createExportedDocumentBundle($source);
+    app(BundleImporter::class)->importZip(Storage::disk('filament')->path($path), $plan, $destination, $user);
+
+    $record = AvgResponsibleProcessingRecord::query()->whereBelongsTo($source)->firstOrFail();
+
+    return [$source, $destination, $document, $record];
+}
+
+function previewDocumentItem(Organisation $source, Organisation $destination, Document $document, AvgResponsibleProcessingRecord $record): array
+{
+    $bundle = app(BundleBuilder::class)->build(
+        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
+        [$record->id->toString()],
+        ['documents' => [$document->id->toString()]],
+        $source,
+    );
+
+    return app(PreviewBuilder::class)->build($bundle, $destination)[$document->id->toString()];
+}
+
+it('flags a document whose source attachment changed as needing a decision', function (): void {
+    Storage::fake('filament');
+    Storage::fake('media-library');
+
+    [$source, $destination, $document, $record] = copyDocumentOnceForPreview();
+
+    // Source file changes after the copy: the destination copy is now stale.
+    $document->clearMediaCollection(MediaGroup::ATTACHMENTS->value);
+    $document->addMediaFromString('updated bytes')
+        ->usingFileName('beleid.txt')
+        ->usingName('Beleidsdocument')
+        ->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+
+    $item = previewDocumentItem($source, $destination, $document, $record);
+
+    expect($item['has_match'])->toBeTrue()
+        ->and($item['unchanged'])->toBeFalse()
+        ->and($item['needs_decision'])->toBeTrue();
+});
+
+it('flags a document with an identical attachment as unchanged', function (): void {
+    Storage::fake('filament');
+    Storage::fake('media-library');
+
+    [$source, $destination, $document, $record] = copyDocumentOnceForPreview();
+
+    // Nothing changed on either side: the attachment matches by content_hash.
+    $item = previewDocumentItem($source, $destination, $document, $record);
+
+    expect($item['has_match'])->toBeTrue()
+        ->and($item['unchanged'])->toBeTrue()
+        ->and($item['needs_decision'])->toBeFalse();
 });

--- a/src/cms/tests/Feature/Transfer/MediaHashesTest.php
+++ b/src/cms/tests/Feature/Transfer/MediaHashesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Media\MediaGroup;
+use App\Models\Document;
+use App\Models\Organisation;
+use App\Transfer\Import\MediaHashes;
+use Illuminate\Support\Facades\Storage;
+
+it('reports no match when the source media block is not a list', function (): void {
+    $document = Document::factory()->for(Organisation::factory())->make();
+
+    expect(app(MediaHashes::class)->match($document, ['media' => 'nope']))->toBeFalse();
+});
+
+it('reports no match when a source media item carries no content hash', function (): void {
+    $document = Document::factory()->for(Organisation::factory())->make();
+
+    $entity = ['media' => [['file_name' => 'x.txt', 'content_hash' => null]]];
+
+    expect(app(MediaHashes::class)->match($document, $entity))->toBeFalse();
+});
+
+it('reports no match when the destination media has no computed hash', function (): void {
+    Storage::fake('media-library');
+
+    $document = Document::factory()->for(Organisation::factory())->create();
+    $media = $document->addMediaFromString('bytes')
+        ->usingFileName('x.txt')
+        ->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+
+    // A destination file whose hash was never computed cannot be compared: treat as differing.
+    $media->content_hash = null;
+    $media->saveQuietly();
+
+    $entity = ['media' => [['file_name' => 'x.txt', 'content_hash' => 'somehash']]];
+
+    expect(app(MediaHashes::class)->match($document->refresh(), $entity))->toBeFalse();
+});
+
+it('matches when source and destination hashes are equal regardless of order', function (): void {
+    Storage::fake('media-library');
+
+    $document = Document::factory()->for(Organisation::factory())->create();
+    $document->addMediaFromString('first')->usingFileName('a.txt')->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+    $document->addMediaFromString('second')->usingFileName('b.txt')->toMediaCollection(MediaGroup::ATTACHMENTS->value);
+
+    $document->refresh()->load('media');
+    $hashes = $document->media->pluck('content_hash')->all();
+
+    // Same set of hashes, reversed order.
+    $entity = [
+        'media' => [
+            ['file_name' => 'b.txt', 'content_hash' => $hashes[1]],
+            ['file_name' => 'a.txt', 'content_hash' => $hashes[0]],
+        ]];
+
+    expect(app(MediaHashes::class)->match($document, $entity))->toBeTrue();
+});


### PR DESCRIPTION
Stacked on #60 (`cross-org-copy`). Follow-up promised in https://github.com/sourcehaven-bv/openvwr/pull/60#issuecomment-5073500415 — fixes the stale-attachment gap that #60 left for later.

## Problem

On the cross-org copy in #60, a document's binary attachment copied correctly on the **first** copy, but an **overwrite kept the stale file**: `BundleImporter::overwriteEntity` only imported media when the destination had none (`$existing->media->isEmpty()`). And a document whose *only* change was its attachment read as "identiek — niets te doen", because `EditDetector` never looks at media (it's a `MorphMany`, not a pivot relation).

## Fix — use the existing `Media.content_hash`

`Media` already stores a sha256 `content_hash` (computed synchronously in the post-upload job chain), so no schema change is needed. It gives a cheap "do the bytes already agree?" check.

- **Export** — `EntitySerializer::serializeMedia()` now carries each media item's `content_hash`.
- **Overwrite** — a document's attachments are re-imported only when their hashes differ from the source; when they match, no bytes are moved (the cheap win). Only the collections the source actually carries are cleared, so unrelated attachments are left in place.
- **Preview** — a document whose source file changed is now flagged as needing a decision (skip / overwrite / copy) instead of being shown as unchanged. `EditDetector` stays focused on local edits; the source-vs-destination media comparison lives in `PreviewBuilder`, where both sides are in hand.
- **Refactor** — document-media handling and hash comparison were extracted from `BundleImporter` into `DocumentMediaImporter` and `MediaHashes` (also keeps `BundleImporter` under the phpmd class-complexity threshold).

A null/missing hash on either side is treated as "may differ" → re-import, so the change is always safe when a hash is unavailable.

## Tests

- overwrite refreshes a stale attachment when the source file changed
- overwrite leaves an identical attachment untouched (same media uuid preserved)
- preview flags a changed-attachment document as needing a decision; identical one stays unchanged
- unit coverage for the `MediaHashes` null/mismatch/order-insensitive branches and the `DocumentMediaImporter` malformed-media fallback

Transfer suite green (84 tests); phpstan / phpcs / phpmd clean; 100% coverage on all changed files. (The 4 local `HugoStaticWebsiteGenerator` failures are pre-existing — missing `hugo` binary — and untouched here.)

## Review base

Diff against **`cross-org-copy`**, not `main`. Merge #60 first, then this.