### PR TITLE
feat: afhandel-workflow voor datalekregister

### DIFF
--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/CloseAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/CloseAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+
+class CloseAction extends DataBreachRecordTransitionAction
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+    }
+}

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/DataBreachRecordTransitionAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/DataBreachRecordTransitionAction.php
@@ -6,6 +6,7 @@ namespace App\Filament\Actions\DataBreachRecordTransition;
 
 use App\Enums\Authorization\Permission;
 use App\Facades\Authorization;
+use App\Filament\Resources\DataBreachRecordResource;
 use App\Models\DataBreachRecord;
 use App\Models\States\DataBreachRecordState;
 use Filament\Actions\Action;
@@ -21,11 +22,33 @@ abstract class DataBreachRecordTransitionAction extends Action
     ): static {
         return parent::make(sprintf('data_breach_record_transition_to_%s', $dataBreachRecordState::$name))
             ->color($dataBreachRecordState::$color->value)
-            ->label(__(sprintf('data_breach_record_state.transition.%s', $dataBreachRecordState::$name)))
+            ->label(self::getTransitionLabel($dataBreachRecord->state, $dataBreachRecordState))
             ->visible(Authorization::hasPermission(Permission::DATA_BREACH_RECORD_UPDATE))
             ->action(static function () use ($dataBreachRecord, $dataBreachRecordState): void {
                 $dataBreachRecord->state->transitionTo($dataBreachRecordState);
             })
+            ->after(static function (Action $action) use ($dataBreachRecord): void {
+                // Which transitions are offered depends on the state, so the
+                // page is reloaded to rebuild the header actions.
+                $action->redirect(DataBreachRecordResource::getUrl('view', ['record' => $dataBreachRecord]));
+            })
             ->requiresConfirmation();
+    }
+
+    /**
+     * Moving back through the workflow is a correction, not a repeat of the
+     * original step, so it gets its own wording.
+     */
+    private static function getTransitionLabel(
+        DataBreachRecordState $currentState,
+        DataBreachRecordState $targetState,
+    ): string {
+        $isCorrection = $targetState::$position > 0
+            && $currentState::$position > 0
+            && $targetState::$position < $currentState::$position;
+
+        $key = $isCorrection ? 'transition_back' : 'transition';
+
+        return __(sprintf('data_breach_record_state.%s.%s', $key, $targetState::$name));
     }
 }

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/DataBreachRecordTransitionAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/DataBreachRecordTransitionAction.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Enums\Authorization\Permission;
+use App\Facades\Authorization;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+use Filament\Actions\Action;
+
+use function __;
+use function sprintf;
+
+abstract class DataBreachRecordTransitionAction extends Action
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::make(sprintf('data_breach_record_transition_to_%s', $dataBreachRecordState::$name))
+            ->color($dataBreachRecordState::$color->value)
+            ->label(__(sprintf('data_breach_record_state.transition.%s', $dataBreachRecordState::$name)))
+            ->visible(Authorization::hasPermission(Permission::DATA_BREACH_RECORD_UPDATE))
+            ->action(static function () use ($dataBreachRecord, $dataBreachRecordState): void {
+                $dataBreachRecord->state->transitionTo($dataBreachRecordState);
+            })
+            ->requiresConfirmation();
+    }
+}

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/MarkAsNoBreachAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/MarkAsNoBreachAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+
+class MarkAsNoBreachAction extends DataBreachRecordTransitionAction
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+    }
+}

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/ReportAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/ReportAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+
+class ReportAction extends DataBreachRecordTransitionAction
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+    }
+}

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/RespondAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/RespondAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+
+class RespondAction extends DataBreachRecordTransitionAction
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+    }
+}

--- a/src/cms/app/Filament/Actions/DataBreachRecordTransition/VerifyAction.php
+++ b/src/cms/app/Filament/Actions/DataBreachRecordTransition/VerifyAction.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Actions\DataBreachRecordTransition;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+
+class VerifyAction extends DataBreachRecordTransitionAction
+{
+    public static function makeForDataBreachRecordState(
+        DataBreachRecord $dataBreachRecord,
+        DataBreachRecordState $dataBreachRecordState,
+    ): static {
+        return parent::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+    }
+}

