### PR TITLE
feat: leesbaardere one-page layout met snelnavigatie en layout-toggle

### DIFF
--- a/src/cms/app/Filament/Actions/ToggleRegisterLayoutAction.php
+++ b/src/cms/app/Filament/Actions/ToggleRegisterLayoutAction.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions;
+
+use App\Enums\RegisterLayout;
+use App\Facades\Authentication;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Resources\Pages\ViewRecord;
+
+use function __;
+
+/**
+ * Switches the current user between the stepwise and one-page register layout.
+ *
+ * The preference still lives on the user (users.register_layout), so the choice
+ * persists exactly as it does when set from the profile -- this only puts the
+ * switch where the layout is actually being used, instead of several clicks
+ * away in the profile settings.
+ */
+class ToggleRegisterLayoutAction extends Action
+{
+    public static function make(?string $name = 'toggle_register_layout'): static
+    {
+        return parent::make($name)
+            ->label(static function (): string {
+                return __(self::targetLayout() === RegisterLayout::ONE_PAGE
+                    ? 'user.profile.settings.register_layout_switch_to_one_page'
+                    : 'user.profile.settings.register_layout_switch_to_steps');
+            })
+            ->icon(static function (): string {
+                return self::targetLayout() === RegisterLayout::ONE_PAGE
+                    ? 'heroicon-o-bars-3'
+                    : 'heroicon-o-queue-list';
+            })
+            ->color('gray')
+            // The layout is chosen when the form schema is built, so switching
+            // it has to reload the page rather than re-render in place.
+            ->action(static function (Action $action, EditRecord|ViewRecord $livewire): void {
+                $user = Authentication::user();
+                $user->register_layout = self::targetLayout();
+                $user->save();
+
+                // Livewire's own URL is the AJAX endpoint, so rebuild the
+                // record page URL from the page class instead of the referer.
+                $action->redirect(
+                    $livewire::getUrl(['record' => $livewire->getRecord()]),
+                    navigate: false,
+                );
+            });
+    }
+
+    private static function targetLayout(): RegisterLayout
+    {
+        return Authentication::user()->register_layout === RegisterLayout::ONE_PAGE
+            ? RegisterLayout::STEPS
+            : RegisterLayout::ONE_PAGE;
+    }
+}

