### PR TITLE
chore: native dev setup-script en just-recipes

### DIFF
--- a/docs/local_development_without_docker.md
+++ b/docs/local_development_without_docker.md
@@ -25,16 +25,51 @@ brew install php@8.4 node
 # PostgreSQL: Postgres.app of `brew install postgresql@15`
 ```
 
-Draai onderstaande commando's met de 8.4-binary als je systeem-PHP nieuwer is:
+## Setup (macOS + Homebrew)
+
+Eén commando installeert de dependencies, maakt de database aan, bouwt de
+assets en vult de database met testdata:
 
 ```bash
-PHP=/opt/homebrew/opt/php@8.4/bin/php
+just setup-native
 ```
 
-## Setup
+Het script is idempotent: het slaat over wat er al is, en laat een bestaande
+`.env` ongemoeid. Daarna:
+
+```bash
+just dev-native          # start op http://127.0.0.1:8000
+just dev-native-login    # print een magic link om in te loggen
+```
+
+Verdere commando's:
+
+| Commando | Doet |
+|---|---|
+| `just setup-native` | Volledige setup vanaf niets |
+| `just doctor-native` | Controleert de omgeving en meldt wat ontbreekt |
+| `just dev-native [port]` | Start de applicatie (standaard poort 8000) |
+| `just dev-native-login [email]` | Magic link (standaard `admin@example.com`) |
+| `just dev-native-reset` | Database opnieuw opbouwen en seeden |
+| `just test-native [args]` | Testsuite draaien met PHP 8.4 |
+
+Werkt er iets niet, draai dan `just doctor-native`: die controleert PHP-versie
+en -extensies, de tools, beide databases, `.env`, `APP_KEY`, dependencies en de
+gebouwde assets, en noemt per probleem het commando dat het oplost.
+
+De vier vereiste extensies (`pdo_pgsql`, `fileinfo`, `sockets`, `zip`) zitten
+ingebouwd in Homebrew's `php@8.4` — ontbreekt er één, dan wijst dat op een
+kapotte installatie (`brew reinstall php@8.4`) eerder dan op een ontbrekend
+pecl-pakket.
+
+## Handmatig, stap voor stap
+
+Wat `just setup-native` doet, met de hand. Draai de commando's met de
+8.4-binary als je systeem-PHP nieuwer is:
 
 ```bash
 cd src/cms
+PHP=$(brew --prefix php@8.4)/bin/php
 
 # 1. Database + rol
 psql -h 127.0.0.1 -d postgres -c "CREATE ROLE sail LOGIN PASSWORD 'password' SUPERUSER;"
@@ -45,7 +80,7 @@ cp .env.nodocker.example .env
 $PHP artisan key:generate   # vóór het seeden, zie waarschuwing hieronder
 
 # 3. Dependencies en assets
-$PHP /opt/homebrew/bin/composer install
+$PHP $(command -v composer) install
 npm install && npm run build          # zonder assets rendert de UI ongestyled
 
 # 4. Database vullen
@@ -85,15 +120,11 @@ testen.
 
 De applicatie kent geen wachtwoorden: inloggen gaat via een ondertekende
 magic link. `MAIL_MAILER=log` logt alleen metadata, niet de link zelf. Genereer
-daarom een login-URL via artisan:
+daarom een login-URL:
 
 ```bash
-$PHP artisan tinker --execute='
-$u = App\Models\User::where("email", "admin@example.com")->firstOrFail();
-app(App\Services\UserLoginToken\UserLoginService::class)->sendPasswordLessLoginLink($u, "/");
-$t = $u->userLoginTokens()->orderByDesc("expires_at")->firstOrFail();
-echo (new App\Mail\Authentication\PasswordLessLoginLink($t))->link;
-'
+just dev-native-login                    # admin@example.com
+just dev-native-login fg@example.com     # of een andere rol
 ```
 
 Open de URL, klik op "Inloggen", en vul op het tweefactorscherm een willekeurige
@@ -110,5 +141,12 @@ screenshots, niet als vervanging van de Docker-omgeving:
 - `QUEUE_CONNECTION=sync` verwerkt jobs synchroon. Zodra het project een echte
   queue-driver gebruikt, worden jobs lokaal niet meer verwerkt zonder worker.
 - Virusscanning en objectopslag worden niet echt getest.
+- De vier `HugoStaticWebsiteGenerator`-tests falen zonder het `hugo`-binary
+  (`brew install hugo`). De rest van de suite slaagt native.
 