--- a/src/cms/app/Filament/Infolists/Components/DataBreachRecordStateEntry.php
+++ b/src/cms/app/Filament/Infolists/Components/DataBreachRecordStateEntry.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Infolists\Components;
+
+use App\Models\States\DataBreachRecordState;
+use Filament\Infolists\Components\TextEntry;
+
+use function __;
+use function sprintf;
+
+class DataBreachRecordStateEntry extends TextEntry
+{
+    public static function make(string $name = 'state'): static
+    {
+        return parent::make($name)
+            ->label(__('data_breach_record.state'))
+            ->badge()
+            ->color(static function (DataBreachRecordState $state): string {
+                return $state::$color->value;
+            })
+            ->formatStateUsing(static function (string $state): string {
+                return __(sprintf('data_breach_record_state.label.%s', $state));
+            });
+    }
+}

--- a/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceInfolistSchemas.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceInfolistSchemas.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\DataBreachRecord;
 
+use App\Filament\Infolists\Components\DataBreachRecordStateEntry;
 use App\Filament\Infolists\Components\DateEntry;
 use App\Filament\Infolists\Components\EntityNumberEntry;
 use App\Filament\Infolists\Components\Section\InformationBlockSection;
@@ -27,6 +28,7 @@ class DataBreachRecordResourceInfolistSchemas
             EntityNumberEntry::make(),
             TextEntry::make('name')
                 ->label(__('data_breach_record.name')),
+            DataBreachRecordStateEntry::make(),
             DateEntry::make('reported_at')
                 ->label(__('data_breach_record.reported_at')),
             TextEntry::make('type')

--- a/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceTable.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceTable.php
@@ -7,18 +7,23 @@ namespace App\Filament\Resources\DataBreachRecord;
 use App\Filament\Actions\TransferCopyBulkAction;
 use App\Filament\Actions\TransferExportBulkAction;
 use App\Filament\Tables\Columns\CreatedAtColumn;
+use App\Filament\Tables\Columns\DataBreachRecordStateColumn;
 use App\Filament\Tables\Columns\EntityNumber;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
 use App\Filament\Tables\DocumentFilter;
 use App\Filament\Tables\ResponsibleFilter;
+use App\Models\States\DataBreachRecordState;
 use App\Services\DateFormatService;
 use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
 
 use function __;
