### PR TITLE
feat: one-page layout voor overige registers

### DIFF
--- a/src/cms/app/Filament/OnePageLayoutRenderHooks.php
+++ b/src/cms/app/Filament/OnePageLayoutRenderHooks.php
@@ -6,13 +6,19 @@ namespace App\Filament;
 
 use App\Enums\RegisterLayout;
 use App\Facades\Authentication;
-use App\Filament\Pages\ProcessingRecordEditRecord;
-use App\Filament\Pages\ProcessingRecordViewRecord;
+use App\Filament\Resources\AlgorithmRecordResource;
+use App\Filament\Resources\AvgProcessorProcessingRecordResource;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
+use App\Filament\Resources\DataBreachRecordResource;
+use App\Filament\Resources\WpgProcessingRecordResource;
+use Filament\Resources\Pages\EditRecord;
+use Filament\Resources\Pages\ViewRecord;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use Livewire\Component;
 
 use function app;
+use function in_array;
 use function view;
 
 /**
@@ -26,6 +32,17 @@ use function view;
  */
 class OnePageLayoutRenderHooks
 {
+    /**
+     * The registers that render their record pages with the one-page layout.
+     */
+    private const ONE_PAGE_RESOURCES = [
+        AlgorithmRecordResource::class,
+        AvgProcessorProcessingRecordResource::class,
+        AvgResponsibleProcessingRecordResource::class,
+        DataBreachRecordResource::class,
+        WpgProcessingRecordResource::class,
+    ];
+
     public static function register(): void
     {
         FilamentView::registerRenderHook(
@@ -56,6 +73,11 @@ class OnePageLayoutRenderHooks
     /**
      * The navigation is only useful where the one-page layout actually renders:
      * a register record page, for a user who selected that layout.
+     *
+     * Matching on the record-page contract rather than on the project's own
+     * base classes: not every register extends those (ViewDataBreachRecord
+     * extends Filament's ViewRecord directly), and the layout is chosen per
+     * resource, not per base class.
      */
     private static function isOnePageRegisterPage(): bool
     {
@@ -65,7 +87,21 @@ class OnePageLayoutRenderHooks
 
         $page = self::getLivewireComponent();
 
-        return $page instanceof ProcessingRecordEditRecord || $page instanceof ProcessingRecordViewRecord;
+        if (!$page instanceof EditRecord && !$page instanceof ViewRecord) {
+            return false;
+        }
+
+        return self::rendersOnePageLayout($page);
+    }
+
+    /**
+     * A resource opts in by exposing sections carrying the one-page anchor,
+     * which is what the navigation reads. Resources without them (users,
+     * organisations, lookup lists) are left untouched.
+     */
+    private static function rendersOnePageLayout(EditRecord|ViewRecord $page): bool
+    {
+        return in_array($page::getResource(), self::ONE_PAGE_RESOURCES, true);
     }
 
     private static function getLivewireComponent(): ?Component

--- a/src/cms/app/Filament/Pages/ProcessingRecordViewRecord.php
+++ b/src/cms/app/Filament/Pages/ProcessingRecordViewRecord.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Pages;
 
 use App\Filament\Actions\CreateSnapshotAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Widgets\FgRemarksWidget;
 use App\Models\Contracts\EntityNumerable;
 use App\Models\Contracts\SnapshotSource;
@@ -19,6 +20,7 @@ class ProcessingRecordViewRecord extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             CreateSnapshotAction::make(),
             DeleteAction::make(),
         ];

--- a/src/cms/app/Filament/Resources/AlgorithmRecordResource/AlgorithmRecordResourceForm.php
+++ b/src/cms/app/Filament/Resources/AlgorithmRecordResource/AlgorithmRecordResourceForm.php
@@ -46,32 +46,25 @@ class AlgorithmRecordResourceForm
             ->schema([
                 Section::make(__('algorithm_record.step_processing_name'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('algorithm_record.step_responsible_use'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getResponsibleUse())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible_use']),
                 Section::make(__('algorithm_record.step_mechanics'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getMechanics())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_mechanics']),
                 Section::make(__('algorithm_record.step_meta'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getMeta())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_meta']),
                 Section::make(__('algorithm_record.step_impact'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getImpact())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_impact']),
                 Section::make(__('algorithm_record.step_validation'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getValidation())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_validation']),
                 Section::make(__('algorithm_record.step_attachments'))
                     ->schema(AlgorithmRecordResourceFormSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AlgorithmRecordResource/AlgorithmRecordResourceInfolist.php
+++ b/src/cms/app/Filament/Resources/AlgorithmRecordResource/AlgorithmRecordResourceInfolist.php
@@ -45,32 +45,25 @@ class AlgorithmRecordResourceInfolist
             ->schema([
                 Section::make(__('algorithm_record.step_processing_name'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('algorithm_record.step_responsible_use'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getResponsibleUse())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible_use']),
                 Section::make(__('algorithm_record.step_mechanics'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getMechanics())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_mechanics']),
                 Section::make(__('algorithm_record.step_meta'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getMeta())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_meta']),
                 Section::make(__('algorithm_record.step_impact'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getImpact())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_impact']),
                 Section::make(__('algorithm_record.step_validation'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getValidation())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_validation']),
                 Section::make(__('algorithm_record.step_attachments'))
                     ->schema(AlgorithmRecordResourceInfolistSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AlgorithmRecordResource/Pages/EditAlgorithmRecord.php
+++ b/src/cms/app/Filament/Resources/AlgorithmRecordResource/Pages/EditAlgorithmRecord.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\AlgorithmRecordResource\Pages;
 
 use App\Filament\Actions\CloneAction;
 use App\Filament\Actions\CreateSnapshotAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordEditRecord;
 use App\Filament\Resources\AlgorithmRecordResource;
 use Filament\Actions\DeleteAction;
@@ -17,6 +18,7 @@ class EditAlgorithmRecord extends ProcessingRecordEditRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             CloneAction::make(),
             CreateSnapshotAction::makeWithChangesCheck($this->data, $this->savedDataHash),
             DeleteAction::make(),

--- a/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceForm.php
+++ b/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceForm.php
@@ -60,60 +60,46 @@ class AvgProcessorProcessingRecordResourceForm
             ->schema([
                 Section::make(__('avg_processor_processing_record.step_processing_name'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('avg_processor_processing_record.step_responsible'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('avg_processor_processing_record.step_processor'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getProcessors())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('avg_processor_processing_record.step_receiver'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('avg_processor_processing_record.step_processing_goal'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_goal']),
                 Section::make(__('avg_processor_processing_record.step_involved_data'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getInvolvedData())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_involved_data']),
                 Section::make(__('avg_processor_processing_record.step_decision_making'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('avg_processor_processing_record.step_system'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getSystem())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system']),
                 Section::make(__('avg_processor_processing_record.step_security'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('avg_processor_processing_record.step_passthrough'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getPassthrough())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_passthrough']),
                 Section::make(__('avg_processor_processing_record.step_geb_pia'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getGebPia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_pia']),
                 Section::make(__('avg_processor_processing_record.step_contact_person'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getContactPerson())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('avg_processor_processing_record.step_attachments'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('avg_processor_processing_record.step_remarks'))
                     ->schema(AvgProcessorProcessingRecordResourceFormSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceInfolist.php
+++ b/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceInfolist.php
@@ -59,60 +59,46 @@ class AvgProcessorProcessingRecordResourceInfolist
             ->schema([
                 Section::make(__('avg_processor_processing_record.step_processing_name'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('avg_processor_processing_record.step_responsible'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('avg_processor_processing_record.step_processor'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getProcessors())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('avg_processor_processing_record.step_receiver'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('avg_processor_processing_record.step_processing_goal'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_goal']),
                 Section::make(__('avg_processor_processing_record.step_involved_data'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getInvolvedData())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_involved_data']),
                 Section::make(__('avg_processor_processing_record.step_decision_making'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('avg_processor_processing_record.step_system'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getSystem())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system']),
                 Section::make(__('avg_processor_processing_record.step_security'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('avg_processor_processing_record.step_passthrough'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getPassthrough())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_passthrough']),
                 Section::make(__('avg_processor_processing_record.step_geb_pia'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getGebPia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_pia']),
                 Section::make(__('avg_processor_processing_record.step_contact_person'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getContactPerson())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('avg_processor_processing_record.step_attachments'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('avg_processor_processing_record.step_remarks'))
                     ->schema(AvgProcessorProcessingRecordResourceInfolistSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/Pages/EditAvgProcessorProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/Pages/EditAvgProcessorProcessingRecord.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\AvgProcessorProcessingRecordResource\Pages;
 
 use App\Filament\Actions\CloneAction;
 use App\Filament\Actions\CreateSnapshotAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordEditRecord;
 use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 use Filament\Actions\DeleteAction;
@@ -17,6 +18,7 @@ class EditAvgProcessorProcessingRecord extends ProcessingRecordEditRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             CloneAction::make(),
             CreateSnapshotAction::makeWithChangesCheck($this->data, $this->savedDataHash),
             DeleteAction::make(),

--- a/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceForm.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceForm.php
@@ -44,28 +44,22 @@ class DataBreachRecordResourceForm
             ->schema([
                 Section::make(__('data_breach_record.step_name'))
                     ->schema(DataBreachRecordResourceFormSchemas::getName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_name']),
                 Section::make(__('data_breach_record.step_responsible'))
                     ->schema(DataBreachRecordResourceFormSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('data_breach_record.step_dates'))
                     ->schema(DataBreachRecordResourceFormSchemas::getDates())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_dates']),
                 Section::make(__('data_breach_record.step_incident'))
                     ->schema(DataBreachRecordResourceFormSchemas::getIncident())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_incident']),
                 Section::make(__('data_breach_record.step_processing_records'))
                     ->schema(DataBreachRecordResourceFormSchemas::getProcessingRecords())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_records']),
                 Section::make(__('data_breach_record.step_attachments'))
                     ->schema(DataBreachRecordResourceFormSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceInfolist.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceInfolist.php
@@ -43,28 +43,22 @@ class DataBreachRecordResourceInfolist
             ->schema([
                 Section::make(__('data_breach_record.step_name'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_name']),
                 Section::make(__('data_breach_record.step_responsible'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('data_breach_record.step_dates'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getDates())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_dates']),
                 Section::make(__('data_breach_record.step_incident'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getIncident())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_incident']),
                 Section::make(__('data_breach_record.step_processing_records'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getProcessingRecords())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_records']),
                 Section::make(__('data_breach_record.step_attachments'))
                     ->schema(DataBreachRecordResourceInfolistSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/DataBreachRecord/Pages/EditDataBreachRecord.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/Pages/EditDataBreachRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\DataBreachRecord\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordEditRecord;
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Models\DataBreachRecord;
@@ -21,6 +22,7 @@ class EditDataBreachRecord extends ProcessingRecordEditRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             DeleteAction::make(),
         ];
     }

--- a/src/cms/app/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecord.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/Pages/ViewDataBreachRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\DataBreachRecord\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Filament\Widgets\FgRemarksWidget;
 use App\Models\DataBreachRecord;
@@ -20,6 +21,7 @@ class ViewDataBreachRecord extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             ...$this->getDataBreachRecordWorkflowActions(),
             DeleteAction::make(),
         ];

--- a/src/cms/app/Filament/Resources/WpgProcessingRecordResource/Pages/EditWpgProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/WpgProcessingRecordResource/Pages/EditWpgProcessingRecord.php
@@ -6,6 +6,7 @@ namespace App\Filament\Resources\WpgProcessingRecordResource\Pages;
 
 use App\Filament\Actions\CloneAction;
 use App\Filament\Actions\CreateSnapshotAction;
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\ProcessingRecordEditRecord;
 use App\Filament\Resources\WpgProcessingRecordResource;
 use Filament\Actions\DeleteAction;
@@ -17,6 +18,7 @@ class EditWpgProcessingRecord extends ProcessingRecordEditRecord
     protected function getHeaderActions(): array
     {
         return [
+            ToggleRegisterLayoutAction::make(),
             CloneAction::make(),
             CreateSnapshotAction::makeWithChangesCheck($this->data, $this->savedDataHash),
             DeleteAction::make(),

--- a/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceForm.php
+++ b/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceForm.php
@@ -60,60 +60,46 @@ class WpgProcessingRecordResourceForm
             ->schema([
                 Section::make(__('wpg_processing_record.step_processing_name'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('wpg_processing_record.step_responsible'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('wpg_processing_record.step_processor'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getProcessor())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('wpg_processing_record.step_receiver'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('wpg_processing_record.step_wpg_goal'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_wpg_goal']),
                 Section::make(__('wpg_processing_record.step_special_police_data'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getSpecialPoliceData())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_special_police_data']),
                 Section::make(__('wpg_processing_record.step_decision_making'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('wpg_processing_record.step_system_application'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getSystems())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system_application']),
                 Section::make(__('wpg_processing_record.step_security'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('wpg_processing_record.step_geb_dpia'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getGebDpia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_dpia']),
                 Section::make(__('wpg_processing_record.step_contact_person'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getContactPersons())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('wpg_processing_record.step_attachments'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('wpg_processing_record.step_remarks'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
                 Section::make(__('wpg_processing_record.step_categories_involved'))
                     ->schema(WpgProcessingRecordResourceFormSchemas::getCategoriesInvolved())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_categories_involved']),
             ]);
     }
 }

--- a/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceInfolist.php
+++ b/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceInfolist.php
@@ -59,60 +59,46 @@ class WpgProcessingRecordResourceInfolist
             ->schema([
                 Section::make(__('wpg_processing_record.step_processing_name'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getProcessingName())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processing_name']),
                 Section::make(__('wpg_processing_record.step_responsible'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getResponsible())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_responsible']),
                 Section::make(__('wpg_processing_record.step_processor'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getProcessor())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_processor']),
                 Section::make(__('wpg_processing_record.step_receiver'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getReceiver())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_receiver']),
                 Section::make(__('wpg_processing_record.step_wpg_goal'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getProcessingGoal())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_wpg_goal']),
                 Section::make(__('wpg_processing_record.step_special_police_data'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getSpecialPoliceData())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_special_police_data']),
                 Section::make(__('wpg_processing_record.step_decision_making'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getDecisionMaking())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_decision_making']),
                 Section::make(__('wpg_processing_record.step_system_application'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getSystems())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_system_application']),
                 Section::make(__('wpg_processing_record.step_security'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getSecurity())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_security']),
                 Section::make(__('wpg_processing_record.step_geb_dpia'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getGebDpia())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_geb_dpia']),
                 Section::make(__('wpg_processing_record.step_contact_person'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getContactPersons())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_contact_person']),
                 Section::make(__('wpg_processing_record.step_attachments'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getAttachments())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_attachments']),
                 Section::make(__('wpg_processing_record.step_remarks'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getRemarks())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_remarks']),
                 Section::make(__('wpg_processing_record.step_categories_involved'))
                     ->schema(WpgProcessingRecordResourceInfolistSchemas::getCategoriesInvolved())
-                    ->compact()
-                    ->aside(),
+                    ->extraAttributes(['data-onepage-section' => 'step_categories_involved']),
             ]);
     }
 }


### PR DESCRIPTION
Vervolg op #71: dezelfde one-page behandeling voor de overige vier registers — Wpg, AVG Verwerker, Algoritmes en Datalekken. Geen nieuwe CSS of componenten; die zijn al gedeeld.

## Wijzigingen

Per register, formulier én infolist:

- `->compact()->aside()` verwijderd, zodat de velden de volle kolombreedte gebruiken in plaats van in `md:col-span-2` geperst te worden.
- `data-onepage-section` ankers toegevoegd, waarmee de bestaande snelnavigatie de secties oppikt.

| register | secties |
|---|---|
| Wpg Verantwoordelijke | 14 |
| AVG Verwerker | 14 |
| Algoritmes | 7 |
| Datalekken | 6 |

Layout-toggle toegevoegd aan alle bewerk- en bekijkpagina's. Voor de drie bekijkpagina's die `ProcessingRecordViewRecord` gebruiken kon dat in de basisklasse.

## Detectie van registerpagina's aangepast

De render hook keek of de pagina `ProcessingRecordEditRecord` of `ProcessingRecordViewRecord` was. Dat gaat mis bij `ViewDataBreachRecord`, die rechtstreeks van Filaments `ViewRecord` afstamt — daar zou de navigatie stilzwijgend niet renderen.

De controle kijkt nu of de resource in `ONE_PAGE_RESOURCES` staat. Dat is ook inhoudelijk de juiste vraag: de layout hoort bij de resource, niet bij de basisklasse. Andere resources (gebruikers, organisaties, keuzelijsten) blijven ongemoeid.

Alternatief was `ViewDataBreachRecord` van basisklasse laten wisselen, maar dat verandert ook header widgets en acties — meer dan hier nodig is.

## Getest

Alle acht pagina's in de browser gecontroleerd op 1680px; per pagina secties, navigatie-items, resterende `aside` en de toggle:

| pagina | secties | nav | aside | toggle |
|---|---|---|---|---|
| Wpg bewerken/bekijken | 14 | 14 | 0 | ja |
| AVG Verwerker bewerken/bekijken | 14 | 14 | 0 | ja |
| Algoritmes bewerken/bekijken | 7 | 7 | 0 | ja |
| Datalekken bewerken/bekijken | 6 | 6 | 0 | ja |

Verder:

- Navigatie stopt boven de knoppen op Wpg: onderkant 601 vs knoppen op 623, op alle geteste scrollposities.
- Een niet-registerpagina (Systemen/Applicaties bewerken) heeft geen layout, geen navigatie en geen toggle.

CI-commando lokaal: 1470 tests geslaagd, coverage 100.0%. phpcs, phpstan en phpmd schoon.