-Draai de testsuite en CI daarom op de Docker-setup.
+**PHP 8.4 is een harde eis, ook voor de tests.** Op 8.5 faalt het overgrote
+deel van de suite (±800 tests) op `HasUuidAsId`: het custom `Uuid`-object kan
+daar niet meer als array-key worden gebruikt. `just test-native` gebruikt
+daarom expliciet de 8.4-binary.
+
+Draai de testsuite en CI daarom bij voorkeur op de Docker-setup.

--- a/justfile
+++ b/justfile
@@ -101,6 +101,35 @@ dev-reset:
 login-link email="admin@example.com":
     cd src/cms && php artisan dev:login-link --email={{email}}
 
+# Native Development (no Docker)
+# ==============================
+# macOS + Homebrew only. See docs/local_development_without_docker.md.
+
+# Install dependencies, create the database, and seed test data
+setup-native:
+    ./scripts/setup-local-dev.sh
+
+# Check the native environment and report what is missing
+doctor-native:
+    ./scripts/check-local-dev.sh
+
+# Serve the application natively on http://127.0.0.1:8000
+dev-native port="8000":
+    cd src/cms && "$(brew --prefix php@8.4)/bin/php" artisan serve --host=127.0.0.1 --port={{port}}
+
+# Print a magic-link to log in (defaults to admin@example.com), pinned to PHP 8.4
+dev-native-login email="admin@example.com":
+    cd src/cms && "$(brew --prefix php@8.4)/bin/php" artisan dev:login-link --email={{email}}
+
+# Run the test suite natively (needs PHP 8.4; 8.5 fails on UUID casts)
+test-native +args="":
+    cd src/cms && "$(brew --prefix php@8.4)/bin/php" -d memory_limit=4G ./vendor/bin/pest {{args}}
+
+# Rebuild the native database from scratch and reseed
+dev-native-reset:
+    cd src/cms && "$(brew --prefix php@8.4)/bin/php" artisan migrate:fresh --force \
+        && "$(brew --prefix php@8.4)/bin/php" artisan db:seed --class=TestDataSeeder --force
+
 # Build frontend assets
 dev-build:
     @echo "🎨 Building frontend assets..."