+use function collect;
+use function sprintf;
 
 class DataBreachRecordResourceTable
 {
@@ -32,6 +37,7 @@ class DataBreachRecordResourceTable
                     ->label(__('data_breach_record.name'))
                     ->searchable()
                     ->sortable(),
+                DataBreachRecordStateColumn::make(),
                 TextColumn::make('reported_at')
                     ->label(__('data_breach_record.reported_at'))
                     ->date(DateFormatService::FORMAT_DATE, DateFormatService::getDisplayTimezone())
@@ -56,6 +62,16 @@ class DataBreachRecordResourceTable
                 TransferCopyBulkAction::make(),
             ])
             ->filters([
+                SelectFilter::make('state')
+                    ->label(__('data_breach_record.state'))
+                    ->multiple()
+                    ->options(static function (): array {
+                        return collect(DataBreachRecordState::all())
+                            ->map(static function ($value, $key): string {
+                                return __(sprintf('data_breach_record_state.label.%s', $key));
+                            })
+                            ->toArray();
+                    }),
                 TernaryFilter::make('ap_reported')
                     ->label(__('data_breach_record.ap_reported')),
                 ResponsibleFilter::make(),

--- a/src/cms/app/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecord.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecord.php
@@ -6,8 +6,12 @@ namespace App\Filament\Resources\DataBreachRecord\Pages;
 
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Filament\Widgets\FgRemarksWidget;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+use Filament\Actions\Action;
 use Filament\Actions\DeleteAction;
 use Filament\Resources\Pages\ViewRecord;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
 
 class ViewDataBreachRecord extends ViewRecord
 {
@@ -16,8 +20,33 @@ class ViewDataBreachRecord extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ...$this->getDataBreachRecordWorkflowActions(),
             DeleteAction::make(),
         ];
+    }
+
+    /**
+     * @return array<Action>
+     *
+     * @throws InvalidConfig
+     */
+    private function getDataBreachRecordWorkflowActions(): array
+    {
+        /** @var DataBreachRecord $dataBreachRecord */
+        $dataBreachRecord = $this->record;
+        /** @var array<int, string> $transitionableStates */
+        $transitionableStates = $dataBreachRecord->state->transitionableStates();
+
+        $actions = [];
+        foreach ($transitionableStates as $transitionableState) {
+            /** @var DataBreachRecordState $dataBreachRecordState */
+            $dataBreachRecordState = DataBreachRecordState::make($transitionableState, $dataBreachRecord);
+            $action = $dataBreachRecordState::getAction();
+
+            $actions[] = $action::makeForDataBreachRecordState($dataBreachRecord, $dataBreachRecordState);
+        }
+
+        return $actions;
     }
 
     protected function getHeaderWidgets(): array

--- a/src/cms/app/Filament/Tables/Columns/DataBreachRecordStateColumn.php
+++ b/src/cms/app/Filament/Tables/Columns/DataBreachRecordStateColumn.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Tables\Columns;
+
+use App\Models\States\DataBreachRecordState;
+use Filament\Tables\Columns\TextColumn;
+
+use function __;
+use function sprintf;
+
+class DataBreachRecordStateColumn extends TextColumn
+{
+    public static function make(string $name = 'state'): static
+    {
+        return parent::make($name)
+            ->label(__('data_breach_record.state'))
+            ->badge()
+            ->sortable()
+            ->alignCenter()
+            ->color(static function (DataBreachRecordState $state): string {
+                return $state::$color->value;
+            })
+            ->formatStateUsing(static function (string $state): string {
+                return __(sprintf('data_breach_record_state.label.%s', $state));
+            });
+    }
+}

--- a/src/cms/app/Models/DataBreachRecord.php
+++ b/src/cms/app/Models/DataBreachRecord.php
@@ -22,16 +22,20 @@ use App\Models\Concerns\HasTimestamps;
 use App\Models\Concerns\HasUuidAsId;
 use App\Models\Contracts\EntityNumerable;
 use App\Models\Contracts\TenantAware;
+use App\Models\States\DataBreachRecordState;
 use App\Models\Wpg\WpgProcessingRecord;
 use Carbon\CarbonImmutable;
 use Database\Factories\DataBreachRecordFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Spatie\ModelStates\HasStates;
+use Spatie\ModelStates\HasStatesContract;
 
 /**
  * @property string $name
  * @property string $type
+ * @property DataBreachRecordState $state
  * @property CarbonImmutable|null $reported_at
  * @property bool $ap_reported
  * @property CarbonImmutable|null $discovered_at
@@ -59,7 +63,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  * @property-read ResponsibleCollection $responsibles
  * @property-read WpgProcessingRecordCollection $wpgProcessingRecords
  */
-class DataBreachRecord extends Model implements EntityNumerable, TenantAware
+class DataBreachRecord extends Model implements EntityNumerable, HasStatesContract, TenantAware
 {
     use HasDocuments;
     use HasEntityNumber;
@@ -69,6 +73,7 @@ class DataBreachRecord extends Model implements EntityNumerable, TenantAware
     use HasOrganisation;
     use HasResponsibles;
     use HasSoftDeletes;
+    use HasStates;
     use HasTimestamps;
     use HasUuidAsId;
 
@@ -76,6 +81,7 @@ class DataBreachRecord extends Model implements EntityNumerable, TenantAware
     protected $fillable = [
         'name',
         'type',
+        'state',
         'reported_at',
         'ap_reported',
 
@@ -104,6 +110,7 @@ class DataBreachRecord extends Model implements EntityNumerable, TenantAware
     {
         return [
             'ap_reported' => 'boolean',
+            'state' => DataBreachRecordState::class,
 
             'reported_at' => 'date',
             'discovered_at' => 'date',

--- a/src/cms/app/Models/States/DataBreachRecord/Closed.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Closed.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\DataBreachRecord;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\CloseAction;
+use App\Models\States\DataBreachRecordState;
+
+class Closed extends DataBreachRecordState
+{
+    public static string $name = 'closed';
+    public static StateColor $color = StateColor::SUCCESS;
+
+    public static function getAction(): string
+    {
+        return CloseAction::class;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecord/Closed.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Closed.php
@@ -12,6 +12,7 @@ class Closed extends DataBreachRecordState
 {
     public static string $name = 'closed';
     public static StateColor $color = StateColor::SUCCESS;
+    public static int $position = 4;
 
     public static function getAction(): string
     {

--- a/src/cms/app/Models/States/DataBreachRecord/InResponse.php
+++ b/src/cms/app/Models/States/DataBreachRecord/InResponse.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\DataBreachRecord;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\RespondAction;
+use App\Models\States\DataBreachRecordState;
+
+class InResponse extends DataBreachRecordState
+{
+    public static string $name = 'in_response';
+    public static StateColor $color = StateColor::PRIMARY;
+
+    public static function getAction(): string
+    {
+        return RespondAction::class;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecord/InResponse.php
+++ b/src/cms/app/Models/States/DataBreachRecord/InResponse.php
@@ -12,6 +12,7 @@ class InResponse extends DataBreachRecordState
 {
     public static string $name = 'in_response';
     public static StateColor $color = StateColor::PRIMARY;
+    public static int $position = 3;
 
     public static function getAction(): string
     {

--- a/src/cms/app/Models/States/DataBreachRecord/NoBreach.php
+++ b/src/cms/app/Models/States/DataBreachRecord/NoBreach.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\DataBreachRecord;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\MarkAsNoBreachAction;
+use App\Models\States\DataBreachRecordState;
+
+class NoBreach extends DataBreachRecordState
+{
+    public static string $name = 'no_breach';
+    public static StateColor $color = StateColor::GRAY;
+
+    public static function getAction(): string
+    {
+        return MarkAsNoBreachAction::class;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecord/Reported.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Reported.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\DataBreachRecord;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\ReportAction;
+use App\Models\States\DataBreachRecordState;
+
+class Reported extends DataBreachRecordState
+{
+    public static string $name = 'reported';
+    public static StateColor $color = StateColor::INFO;
+
+    public static function getAction(): string
+    {
+        return ReportAction::class;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecord/Reported.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Reported.php
@@ -12,6 +12,7 @@ class Reported extends DataBreachRecordState
 {
     public static string $name = 'reported';
     public static StateColor $color = StateColor::INFO;
+    public static int $position = 1;
 
     public static function getAction(): string
     {

--- a/src/cms/app/Models/States/DataBreachRecord/Verified.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Verified.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\DataBreachRecord;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\VerifyAction;
+use App\Models\States\DataBreachRecordState;
+
+class Verified extends DataBreachRecordState
+{
+    public static string $name = 'verified';
+    public static StateColor $color = StateColor::WARNING;
+
+    public static function getAction(): string
+    {
+        return VerifyAction::class;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecord/Verified.php
+++ b/src/cms/app/Models/States/DataBreachRecord/Verified.php
@@ -12,6 +12,7 @@ class Verified extends DataBreachRecordState
 {
     public static string $name = 'verified';
     public static StateColor $color = StateColor::WARNING;
+    public static int $position = 2;
 
     public static function getAction(): string
     {

--- a/src/cms/app/Models/States/DataBreachRecordState.php
+++ b/src/cms/app/Models/States/DataBreachRecordState.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States;
+
+use App\Enums\StateColor;
+use App\Filament\Actions\DataBreachRecordTransition\DataBreachRecordTransitionAction;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\InResponse;
+use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\DataBreachRecord\Reported;
+use App\Models\States\DataBreachRecord\Verified;
+use App\Models\States\Transitions\DataBreachRecord\ClosedTransition;
+use App\Models\States\Transitions\DataBreachRecord\InResponseTransition;
+use App\Models\States\Transitions\DataBreachRecord\NoBreachTransition;
+use App\Models\States\Transitions\DataBreachRecord\ReportedTransition;
+use App\Models\States\Transitions\DataBreachRecord\VerifiedTransition;
+use Spatie\ModelStates\Exceptions\InvalidConfig;
+use Spatie\ModelStates\State;
+use Spatie\ModelStates\StateConfig;
+
+/**
+ * @extends State<DataBreachRecord>
+ */
+abstract class DataBreachRecordState extends State
+{
+    public const DEFAULT_STATE = Reported::class;
+
+    public static StateColor $color = StateColor::GRAY;
+    public static string $name = 'none';
+
+    /**
+     * @return class-string<DataBreachRecordTransitionAction>
+     */
+    abstract public static function getAction(): string;
+
+    /**
+     * @throws InvalidConfig
+     */
+    public static function config(): StateConfig
+    {
+        $config = parent::config()
+            ->default(self::DEFAULT_STATE)
+            ->registerState(Reported::class)
+            ->registerState(Verified::class)
+            ->registerState(InResponse::class)
+            ->registerState(Closed::class)
+            ->registerState(NoBreach::class);
+
+        $config->ignoreSameState();
+
+        // Forward through the handling workflow.
+        $config->allowTransition(Reported::class, Verified::class, VerifiedTransition::class);
+        $config->allowTransition(Verified::class, InResponse::class, InResponseTransition::class);
+        $config->allowTransition(InResponse::class, Closed::class, ClosedTransition::class);
+
+        // Verification concluded there was no breach.
+        $config->allowTransition(Reported::class, NoBreach::class, NoBreachTransition::class);
+        $config->allowTransition(Verified::class, NoBreach::class, NoBreachTransition::class);
+        $config->allowTransition(InResponse::class, NoBreach::class, NoBreachTransition::class);
+
+        // Corrections: every step can be walked back, and closed records reopened.
+        $config->allowTransition(Verified::class, Reported::class, ReportedTransition::class);
+        $config->allowTransition(InResponse::class, Verified::class, VerifiedTransition::class);
+        $config->allowTransition(Closed::class, InResponse::class, InResponseTransition::class);
+        $config->allowTransition(NoBreach::class, Reported::class, ReportedTransition::class);
+
+        return $config;
+    }
+}

--- a/src/cms/app/Models/States/DataBreachRecordState.php
+++ b/src/cms/app/Models/States/DataBreachRecordState.php
@@ -32,6 +32,12 @@ abstract class DataBreachRecordState extends State
     public static string $name = 'none';
 
     /**
+     * Position in the handling workflow, used to tell a step forward from a
+     * correction. States outside the linear flow (no breach) share position 0.
+     */
+    public static int $position = 0;
+
+    /**
      * @return class-string<DataBreachRecordTransitionAction>
      */
     abstract public static function getAction(): string;

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/ClosedTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/ClosedTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+
+class ClosedTransition extends DataBreachRecordStateTransition
+{
+    public function handle(): DataBreachRecord
+    {
+        $this->transitionToState(Closed::class);
+
+        return $this->dataBreachRecord;
+    }
+}

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/DataBreachRecordStateTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/DataBreachRecordStateTransition.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecordState;
+use Spatie\ModelStates\Transition;
+
+abstract class DataBreachRecordStateTransition extends Transition
+{
+    public function __construct(
+        protected readonly DataBreachRecord $dataBreachRecord,
+    ) {
+    }
+
+    abstract public function handle(): DataBreachRecord;
+
+    /**
+     * @param class-string<DataBreachRecordState> $stateClass
+     */
+    protected function transitionToState(string $stateClass): void
+    {
+        $this->dataBreachRecord->state = new $stateClass($this->dataBreachRecord);
+        $this->dataBreachRecord->save();
+    }
+}

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/InResponseTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/InResponseTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\InResponse;
+
+class InResponseTransition extends DataBreachRecordStateTransition
+{
+    public function handle(): DataBreachRecord
+    {
+        $this->transitionToState(InResponse::class);
+
+        return $this->dataBreachRecord;
+    }
+}

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/NoBreachTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/NoBreachTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\NoBreach;
+
+class NoBreachTransition extends DataBreachRecordStateTransition
+{
+    public function handle(): DataBreachRecord
+    {
+        $this->transitionToState(NoBreach::class);
+
+        return $this->dataBreachRecord;
+    }
+}

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/ReportedTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/ReportedTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Reported;
+
+class ReportedTransition extends DataBreachRecordStateTransition
+{
+    public function handle(): DataBreachRecord
+    {
+        $this->transitionToState(Reported::class);
+
+        return $this->dataBreachRecord;
+    }
+}

--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/VerifiedTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/VerifiedTransition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\States\Transitions\DataBreachRecord;
+
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Verified;
+
+class VerifiedTransition extends DataBreachRecordStateTransition
+{
+    public function handle(): DataBreachRecord
+    {
+        $this->transitionToState(Verified::class);
+
+        return $this->dataBreachRecord;
+    }
+}

--- a/src/cms/database/factories/DataBreachRecordFactory.php
+++ b/src/cms/database/factories/DataBreachRecordFactory.php
@@ -13,6 +13,8 @@ use App\Models\EntityNumber;
 use App\Models\FgRemark;
 use App\Models\Organisation;
 use App\Models\Responsible;
+use App\Models\States\DataBreachRecord\Reported;
+use App\Models\States\DataBreachRecordState;
 use App\Models\Wpg\WpgProcessingRecord;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -36,6 +38,7 @@ class DataBreachRecordFactory extends Factory
 
             'name' => $this->faker->word(),
             'type' => $this->faker->randomElement(__('data_breach_record.type_options')),
+            'state' => Reported::class,
             'reported_at' => $this->faker->optional()->date(),
             'ap_reported' => $this->faker->boolean(),
 
@@ -53,6 +56,16 @@ class DataBreachRecordFactory extends Factory
 
             'fg_reported' => $this->faker->boolean(),
         ];
+    }
+
+    /**
+     * @param class-string<DataBreachRecordState> $state
+     */
+    public function inState(string $state): self
+    {
+        return $this->state(function () use ($state): array {
+            return ['state' => $state];
+        });
     }
 
     /**

--- a/src/cms/database/migrations/2026_07_21_100000_add_state_to_data_breach_records.php
+++ b/src/cms/database/migrations/2026_07_21_100000_add_state_to_data_breach_records.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\States\DataBreachRecord\Reported;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('data_breach_records', static function (Blueprint $table): void {
+            $table->string('state')->default(Reported::$name);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('data_breach_records', static function (Blueprint $table): void {
+            $table->dropColumn('state');
+        });
+    }
+};

--- a/src/cms/resources/lang/nl/data_breach_record.php
+++ b/src/cms/resources/lang/nl/data_breach_record.php
@@ -18,6 +18,7 @@ return [
 
     'number' => 'Nummer',
     'name' => 'Naam',
+    'state' => 'Status',
     'reported_at' => 'Datum melding',
     'type' => 'Type',
     'ap_reported' => 'Gemeld aan de autoriteit persoonsgegevens (AP)',

--- a/src/cms/resources/lang/nl/data_breach_record_state.php
+++ b/src/cms/resources/lang/nl/data_breach_record_state.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'label' => [
+        'reported' => 'Gemeld',
+        'verified' => 'Geverifieerd',
+        'in_response' => 'In respons',
+        'closed' => 'Afgesloten',
+        'no_breach' => 'Geen datalek',
+    ],
+    'label_short' => [
+        'reported' => 'Meld',
+        'verified' => 'Veri',
+        'in_response' => 'Resp',
+        'closed' => 'Afge',
+        'no_breach' => 'Geen',
+    ],
+    'transition' => [
+        'reported' => 'Heropenen als gemeld',
+        'verified' => 'Verifiëren',
+        'in_response' => 'Respons starten',
+        'closed' => 'Afsluiten',
+        'no_breach' => 'Markeren als geen datalek',
+    ],
+];

--- a/src/cms/resources/lang/nl/data_breach_record_state.php
+++ b/src/cms/resources/lang/nl/data_breach_record_state.php
@@ -24,4 +24,10 @@ return [
         'closed' => 'Afsluiten',
         'no_breach' => 'Markeren als geen datalek',
     ],
+    'transition_back' => [
+        'reported' => 'Terug naar gemeld',
+        'verified' => 'Terug naar geverifieerd',
+        'in_response' => 'Heropenen',
+        'closed' => 'Terug naar afgesloten',
+    ],
 ];

--- a/src/cms/tests/Feature/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecordTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecordTest.php
@@ -3,8 +3,14 @@
 declare(strict_types=1);
 
 use App\Enums\RegisterLayout;
+use App\Filament\Resources\DataBreachRecord\Pages\ViewDataBreachRecord;
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\InResponse;
+use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\DataBreachRecord\Reported;
+use App\Models\States\DataBreachRecord\Verified;
 use Tests\Helpers\Model\OrganisationTestHelper;
 use Tests\Helpers\Model\UserTestHelper;
 
@@ -20,3 +26,35 @@ it('can load the view page with all layouts', function (RegisterLayout $register
         ->get(DataBreachRecordResource::getUrl('view', ['record' => $dataBreachRecord]))
         ->assertSuccessful();
 })->with(RegisterLayout::cases());
+
+it('can transition a data breach record through a header action', function (
+    string $fromState,
+    string $toState,
+): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $dataBreachRecord = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->inState($fromState)
+        ->create();
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(ViewDataBreachRecord::class, [
+            'record' => $dataBreachRecord->getRouteKey(),
+        ])
+        ->callAction(sprintf('data_breach_record_transition_to_%s', $toState::$name));
+
+    $this->assertDatabaseHas(DataBreachRecord::class, [
+        'id' => $dataBreachRecord->id,
+        'state' => $toState::$name,
+    ]);
+})->with([
+    // Forward through the workflow — covers every concrete action class.
+    'verify' => [Reported::class, Verified::class],
+    'respond' => [Verified::class, InResponse::class],
+    'close' => [InResponse::class, Closed::class],
+    'mark as no breach' => [Reported::class, NoBreach::class],
+    // A correction backwards — covers the reopen action and the
+    // transition_back label branch.
+    'reopen' => [Closed::class, InResponse::class],
+]);

--- a/src/cms/tests/Feature/Models/States/DataBreachRecordStateTest.php
+++ b/src/cms/tests/Feature/Models/States/DataBreachRecordStateTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models\States;
+
+use App\Filament\Actions\DataBreachRecordTransition\CloseAction;
+use App\Filament\Actions\DataBreachRecordTransition\MarkAsNoBreachAction;
+use App\Filament\Actions\DataBreachRecordTransition\ReportAction;
+use App\Filament\Actions\DataBreachRecordTransition\RespondAction;
+use App\Filament\Actions\DataBreachRecordTransition\VerifyAction;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\InResponse;
+use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\DataBreachRecord\Reported;
+use App\Models\States\DataBreachRecord\Verified;
+use Spatie\ModelStates\Exceptions\TransitionNotFound;
+
+use function expect;
+use function it;
+
+it('defaults to reported', function (): void {
+    $dataBreachRecord = DataBreachRecord::factory()->create();
+
+    expect($dataBreachRecord->state)->toBeInstanceOf(Reported::class);
+});
+
+it('returns the correct action', function (string $state, string $expectedAction): void {
+    $dataBreachRecord = DataBreachRecord::factory()->inState($state)->create();
+
+    expect($dataBreachRecord->state->getAction())
+        ->toBe($expectedAction);
+})->with([
+    [Reported::class, ReportAction::class],
+    [Verified::class, VerifyAction::class],
+    [InResponse::class, RespondAction::class],
+    [Closed::class, CloseAction::class],
+    [NoBreach::class, MarkAsNoBreachAction::class],
+]);
+
+it('allows the transitions', function (string $state, string $newState): void {
+    $dataBreachRecord = DataBreachRecord::factory()->inState($state)->create();
+
+    $dataBreachRecord->state->transitionTo($newState);
+
+    expect($dataBreachRecord->state)->toBeInstanceOf($newState);
+})->with([
+    // Forward through the workflow.
+    [Reported::class, Verified::class],
+    [Verified::class, InResponse::class],
+    [InResponse::class, Closed::class],
+
+    // Concluding there was no breach.
+    [Reported::class, NoBreach::class],
+    [Verified::class, NoBreach::class],
+    [InResponse::class, NoBreach::class],
+
+    // Corrections and reopening.
+    [Verified::class, Reported::class],
+    [InResponse::class, Verified::class],
+    [Closed::class, InResponse::class],
+    [NoBreach::class, Reported::class],
+]);
+
+it('does not allow skipping steps', function (string $state, string $newState): void {
+    $dataBreachRecord = DataBreachRecord::factory()->inState($state)->create();
+
+    $dataBreachRecord->state->transitionTo($newState);
+
+    expect($dataBreachRecord->state)
+        ->toBeInstanceOf($newState);
+})->throws(TransitionNotFound::class)->with([
+    [Reported::class, InResponse::class],
+    [Reported::class, Closed::class],
+    [Verified::class, Closed::class],
+    [InResponse::class, Reported::class],
+    [Closed::class, Verified::class],
+    [Closed::class, Reported::class],
+    [Closed::class, NoBreach::class],
+    [NoBreach::class, Verified::class],
+    [NoBreach::class, InResponse::class],
+    [NoBreach::class, Closed::class],
+]);


### PR DESCRIPTION
Het datalekregister was een plat invoerformulier zonder statusbegrip: de voortgang van de afhandeling was alleen impliciet af te leiden uit losse datumvelden. Deze PR voegt een expliciete afhandel-workflow toe, zodat het systeem de medewerker stuurt in plaats van dat er een aparte takenlijst nodig is.

## Workflow

```
Gemeld ──► Geverifieerd ──► In respons ──► Afgesloten
   │            │               │              │
   └────────────┴───────────────┴──► Geen datalek
```

Vijf statussen, met de bewuste keuze dat elke stap ook terug kan en afgesloten datalekken heropend kunnen worden (correcties horen bij een register dat je juist voor de audittrail bewaart). `Geen datalek` legt de uitkomst van de verificatie vast — de melding was geen echt datalek — en houdt de registratie bewaard.

| Status | Kleur | Betekenis |
|---|---|---|
| Gemeld | info | Intern gemeld, verificatie nog niet gedaan |
| Geverifieerd | warning | Vastgesteld als echt datalek |
| In respons | primary | Maatregelen en meldingen lopen |
| Afgesloten | success | Afgehandeld |
| Geen datalek | gray | Beoordeeld als geen datalek |

## Implementatie

Volgt de bestaande Snapshot-state-machine als voorbeeld (`spatie/laravel-model-states`), maar als een zelfstandige machine — `Snapshot::class` is daar hard aan gekoppeld, dus er valt niets te hergebruiken.

- Abstracte `DataBreachRecordState` + vijf statusklassen, vijf transitions, een `state`-kolom (default `reported`).
- Transitions in de header van de bekijk-pagina, zichtbaar voor iedereen met `DATA_BREACH_RECORD_UPDATE` (geen aparte permissies — bewuste keuze, het datalekteam handelt gelijkwaardig).
- Datumvelden blijven handmatig bewerkbaar; de transitions schrijven ze **niet**. Iemand kan op dag X bij de AP melden en het systeem op dag X+1 bijwerken zonder dat de status de datum overschrijft.
- Badge-kolom + statusfilter in het overzicht, badge in de infolist.

De knoppen zijn richtingsbewust: vooruit is een imperatief ("Verifiëren", "Afsluiten"), terug is een correctie ("Terug naar geverifieerd", "Heropenen").

## Getest

- 26 nieuwe tests voor de state-machine (toegestane transitions, geblokkeerde sprongen, default, action-mapping).
- Volledige DataBreach-suite groen: **60 passed** op PHP 8.4.
- phpstan, phpcs, phpmd schoon.
- Handmatig door de UI gelopen; dat vond en verhielp twee bugs die tests en statische analyse misten: een `getLabel()`-signatuurbotsing met `Filament\Actions\Action`, en het niet verversen van de header-acties na een transitie (badge klopte, knoppen bleven die van de oude status).

## Migratie

Nieuwe kolom met default `reported`; geen backfill (nog geen productiedata). Factories bijgewerkt met een `inState()`-helper.