--- a/src/cms/app/Filament/OnePageLayoutRenderHooks.php
+++ b/src/cms/app/Filament/OnePageLayoutRenderHooks.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament;
+
+use App\Enums\RegisterLayout;
+use App\Facades\Authentication;
+use App\Filament\Pages\ProcessingRecordEditRecord;
+use App\Filament\Pages\ProcessingRecordViewRecord;
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
+use Livewire\Component;
+
+use function app;
+use function view;
+
+/**
+ * Wraps the one-page register layout in a grid so the quick-jump navigation
+ * can sit beside the form, and renders that navigation.
+ *
+ * This is done with render hooks rather than by overriding Filament's
+ * edit-record/view-record views: those views are non-trivial, and copying them
+ * into the project means re-reconciling them on every Filament upgrade. The
+ * hooks either side of the page slot give the same wrapping for free.
+ */
+class OnePageLayoutRenderHooks
+{
+    public static function register(): void
+    {
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::PAGE_HEADER_WIDGETS_AFTER,
+            static function (): string {
+                if (!self::isOnePageRegisterPage()) {
+                    return '';
+                }
+
+                return '<div class="onepage-layout">';
+            },
+        );
+
+        FilamentView::registerRenderHook(
+            PanelsRenderHook::PAGE_FOOTER_WIDGETS_BEFORE,
+            static function (): string {
+                if (!self::isOnePageRegisterPage()) {
+                    return '';
+                }
+
+                return '<div class="onepage-nav-ctn">'
+                    . view('filament.forms.components.onepage-nav')->render()
+                    . '</div></div>';
+            },
+        );
+    }
+
+    /**
+     * The navigation is only useful where the one-page layout actually renders:
+     * a register record page, for a user who selected that layout.
+     */
+    private static function isOnePageRegisterPage(): bool
+    {
+        if (Authentication::user()->register_layout !== RegisterLayout::ONE_PAGE) {
+            return false;
+        }
+
+        $page = self::getLivewireComponent();
+
+        return $page instanceof ProcessingRecordEditRecord || $page instanceof ProcessingRecordViewRecord;
+    }
+
+    private static function getLivewireComponent(): ?Component
+    {
+        $component = app('livewire')->current();
+
+        return $component instanceof Component ? $component : null;
+    }
+}

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceForm.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceForm.php
@@ -62,64 +62,49 @@ class AvgResponsibleProcessingRecordResourceForm
             ->schema([
                 Section::make(__('avg_responsible_processing_record.step_processing_name'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('avg_responsible_processing_record.step_responsible'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('avg_responsible_processing_record.step_processor'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getProcessor())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('avg_responsible_processing_record.step_receiver'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('avg_responsible_processing_record.step_processing_goal'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_goal']),
                 Section::make(__('avg_responsible_processing_record.step_stakeholder_data'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getStakeholder())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_stakeholder_data']),
                 Section::make(__('avg_responsible_processing_record.step_decision_making'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('avg_responsible_processing_record.step_system'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getSystem())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system']),
                 Section::make(__('avg_responsible_processing_record.step_security'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('avg_responsible_processing_record.step_passthrough'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getPassthrough())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_passthrough']),
                 Section::make(__('avg_responsible_processing_record.step_geb_dpia'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getGebDpia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_dpia']),
                 Section::make(__('avg_responsible_processing_record.step_contact_person'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getContactPerson())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('avg_responsible_processing_record.step_attachments'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('avg_responsible_processing_record.step_remarks'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
                 Section::make(__('avg_responsible_processing_record.step_publish'))
                     ->schema(AvgResponsibleProcessingRecordResourceFormSchemas::getPublish())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_publish']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceInfolist.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceInfolist.php
@@ -61,64 +61,49 @@ class AvgResponsibleProcessingRecordResourceInfolist
             ->schema([
                 Section::make(__('avg_responsible_processing_record.step_processing_name'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('avg_responsible_processing_record.step_responsible'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('avg_responsible_processing_record.step_processor'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getProcessor())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('avg_responsible_processing_record.step_receiver'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('avg_responsible_processing_record.step_processing_goal'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_goal']),
                 Section::make(__('avg_responsible_processing_record.step_stakeholder_data'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getStakeholder())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_stakeholder_data']),
                 Section::make(__('avg_responsible_processing_record.step_decision_making'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('avg_responsible_processing_record.step_system'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getSystem())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system']),
                 Section::make(__('avg_responsible_processing_record.step_security'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('avg_responsible_processing_record.step_passthrough'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getPassthrough())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_passthrough']),
                 Section::make(__('avg_responsible_processing_record.step_geb_dpia'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getGebDpia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_dpia']),
                 Section::make(__('avg_responsible_processing_record.step_contact_person'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getContactPerson())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('avg_responsible_processing_record.step_attachments'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('avg_responsible_processing_record.step_remarks'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
                 Section::make(__('avg_responsible_processing_record.step_publish'))
                     ->schema(AvgResponsibleProcessingRecordResourceInfolistSchemas::getPublish())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_publish']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/EditAvgResponsibleProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/EditAvgResponsibleProcessingRecord.php
@@ -7,6 +7,7 @@ namespace App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages;
 use App\Filament\Actions\CloneAction;
 use App\Filament\Actions\CreateSnapshotAction;
 use App\Filament\Actions\GoToPublicPageAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordEditRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 use Filament\Actions\DeleteAction;
@@ -18,6 +19,7 @@ class EditAvgResponsibleProcessingRecord extends ProcessingRecordEditRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             GoToPublicPageAction::make(),
             CloneAction::make(),
             CreateSnapshotAction::makeWithChangesCheck($this->data, $this->savedDataHash),

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/ViewAvgResponsibleProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/ViewAvgResponsibleProcessingRecord.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages;
 
 use App\Filament\Actions\CreateSnapshotAction;
 use App\Filament\Actions\GoToPublicPageAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordViewRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 use Filament\Actions\DeleteAction;
@@ -17,6 +18,7 @@ class ViewAvgResponsibleProcessingRecord extends ProcessingRecordViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             GoToPublicPageAction::make(),
             CreateSnapshotAction::make(),
             DeleteAction::make(),

--- a/src/cms/app/Providers/FilamentServiceProvider.php
+++ b/src/cms/app/Providers/FilamentServiceProvider.php
@@ -6,6 +6,7 @@ namespace App\Providers;
 
 use App\Facades\Authentication;
 use App\Filament\NavigationGroups\NavigationGroup;
+use App\Filament\OnePageLayoutRenderHooks;
 use App\Filament\Pages\Login;
 use App\Filament\Pages\Profile;
 use App\Filament\SimpleAvatarProvider;
@@ -85,6 +86,8 @@ class FilamentServiceProvider extends PanelProvider
                 return view('filament.version_meta');
             },
         );
+
+        OnePageLayoutRenderHooks::register();
     }
 
     /**

--- a/src/cms/resources/css/filament/admin/theme.css
+++ b/src/cms/resources/css/filament/admin/theme.css
@@ -46,3 +46,160 @@
     list-style-position: outside;
     margin-left: 1rem;
 }
+
+/*
+ * One-page register layout.
+ *
+ * The sections render as a single full-width column: no ->aside(), so the
+ * fields use the whole card instead of being squeezed into a 2/3 grid track.
+ * These rules give the long page a scannable rhythm -- a clear size step
+ * between section heading and field labels, and enough air between sections
+ * that the headings read as landmarks while scrolling fast.
+ */
+/*
+ * Two columns: the form beside the navigation, with the relation managers
+ * spanning both underneath.
+ *
+ * A grid rather than a flex row because it lets the navigation share a row
+ * with the form only. Sticky positioning is bounded by the containing block,
+ * so the navigation scrolls away with the end of the form instead of staying
+ * pinned over the full-width tables below it.
+ */
+.onepage-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 300px;
+    /* Rows: form sections, the form's save/cancel actions, relation managers.
+       The navigation occupies the first row only. */
+    grid-template-rows: auto auto auto;
+    align-items: start;
+    gap: 20px;
+    width: 100%;
+}
+
+/*
+ * The panel caps content at screen-2xl, which the 25rem sidebar then eats into
+ * -- on a wide monitor that leaves the long form squeezed into the left of the
+ * window with dead space beside it. The one-page layout is the one place that
+ * genuinely wants the room, so let its page break out of the cap.
+ */
+.fi-main:has(.onepage-layout) {
+    max-width: none;
+}
+
+/*
+ * The form spans the sections row and the actions row, so the navigation
+ * column can be bounded to the sections alone (see the row definitions on
+ * .onepage-layout). Making it a grid lets its two parts line up with those
+ * rows: sections in row 1, the save/cancel actions in row 2.
+ */
+.onepage-layout > .fi-form {
+    grid-column: 1;
+    min-width: 0;
+    /* Without subgrid the form stays a single-row item: the navigation then
+       ends level with the buttons instead of above them, which is a slightly
+       worse stopping point rather than a broken layout. */
+    grid-row: 1;
+}
+
+@supports (grid-template-rows: subgrid) {
+    .onepage-layout > .fi-form {
+        grid-row: 1 / span 2;
+        display: grid;
+        grid-template-rows: subgrid;
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+/*
+ * The navigation sits in a wrapper that spans the form's full height, and the
+ * sticky element lives inside it. A sticky box cannot be pushed past the
+ * bottom of its containing block, so this is what makes the navigation scroll
+ * up and away with the end of the form rather than hang over the tables.
+ */
+.onepage-layout > .onepage-nav-ctn {
+    grid-column: 2;
+    grid-row: 1;
+    height: 100%;
+}
+
+/*
+ * Relation managers (Versies, Subverwerkingen, Primair contact) are tables and
+ * the navigation has run out of items by the time they appear, so let them
+ * span both columns instead of being squeezed beside empty space.
+ */
+.onepage-layout > .fi-resource-relation-managers {
+    grid-column: 1 / -1;
+    grid-row: 3;
+    min-width: 0;
+}
+
+/* Section rhythm: the "beat" the eye follows when scrolling quickly. */
+.onepage-layout [data-onepage-section] + [data-onepage-section] {
+    margin-top: 1.5rem;
+}
+
+/* The size step that was missing: headings were text-base, same as body.
+   Scoped to the section's own header so nested information blocks keep
+   their smaller heading and the hierarchy stays readable. */
+.onepage-layout [data-onepage-section] > .fi-section-header .fi-section-header-heading {
+    @apply text-xl font-semibold;
+}
+
+/* Nested information blocks are cards inside a card; flatten them so each
+   section reads as one object rather than a box-in-a-box. */
+.onepage-layout [data-onepage-section] .fi-section .fi-section {
+    @apply shadow-none ring-0 bg-gray-50 dark:bg-white/5;
+}
+
+/* Land jump targets below the sticky topbar instead of flush under it. */
+.onepage-layout [data-onepage-section] {
+    scroll-margin-top: 5rem;
+}
+
+/* Quick-jump nav: mirrors the wizard's step-list card so both layouts share
+   a visual language. Sticky, because its whole purpose is orientation while
+   scrolling a long page. */
+.onepage-nav {
+    @apply bg-white rounded-xl shadow-sm ring-1 ring-gray-950/5 dark:bg-gray-900 dark:ring-white/10;
+    position: sticky;
+    top: 5rem;
+    /* align-self keeps the sticky box at its natural height so it can travel
+       within the row rather than being stretched to fill it. */
+    align-self: start;
+    max-height: calc(100vh - 7rem);
+    overflow-y: auto;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.onepage-nav__item {
+    @apply flex w-full items-center gap-x-2 rounded-lg px-3 py-2 text-sm font-medium text-gray-500 dark:text-gray-400;
+    text-align: left;
+    /* Section labels are full sentences in places; wrap rather than overflow. */
+    word-break: break-word;
+}
+
+.onepage-nav__item:hover {
+    @apply bg-gray-100 text-gray-950 dark:bg-white/5 dark:text-white;
+}
+
+.onepage-nav__item.fi-active {
+    @apply bg-gray-300 text-gray-900 dark:bg-gray-700 dark:text-white;
+}
+
+/* Below md the nav would eat the whole viewport; the page is scrollable
+   anyway, so drop it and let the content run full width. */
+@media (max-width: 1279px) {
+    /* Hide the whole column, not just the card, so it does not take a grid
+       slot beside the form. */
+    .onepage-layout > .onepage-nav-ctn {
+        display: none;
+    }
+
+    /* Collapse to a single column so the form uses the full width. */
+    .onepage-layout {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}

--- a/src/cms/resources/css/filament/admin/theme.css
+++ b/src/cms/resources/css/filament/admin/theme.css
@@ -145,14 +145,25 @@
     @apply text-xl font-semibold;
 }
 
+/* Accent bar on the header block itself rather than just the heading text,
+   so it reads as a marker for the whole header (heading + description)
+   instead of underlining just the words. Clipping to the card's rounded
+   corner is added to the overflow-hidden below, on the section itself. */
+.onepage-layout [data-onepage-section] > .fi-section-header {
+    @apply border-l-4 border-primary-600 dark:border-primary-400;
+}
+
 /* Nested information blocks are cards inside a card; flatten them so each
    section reads as one object rather than a box-in-a-box. */
 .onepage-layout [data-onepage-section] .fi-section .fi-section {
     @apply shadow-none ring-0 bg-gray-50 dark:bg-white/5;
 }
 
-/* Land jump targets below the sticky topbar instead of flush under it. */
+/* Land jump targets below the sticky topbar instead of flush under it.
+   overflow-hidden clips the header's accent bar to the card's rounded
+   corner instead of letting its square edge poke past the curve. */
 .onepage-layout [data-onepage-section] {
+    @apply overflow-hidden;
     scroll-margin-top: 5rem;
 }
 

--- a/src/cms/resources/lang/nl/general.php
+++ b/src/cms/resources/lang/nl/general.php
@@ -70,6 +70,7 @@ return [
     'manual' => 'Handleiding',
     'go_to_public_page' => 'Bekijk op de publieke website',
     'edit' => 'Bewerken',
+    'onepage_nav_label' => 'Snel naar onderdeel',
 
     'country' => 'Landen',
     'country_other' => 'Anders, namelijk:',

--- a/src/cms/resources/lang/nl/user.php
+++ b/src/cms/resources/lang/nl/user.php
@@ -113,6 +113,8 @@ return [
                 RegisterLayout::STEPS->value => 'Stapsgewijs met navigatie rechts',
                 RegisterLayout::ONE_PAGE->value => 'Alle gegevens onder elkaar',
             ],
+            'register_layout_switch_to_one_page' => 'Alles onder elkaar',
+            'register_layout_switch_to_steps' => 'Stapsgewijs',
         ],
     ],
 ];

--- a/src/cms/resources/views/filament/forms/components/onepage-nav.blade.php
+++ b/src/cms/resources/views/filament/forms/components/onepage-nav.blade.php
@@ -1,0 +1,102 @@
+{{--
+    Quick-jump navigation for the one-page register layout.
+
+    The section list is built from the DOM rather than passed in: the sections
+    are already marked with data-onepage-section, and reading them client-side
+    keeps this working for both the form (edit) and the infolist (view) without
+    either of them having to hand over their schema.
+
+    Section tracking uses IntersectionObserver so the active item stays correct
+    while scrolling fast, which is what the layout is for.
+--}}
+<div
+    x-data="{
+        sections: [],
+        active: null,
+
+        observer: null,
+
+        init: function () {
+            this.$nextTick(() => this.collect())
+
+            // Conditional fields mean sections can appear or disappear on a
+            // Livewire round trip; rebuild the list so the nav keeps matching
+            // what is actually on the page.
+            Livewire.hook('morphed', () => this.collect())
+        },
+
+        collect: function () {
+            const layout = document.querySelector('.onepage-layout')
+
+            if (! layout) {
+                return
+            }
+
+            const elements = layout.querySelectorAll('[data-onepage-section]')
+
+            this.sections = Array.from(elements).map((element) => {
+                // Direct child header only: sections contain nested information
+                // blocks, whose headings would otherwise win the lookup.
+                const heading = element.querySelector(
+                    ':scope > .fi-section-header .fi-section-header-heading',
+                )
+
+                return {
+                    key: element.dataset.onepageSection,
+                    label: heading ? heading.textContent.trim() : element.dataset.onepageSection,
+                    element: element,
+                }
+            })
+
+            if (! this.sections.length) {
+                return
+            }
+
+            if (this.active === null) {
+                this.active = this.sections[0].key
+            }
+
+            // Drop the previous observer so re-collecting does not leave stale
+            // elements being watched.
+            this.observer?.disconnect()
+
+            this.observer = new IntersectionObserver(
+                (entries) => {
+                    entries
+                        .filter((entry) => entry.isIntersecting)
+                        .forEach((entry) => {
+                            this.active = entry.target.dataset.onepageSection
+                        })
+                },
+                {
+                    // Only count a section as active once it reaches the upper
+                    // part of the viewport, so the highlight tracks what is
+                    // being read rather than whatever is entering at the bottom.
+                    rootMargin: '-80px 0px -70% 0px',
+                    threshold: 0,
+                },
+            )
+
+            this.sections.forEach((section) => this.observer.observe(section.element))
+        },
+
+        jumpTo: function (section) {
+            section.element.scrollIntoView({ behavior: 'smooth', block: 'start' })
+            this.active = section.key
+        },
+    }"
+    class="onepage-nav"
+    role="navigation"
+    aria-label="{{ __('general.onepage_nav_label') }}"
+>
+    <template x-for="section in sections" :key="section.key">
+        <button
+            type="button"
+            class="onepage-nav__item"
+            :class="{ 'fi-active': active === section.key }"
+            :aria-current="active === section.key ? 'true' : null"
+            x-on:click="jumpTo(section)"
+            x-text="section.label"
+        ></button>
+    </template>
+</div>

--- a/src/cms/tests/Feature/Filament/Actions/ToggleRegisterLayoutActionTest.php
+++ b/src/cms/tests/Feature/Filament/Actions/ToggleRegisterLayoutActionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\RegisterLayout;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\ViewAvgResponsibleProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+it('switches the layout and redirects back to the record', function (
+    RegisterLayout $current,
+    RegisterLayout $expected,
+): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation, ['register_layout' => $current]);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+
+    $this->asFilamentUser($user)
+        ->createLivewireTestable(EditAvgResponsibleProcessingRecord::class, [
+            'record' => $avgResponsibleProcessingRecord->id,
+        ])
+        ->callAction('toggle_register_layout')
+        ->assertRedirect(EditAvgResponsibleProcessingRecord::getUrl([
+            'record' => $avgResponsibleProcessingRecord,
+        ]));
+
+    expect($user->refresh()->register_layout)
+        ->toBe($expected);
+})->with([
+    'steps to one page' => [RegisterLayout::STEPS, RegisterLayout::ONE_PAGE],
+    'one page to steps' => [RegisterLayout::ONE_PAGE, RegisterLayout::STEPS],
+]);
+
+it('switches the layout from the view page', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation, [
+        'register_layout' => RegisterLayout::STEPS,
+    ]);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+
+    $this->asFilamentUser($user)
+        ->createLivewireTestable(ViewAvgResponsibleProcessingRecord::class, [
+            'record' => $avgResponsibleProcessingRecord->id,
+        ])
+        ->callAction('toggle_register_layout')
+        ->assertRedirect(ViewAvgResponsibleProcessingRecord::getUrl([
+            'record' => $avgResponsibleProcessingRecord,
+        ]));
+
+    expect($user->refresh()->register_layout)
+        ->toBe(RegisterLayout::ONE_PAGE);
+});
+
+it('only changes the layout of the acting user', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation, [
+        'register_layout' => RegisterLayout::STEPS,
+    ]);
+    $otherUser = UserTestHelper::createForOrganisation($organisation, [
+        'register_layout' => RegisterLayout::STEPS,
+    ]);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+
+    $this->asFilamentUser($user)
+        ->createLivewireTestable(EditAvgResponsibleProcessingRecord::class, [
+            'record' => $avgResponsibleProcessingRecord->id,
+        ])
+        ->callAction('toggle_register_layout');
+
+    expect($user->refresh()->register_layout)
+        ->toBe(RegisterLayout::ONE_PAGE)
+        ->and($otherUser->refresh()->register_layout)
+        ->toBe(RegisterLayout::STEPS);
+});


### PR DESCRIPTION
Verbetert de leesbaarheid van de one-page layout voor verwerkingen, zodat snel scrollen om te scannen werkt. Alleen `AvgResponsibleProcessingRecord` (formulier + infolist); de overige registers volgen later.

## Wat er mis was

De secties gebruikten `->compact()->aside()`. Daardoor:

- `aside()` rendert een 3-koloms grid: kop links, velden geperst in `md:col-span-2` — geen enkele kolom, maar een smalle kolom met een lege marge ernaast, 15x herhaald.
- Sectiekoppen waren `text-base font-semibold`: exact dezelfde grootte als de veldlabels, dus geen visueel ankerpunt bij het scrollen.
- Elke sectie begint met een `InformationBlockSection` — een kaart in een kaart in een smalle kolom.

## Wat er nu gebeurt

- `->aside()` en `->compact()` verwijderd: echte enkele kolom over de volle breedte.
- Sectiekoppen naar `text-xl`, meer ruimte tussen secties, geneste informatieblokken afgevlakt.
- Snelnavigatie rechts met alle 15 secties, die de actieve sectie volgt tijdens het scrollen (`IntersectionObserver`, blijft kloppen bij snel scrollen). Sluit aan op het bestaande stappen-navigatiepatroon uit `processing-record-wizard.blade.php`.
- Relatietabellen (Versies) beslaan de volle breedte onder het formulier.
- Layout-toggle in de paginakop, op zowel bewerken als bekijken.

## Layout-mechaniek

`.onepage-layout` is een grid met drie rijen: sectie-inhoud, formulierknoppen, relatietabellen. Het formulier beslaat rij 1-2 via `grid-template-rows: subgrid`, waardoor de navigatiekolom alleen rij 1 vult. Sticky positioning wordt begrensd door het containing block, dus de navigatie scrollt vanzelf mee weg boven de knoppen — geen JavaScript. Met `@supports`-fallback: zonder subgrid eindigt de navigatie gelijk met de knoppen in plaats van erboven.

De wrapper komt uit render hooks rond de page slot in plaats van een override van Filaments `edit-record`/`view-record` views, zodat er niets van Filament in het project gekopieerd hoeft te worden bij een upgrade.

## Toggle

De voorkeur blijft op de gebruiker staan (`users.register_layout`) en werkt dus precies zoals de profielinstelling; die blijft ook gewoon werken. De layout wordt gekozen bij het opbouwen van het formulierschema, dus wisselen vereist een herlaadactie — de redirect bouwt de record-URL op uit de page class (Livewire's eigen URL is het AJAX-endpoint).

## Getest

Handmatig in de browser op 1680px en smal:

- Navigatie volgt de juiste sectie tijdens scrollen; secties 0/4/9/14 lichten elk hun eigen item op.
- Klikken springt naar de sectie, netjes onder de topbar (`scroll-margin-top`).
- Navigatie stopt boven de knoppen: onderkant 619 vs knoppen op 641, geen overlap op alle geteste scrollposities.
- Onder 1280px verdwijnt de navigatiekolom, formulier over volle breedte, geen horizontale overflow.
- Toggle heen en terug: one-page ↔ wizard, label wisselt mee, voorkeur blijft bewaard.

CI: phpcs, phpstan (1212 bestanden) en phpmd schoon. Testsuite 1462 geslaagd. De 4 falende `HugoStaticWebsiteGeneratorTest`-tests zijn niet gerelateerd: die zoeken `build.sh` in `src/cms/static-website/` terwijl het bestand in `src/static-website/` staat — reproduceerbaar op een schone `main` zonder deze wijzigingen.

## Nog te doen

De overige vier registers (Wpg, AVG Verwerker, Algoritmes, Datalekken) gebruiken hetzelfde `->compact()->aside()`-patroon en kunnen dezelfde behandeling krijgen.