--- a/scripts/check-local-dev.sh
+++ b/scripts/check-local-dev.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Diagnoses a native (non-Docker) development environment.
+# Read-only: reports problems and how to fix them, changes nothing.
+set -uo pipefail
+
+CMS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src/cms" && pwd)"
+PHP_FORMULA="php@8.4"
+DB_PORT="${DB_PORT:-5432}"
+DB_NAME="${DB_NAME:-openvwr_local}"
+TEST_DB_NAME="${TEST_DB_NAME:-testing}"
+
+if [[ -t 1 ]]; then
+    C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'; C_RED=$'\033[0;31m'; C_OFF=$'\033[0m'
+else
+    C_GREEN=''; C_YELLOW=''; C_RED=''; C_OFF=''
+fi
+
+PROBLEMS=0
+ok()   { printf '%s✓%s %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+bad()  { printf '%s✗%s %s\n' "$C_RED" "$C_OFF" "$1"; PROBLEMS=$((PROBLEMS + 1)); }
+hint() { printf '    %s↳ %s%s\n' "$C_YELLOW" "$1" "$C_OFF"; }
+
+# --- Toolchain --------------------------------------------------------------
+
+if command -v brew >/dev/null; then
+    ok "Homebrew installed"
+else
+    bad "Homebrew not found"; hint "Install from https://brew.sh"
+fi
+
+PHP_BIN="$(brew --prefix "$PHP_FORMULA" 2>/dev/null)/bin/php"
+if [[ -x "$PHP_BIN" ]]; then
+    ok "PHP $("$PHP_BIN" -r 'echo PHP_VERSION;') at $PHP_BIN"
+else
+    bad "$PHP_FORMULA not installed"; hint "brew install $PHP_FORMULA"
+fi
+
+# The suite fails wholesale on 8.5: HasUuidAsId uses a custom Uuid object as an
+# array key, which 8.5 rejects.
+if command -v php >/dev/null; then
+    SYSTEM_PHP="$(php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;' 2>/dev/null)"
+    if [[ "$SYSTEM_PHP" != "8.4" ]]; then
+        printf '%s!%s Default `php` is %s; the just recipes pin 8.4 explicitly.\n' \
+            "$C_YELLOW" "$C_OFF" "$SYSTEM_PHP"
+    fi
+fi
+
+if [[ -x "$PHP_BIN" ]]; then
+    # Read the module list once: `grep -q` closes the pipe early, and the
+    # resulting SIGPIPE can truncate php's output on repeated invocations.
+    PHP_MODULES="$("$PHP_BIN" -m 2>/dev/null)"
+    MISSING=()
+    for ext in pdo_pgsql fileinfo sockets zip; do
+        grep -qix "$ext" <<<"$PHP_MODULES" || MISSING+=("$ext")
+    done
+    if [[ ${#MISSING[@]} -eq 0 ]]; then
+        ok "PHP extensions: pdo_pgsql, fileinfo, sockets, zip"
+    else
+        bad "Missing PHP extension(s): ${MISSING[*]}"
+        hint "All four are bundled with $PHP_FORMULA: brew reinstall $PHP_FORMULA"
+        hint "On a non-Homebrew PHP: pecl install ${MISSING[*]}"
+    fi
+fi
+
+for tool in composer node npm psql; do
+    if command -v "$tool" >/dev/null; then
+        ok "$tool found"
+    else
+        bad "$tool not found"
+        case "$tool" in
+            composer) hint "brew install composer" ;;
+            node|npm) hint "brew install node" ;;
+            psql)     hint "brew install postgresql@15, or install Postgres.app" ;;
+        esac
+    fi
+done
+
+# Optional: only the static-website generator needs it.
+if command -v hugo >/dev/null; then
+    ok "hugo found (static-website tests will run)"
+else
+    printf '%s!%s hugo not installed — 4 HugoStaticWebsiteGenerator tests will fail.\n' \
+        "$C_YELLOW" "$C_OFF"
+    hint "brew install hugo"
+fi
+
+# --- Database ---------------------------------------------------------------
+
+if pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1; then
+    ok "PostgreSQL reachable on port $DB_PORT"
+
+    for db in "$DB_NAME" "$TEST_DB_NAME"; do
+        if [[ "$(psql -h 127.0.0.1 -p "$DB_PORT" -d postgres -tAc \
+                "SELECT 1 FROM pg_database WHERE datname='$db'" 2>/dev/null)" == "1" ]]; then
+            TABLES="$(psql -h 127.0.0.1 -p "$DB_PORT" -d "$db" -tAc \
+                "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'" 2>/dev/null)"
+            if [[ "${TABLES:-0}" -gt 0 ]]; then
+                ok "Database '$db' exists ($TABLES tables)"
+            else
+                bad "Database '$db' exists but has no tables"
+                hint "just setup-native"
+            fi
+        else
+            bad "Database '$db' does not exist"
+            hint "just setup-native"
+        fi
+    done
+else
+    bad "PostgreSQL not reachable on 127.0.0.1:$DB_PORT"
+    hint "brew services start postgresql@15, or start Postgres.app"
+fi
+
+# --- Application ------------------------------------------------------------
+
+if [[ -f "$CMS_DIR/.env" ]]; then
+    ok ".env exists"
+    grep -qE '^APP_KEY=.+' "$CMS_DIR/.env" \
+        && ok "APP_KEY is set" \
+        || { bad "APP_KEY is empty"; hint "cd src/cms && \"\$(brew --prefix $PHP_FORMULA)/bin/php\" artisan key:generate"; }
+else
+    bad ".env missing"; hint "just setup-native"
+fi
+
+[[ -d "$CMS_DIR/vendor" ]] \
+    && ok "composer dependencies installed" \
+    || { bad "vendor/ missing"; hint "just setup-native"; }
+
+# Without built assets the UI renders unstyled and every page 500s on the
+# missing Vite manifest.
+[[ -f "$CMS_DIR/public/build/manifest.json" ]] \
+    && ok "frontend assets built" \
+    || { bad "frontend assets not built"; hint "cd src/cms && npm run build"; }
+
+printf '\n'
+if [[ $PROBLEMS -eq 0 ]]; then
+    ok "Environment looks good."
+else
+    printf '%s✗%s %d problem(s) found.\n' "$C_RED" "$C_OFF" "$PROBLEMS"
+    exit 1
+fi

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# Sets up a native (non-Docker) development environment on macOS + Homebrew.
+# See docs/local_development_without_docker.md for the manual equivalent.
+set -euo pipefail
+
+CMS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../src/cms" && pwd)"
+PHP_FORMULA="php@8.4"
+PG_FORMULA="postgresql@15"
+DB_NAME="${DB_NAME:-openvwr_local}"
+TEST_DB_NAME="${TEST_DB_NAME:-testing}"
+DB_USER="${DB_USER:-sail}"
+DB_PASSWORD="${DB_PASSWORD:-password}"
+DB_PORT="${DB_PORT:-5432}"
+
+if [[ -t 1 ]]; then
+    C_BLUE=$'\033[0;34m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'
+    C_RED=$'\033[0;31m'; C_OFF=$'\033[0m'
+else
+    C_BLUE=''; C_GREEN=''; C_YELLOW=''; C_RED=''; C_OFF=''
+fi
+
+info()  { printf '%s→%s %s\n' "$C_BLUE" "$C_OFF" "$1"; }
+ok()    { printf '%s✓%s %s\n' "$C_GREEN" "$C_OFF" "$1"; }
+warn()  { printf '%s!%s %s\n' "$C_YELLOW" "$C_OFF" "$1"; }
+fail()  { printf '%s✗%s %s\n' "$C_RED" "$C_OFF" "$1" >&2; exit 1; }
+
+[[ "$(uname -s)" == "Darwin" ]] || fail "This script targets macOS. See docs/local_development_without_docker.md for other platforms."
+command -v brew >/dev/null || fail "Homebrew not found. Install it from https://brew.sh"
+
+# --- Dependencies -----------------------------------------------------------
+
+install_formula() {
+    local formula="$1"
+    if brew list --formula "$formula" >/dev/null 2>&1; then
+        ok "$formula already installed"
+    else
+        info "Installing $formula..."
+        brew install "$formula"
+    fi
+}
+
+install_formula "$PHP_FORMULA"
+install_formula node
+
+# PostgreSQL may also be provided by Postgres.app, which is not a brew formula.
+if pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1; then
+    ok "PostgreSQL already reachable on port $DB_PORT"
+else
+    install_formula "$PG_FORMULA"
+    info "Starting $PG_FORMULA..."
+    brew services start "$PG_FORMULA" >/dev/null
+    for _ in $(seq 1 30); do
+        pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1 && break
+        sleep 1
+    done
+    pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1 \
+        || fail "PostgreSQL did not become reachable on port $DB_PORT."
+fi
+
+PHP_BIN="$(brew --prefix "$PHP_FORMULA")/bin/php"
+[[ -x "$PHP_BIN" ]] || fail "PHP binary not found at $PHP_BIN"
+
+# composer is not pinned to a PHP version; run it through the 8.4 binary.
+COMPOSER_BIN="$(command -v composer || true)"
+[[ -n "$COMPOSER_BIN" ]] || fail "composer not found. Run: brew install composer"
+
+ok "Using PHP $("$PHP_BIN" -r 'echo PHP_VERSION;')"
+
+check_extensions() {
+    local missing=()
+    local ext
+    # Read the module list once: `grep -q` closes the pipe early, and the
+    # resulting SIGPIPE can truncate php's output on repeated invocations.
+    local modules
+    modules="$("$PHP_BIN" -m 2>/dev/null)"
+    for ext in pdo_pgsql fileinfo sockets zip; do
+        grep -qix "$ext" <<<"$modules" || missing+=("$ext")
+    done
+
+    [[ ${#missing[@]} -eq 0 ]] && { ok "PHP extensions present: pdo_pgsql, fileinfo, sockets, zip"; return 0; }
+
+    # All four are compiled into Homebrew's php@8.4, so a miss means the wrong
+    # binary or a broken install rather than something pecl can fix.
+    warn "Missing PHP extension(s): ${missing[*]}"
+    warn "These ship with Homebrew's $PHP_FORMULA. Try: brew reinstall $PHP_FORMULA"
+    warn "If you use a different PHP build, install them with: pecl install ${missing[*]}"
+    return 1
+}
+
+check_extensions || fail "Cannot continue without the required PHP extensions."
+
+# --- Database ---------------------------------------------------------------
+
+psql_admin() { psql -h 127.0.0.1 -p "$DB_PORT" -d postgres -tAc "$1"; }
+
+if [[ "$(psql_admin "SELECT 1 FROM pg_roles WHERE rolname='$DB_USER'")" == "1" ]]; then
+    ok "Role '$DB_USER' exists"
+else
+    info "Creating role '$DB_USER'..."
+    psql_admin "CREATE ROLE $DB_USER LOGIN PASSWORD '$DB_PASSWORD' SUPERUSER;" >/dev/null
+fi
+
+create_database() {
+    local name="$1"
+    if [[ "$(psql_admin "SELECT 1 FROM pg_database WHERE datname='$name'")" == "1" ]]; then
+        ok "Database '$name' exists"
+    else
+        info "Creating database '$name'..."
+        psql_admin "CREATE DATABASE $name OWNER $DB_USER;" >/dev/null
+    fi
+}
+
+create_database "$DB_NAME"
+# phpunit.xml.dist pins DB_DATABASE=testing, so the suite needs its own database.
+create_database "$TEST_DB_NAME"
+
+# --- Application ------------------------------------------------------------
+
+cd "$CMS_DIR"
+
+if [[ -f .env ]]; then
+    ok ".env already exists (left untouched)"
+else
+    info "Creating .env from .env.nodocker.example..."
+    cp .env.nodocker.example .env
+fi
+
+info "Installing composer dependencies..."
+"$PHP_BIN" "$COMPOSER_BIN" install --no-interaction
+
+# APP_KEY must exist before seeding: otp_secret is encrypted with it, and
+# rotating the key afterwards makes existing secrets undecryptable.
+if grep -qE '^APP_KEY=.+' .env; then
+    ok "APP_KEY already set"
+else
+    info "Generating APP_KEY..."
+    "$PHP_BIN" artisan key:generate
+fi
+
+info "Installing npm dependencies and building assets..."
+npm install --silent
+npm run build
+
+info "Running migrations..."
+"$PHP_BIN" artisan migrate --force
+
+# The suite uses DatabaseTransactions, not RefreshDatabase, so the test
+# database needs its schema up front.
+info "Migrating the '$TEST_DB_NAME' database..."
+DB_DATABASE="$TEST_DB_NAME" "$PHP_BIN" artisan migrate --force
+
+USER_COUNT="$("$PHP_BIN" artisan tinker --execute='echo App\Models\User::count();' 2>/dev/null | tail -1 | tr -dc '0-9')"
+if [[ "${USER_COUNT:-0}" -eq 0 ]]; then
+    info "Seeding test data..."
+    "$PHP_BIN" artisan db:seed --class=TestDataSeeder --force
+else
+    ok "Database already has $USER_COUNT users (skipping seed)"
+fi
+
+printf '\n'
+ok "Setup complete."
+printf '\n  Start the app:  just dev-native\n  Login link:     just dev-native-login\n\n'


### PR DESCRIPTION
Volgt op #25 (native dev-documentatie). Die PR beschreef de setup handmatig; deze automatiseert het voor macOS + Homebrew, zodat één commando volstaat.

## Wat is nieuw

- **`just setup-native`** — installeert dependencies, maakt beide databases (`openvwr_local` én `testing`) aan, genereert `APP_KEY`, bouwt de assets en seedt testdata. Idempotent: slaat over wat er al is en laat een bestaande `.env` ongemoeid.
- **`just doctor-native`** — read-only omgevingscheck. Controleert PHP-versie en -extensies, tools, beide databases, `.env`, `APP_KEY`, dependencies en gebouwde assets, en noemt per probleem het commando dat het oplost. Exit-code niet-nul bij een echt probleem.
- **`just dev-native` / `dev-native-login` / `dev-native-reset` / `test-native`** — starten, inloggen, database resetten, tests draaien.

Alle recipes pinnen expliciet de 8.4-binary. Dat is nodig: op PHP 8.5 faalt het overgrote deel van de testsuite op `HasUuidAsId` (het custom `Uuid`-object kan daar niet meer als array-key worden gebruikt). `dev-native-login` gebruikt het bestaande `dev:login-link`-commando, maar via 8.4 in plaats van de systeem-`php`.

## Getest

Vanaf een schone staat (database, rol en `.env` verwijderd) volledig doorlopen: setup, inloggen via de magic link inclusief tweefactorstap, en de UI met testdata. Daarna nog eens gedraaid om de idempotentie te bevestigen.

Onderweg gevonden en verholpen:

- **De test-database ontbrak.** `phpunit.xml.dist` pint `DB_DATABASE=testing`; zonder die database (apart van `openvwr_local`) faalt de hele suite. `setup-native` maakt en migreert hem nu.
- **`doctor-native` had een SIGPIPE-bug** in de extensiecheck (`php -m | grep -q` sloot de pipe vroeg, waardoor extensies intermitterend als "ontbrekend" werden gemeld). Opgelost door de modulelijst één keer in te lezen.

## Volledige suite native

**1243 passed, 4 failed** op PHP 8.4. De vier falende zijn `HugoStaticWebsiteGenerator`-tests die het `hugo`-binary nodig hebben (`brew install hugo`); beide in de documentatie vermeld.

Geen wijzigingen aan applicatiecode; alleen scripts, `just`-recipes en documentatie. `.env.nodocker.example` is bewust ongemoeid gelaten — de versie uit #25 (met de MinIO-verwijdering en de Hugo-padtoelichting) is al correct.
