### PR TITLE
feat: actionable dashboard met werklijsten

### DIFF
--- a/src/cms/app/Filament/Pages/Dashboard.php
+++ b/src/cms/app/Filament/Pages/Dashboard.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Pages;
 
 use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\AwaitingEstablishmentWidget;
 use App\Filament\Widgets\MyApprovalsWidget;
 use App\Filament\Widgets\OpenDataBreachesWidget;
 use App\Filament\Widgets\OverdueItemsWidget;
@@ -43,6 +44,7 @@ class Dashboard extends BaseDashboard
     {
         return [
             MyApprovalsWidget::class,
+            AwaitingEstablishmentWidget::class,
             OpenDataBreachesWidget::class,
             OverdueItemsWidget::class,
             AllClearWidget::class,

--- a/src/cms/app/Filament/Pages/Dashboard.php
+++ b/src/cms/app/Filament/Pages/Dashboard.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Filament\Widgets\OpenDataBreachesWidget;
+use App\Filament\Widgets\OverdueItemsWidget;
+use Filament\Pages\Dashboard as BaseDashboard;
+use Filament\Widgets\Widget;
+use Filament\Widgets\WidgetConfiguration;
+
+use function __;
+
+/**
+ * The panel's landing page.
+ *
+ * Replaces Filament's stock dashboard, which showed only the framework's
+ * "welcome" and version widgets — nothing about the register a user opened the
+ * application to work on.
+ */
+class Dashboard extends BaseDashboard
+{
+    protected static ?string $navigationIcon = 'heroicon-o-home';
+    protected static ?int $navigationSort = -1;
+
+    public function getTitle(): string
+    {
+        return __('dashboard.title');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('dashboard.title');
+    }
+
+    /**
+     * @return array<class-string<Widget>|WidgetConfiguration>
+     */
+    public function getWidgets(): array
+    {
+        return [
+            MyApprovalsWidget::class,
+            OpenDataBreachesWidget::class,
+            OverdueItemsWidget::class,
+            AllClearWidget::class,
+        ];
+    }
+
+    /**
+     * @return int|array<string, ?int>
+     */
+    public function getColumns(): int|array
+    {
+        return 1;
+    }
+}

--- a/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceTable.php
+++ b/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/AvgProcessorProcessingRecordResourceTable.php
@@ -13,6 +13,7 @@ use App\Filament\Tables\Columns\ImportNumberColumn;
 use App\Filament\Tables\Columns\SnapshotStatusColumn;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
 use App\Filament\Tables\ContactPersonFilter;
+use App\Filament\Tables\DateWindowFilter;
 use App\Filament\Tables\DocumentFilter;
 use App\Filament\Tables\ProcessorFilter;
 use App\Filament\Tables\ReceiverFilter;
@@ -57,6 +58,8 @@ class AvgProcessorProcessingRecordResourceTable
                 TransferCopyBulkAction::make(),
             ])
             ->filters([
+                DateWindowFilter::make('review_at')
+                    ->label(__('general.review_at')),
                 ResponsibleFilter::make(),
                 ProcessorFilter::make(),
                 ReceiverFilter::make(),

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceTable.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/AvgResponsibleProcessingRecordResourceTable.php
@@ -14,6 +14,7 @@ use App\Filament\Tables\Columns\ImportNumberColumn;
 use App\Filament\Tables\Columns\SnapshotStatusColumn;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
 use App\Filament\Tables\ContactPersonFilter;
+use App\Filament\Tables\DateWindowFilter;
 use App\Filament\Tables\DocumentFilter;
 use App\Filament\Tables\ProcessorFilter;
 use App\Filament\Tables\ReceiverFilter;
@@ -59,6 +60,8 @@ class AvgResponsibleProcessingRecordResourceTable
                 TransferCopyBulkAction::make(),
             ])
             ->filters([
+                DateWindowFilter::make('review_at')
+                    ->label(__('general.review_at')),
                 TagFilter::make(),
                 ResponsibleFilter::make(),
                 ProcessorFilter::make(),

--- a/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceTable.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/DataBreachRecordResourceTable.php
@@ -10,6 +10,7 @@ use App\Filament\Tables\Columns\CreatedAtColumn;
 use App\Filament\Tables\Columns\EntityNumber;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
 use App\Filament\Tables\DocumentFilter;
+use App\Filament\Tables\OpenDataBreachFilter;
 use App\Filament\Tables\ResponsibleFilter;
 use App\Services\DateFormatService;
 use Filament\Tables\Actions\EditAction;
@@ -56,6 +57,7 @@ class DataBreachRecordResourceTable
                 TransferCopyBulkAction::make(),
             ])
             ->filters([
+                OpenDataBreachFilter::make(),
                 TernaryFilter::make('ap_reported')
                     ->label(__('data_breach_record.ap_reported')),
                 ResponsibleFilter::make(),

--- a/src/cms/app/Filament/Resources/DocumentResource/DocumentResourceTable.php
+++ b/src/cms/app/Filament/Resources/DocumentResource/DocumentResourceTable.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\DocumentResource;
 use App\Filament\Tables\Columns\CreatedAtColumn;
 use App\Filament\Tables\Columns\ExpiringDateColumn;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
+use App\Filament\Tables\DateWindowFilter;
 use App\Models\Document;
 use Filament\Tables\Actions\DeleteBulkAction;
 use Filament\Tables\Actions\EditAction;
@@ -40,6 +41,8 @@ class DocumentResourceTable
                 UpdatedAtColumn::make(),
             ])
             ->filters([
+                DateWindowFilter::make('expires_at')
+                    ->label(__('document.expires_at')),
                 SelectFilter::make('type')
                     ->relationship('documentType', 'name', static function (Builder $query): void {
                         $query->whereBelongsTo(Authentication::organisation());

--- a/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceTable.php
+++ b/src/cms/app/Filament/Resources/WpgProcessingRecordResource/WpgProcessingRecordResourceTable.php
@@ -13,6 +13,7 @@ use App\Filament\Tables\Columns\ImportNumberColumn;
 use App\Filament\Tables\Columns\SnapshotStatusColumn;
 use App\Filament\Tables\Columns\UpdatedAtColumn;
 use App\Filament\Tables\ContactPersonFilter;
+use App\Filament\Tables\DateWindowFilter;
 use App\Filament\Tables\DocumentFilter;
 use App\Filament\Tables\ProcessorFilter;
 use App\Filament\Tables\ResponsibleFilter;
@@ -56,6 +57,8 @@ class WpgProcessingRecordResourceTable
                 TransferCopyBulkAction::make(),
             ])
             ->filters([
+                DateWindowFilter::make('review_at')
+                    ->label(__('general.review_at')),
                 ResponsibleFilter::make(),
                 ProcessorFilter::make(),
                 SystemFilter::make(),

--- a/src/cms/app/Filament/Tables/DateWindowFilter.php
+++ b/src/cms/app/Filament/Tables/DateWindowFilter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Tables;
+
+use App\Services\Dashboard\DateWindow;
+use Filament\Tables\Filters\SelectFilter;
+use Illuminate\Database\Eloquent\Builder;
+
+use function __;
+use function is_string;
+
+/**
+ * Narrows a date column to what needs attention: dates already past, or coming
+ * up within a lead time. Offering both is what makes the column actionable —
+ * "verlopen" alone only ever reports work that is already too late.
+ *
+ * The boundary rules live in DateWindow so this filter and the dashboard counts
+ * that link to it can never disagree.
+ */
+class DateWindowFilter extends SelectFilter
+{
+    public const string OVERDUE = 'overdue';
+    public const string SOON = 'soon';
+
+    protected DateWindow $dateWindow;
+
+    public static function make(?string $name = null): static
+    {
+        return parent::make($name ?? 'date_window')
+            ->options([
+                self::OVERDUE => __('dashboard.filter.overdue'),
+                self::SOON => __('dashboard.filter.soon'),
+            ])
+            // Resolved per-request with the filter injected by type, so a
+            // ->dateWindow() set after make() is still honoured.
+            ->query(static function (Builder $query, array $data, DateWindowFilter $filter): void {
+                $value = $data['value'] ?? null;
+
+                if (!is_string($value)) {
+                    return;
+                }
+
+                $column = $filter->getAttribute();
+                $dateWindow = $filter->getDateWindow();
+
+                // Narrows in place: BaseFilter::apply() discards whatever a query
+                // callback returns and keeps mutating the builder it handed in.
+                match ($value) {
+                    self::OVERDUE => $dateWindow->overdue($query, $column),
+                    self::SOON => $dateWindow->soon($query, $column),
+                    default => $query,
+                };
+            });
+    }
+
+    public function dateWindow(DateWindow $dateWindow): static
+    {
+        $this->dateWindow = $dateWindow;
+
+        return $this;
+    }
+
+    public function getDateWindow(): DateWindow
+    {
+        return $this->dateWindow ??= new DateWindow();
+    }
+}

--- a/src/cms/app/Filament/Tables/OpenDataBreachFilter.php
+++ b/src/cms/app/Filament/Tables/OpenDataBreachFilter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Tables;
+
+use Filament\Tables\Filters\TernaryFilter;
+use Illuminate\Database\Eloquent\Builder;
+
+use function __;
+
+/**
+ * Splits data breaches on whether they are still being handled. A breach counts
+ * as open until completed_at is filled, which is the only field that marks the
+ * handling as finished.
+ */
+class OpenDataBreachFilter extends TernaryFilter
+{
+    public static function make(?string $name = null): static
+    {
+        return parent::make($name ?? 'open')
+            ->label(__('dashboard.filter.open_data_breach'))
+            ->queries(
+                true: static fn (Builder $query): Builder => $query->whereNull('completed_at'),
+                false: static fn (Builder $query): Builder => $query->whereNotNull('completed_at'),
+                blank: static fn (Builder $query): Builder => $query,
+            );
+    }
+}

--- a/src/cms/app/Filament/Tables/OpenDataBreachFilter.php
+++ b/src/cms/app/Filament/Tables/OpenDataBreachFilter.php
@@ -4,26 +4,53 @@ declare(strict_types=1);
 
 namespace App\Filament\Tables;
 
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\NoBreach;
 use Filament\Tables\Filters\TernaryFilter;
 use Illuminate\Database\Eloquent\Builder;
 
 use function __;
 
 /**
- * Splits data breaches on whether they are still being handled. A breach counts
- * as open until completed_at is filled, which is the only field that marks the
- * handling as finished.
+ * Splits data breaches on whether they are still being handled.
+ *
+ * A breach is finished once the state machine says so — closed, or assessed as
+ * not being a breach — or once completed_at is filled. That second check covers
+ * records from before the state machine existed, which can be finished while
+ * still sitting in the default state.
  */
 class OpenDataBreachFilter extends TernaryFilter
 {
+    private const array FINISHED_STATES = [Closed::class, NoBreach::class];
+
     public static function make(?string $name = null): static
     {
         return parent::make($name ?? 'open')
             ->label(__('dashboard.filter.open_data_breach'))
             ->queries(
-                true: static fn (Builder $query): Builder => $query->whereNull('completed_at'),
-                false: static fn (Builder $query): Builder => $query->whereNotNull('completed_at'),
+                true: static fn (Builder $query): Builder => $query
+                    ->whereNull('completed_at')
+                    ->whereNotIn('state', self::finishedStateNames()),
+                false: static fn (Builder $query): Builder => $query
+                    ->where(static function (Builder $query): void {
+                        $query->whereNotNull('completed_at')
+                            ->orWhereIn('state', self::finishedStateNames());
+                    }),
                 blank: static fn (Builder $query): Builder => $query,
             );
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function finishedStateNames(): array
+    {
+        $names = [];
+
+        foreach (self::FINISHED_STATES as $state) {
+            $names[] = $state::$name;
+        }
+
+        return $names;
     }
 }

--- a/src/cms/app/Filament/Widgets/AllClearWidget.php
+++ b/src/cms/app/Filament/Widgets/AllClearWidget.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Enums\Authorization\Permission;
+use App\Facades\Authorization;
+use Filament\Widgets\Widget;
+
+/**
+ * Shown only when every attention list is empty.
+ *
+ * Without it, a user with nothing to do gets a dashboard that is literally
+ * blank, which reads as a broken page rather than as good news. This says the
+ * quiet part out loud: there is nothing waiting for you.
+ *
+ * It asks each list widget whether it would render, so a new list added later
+ * only has to be named here to be accounted for.
+ */
+class AllClearWidget extends Widget
+{
+    /**
+     * The widgets whose absence means there is genuinely nothing to do.
+     */
+    private const array ATTENTION_WIDGETS = [
+        OpenDataBreachesWidget::class,
+        OverdueItemsWidget::class,
+        MyApprovalsWidget::class,
+    ];
+
+    // Last, so that on the one render where it appears it is not competing with
+    // anything; the sort is irrelevant when it is the only widget on the page.
+    protected static ?int $sort = 99;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.all-clear';
+
+    public static function canView(): bool
+    {
+        if (!self::hasAnyAttentionPermission()) {
+            return false;
+        }
+
+        foreach (self::ATTENTION_WIDGETS as $widget) {
+            if ($widget::canView()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Whether the viewer can see any of the things the lists report on.
+     *
+     * Without this a user who simply has no register permissions — the
+     * functional manager holds none — would be told that nothing requires their
+     * attention, which reads as "your register is clean" when it means "you
+     * cannot see the register at all".
+     */
+    private static function hasAnyAttentionPermission(): bool
+    {
+        $permissions = [
+            Permission::CORE_ENTITY_VIEW,
+            Permission::DOCUMENT_VIEW,
+            Permission::DATA_BREACH_RECORD_VIEW,
+            Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL,
+        ];
+
+        foreach ($permissions as $permission) {
+            if (Authorization::hasPermission($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/cms/app/Filament/Widgets/AllClearWidget.php
+++ b/src/cms/app/Filament/Widgets/AllClearWidget.php
@@ -9,7 +9,7 @@ use App\Facades\Authorization;
 use Filament\Widgets\Widget;
 
 /**
- * Shown only when every attention list is empty.
+ * Shown whenever every attention list is empty.
  *
  * Without it, a user with nothing to do gets a dashboard that is literally
  * blank, which reads as a broken page rather than as good news. This says the
@@ -17,6 +17,10 @@ use Filament\Widgets\Widget;
  *
  * It asks each list widget whether it would render, so a new list added later
  * only has to be named here to be accounted for.
+ *
+ * Someone who may see no register at all still gets a message; only the wording
+ * changes, via hasRegisterAccess(). Rendering nothing for them would leave the
+ * page blank, which is the failure this widget exists to prevent.
  */
 class AllClearWidget extends Widget
 {
@@ -27,6 +31,7 @@ class AllClearWidget extends Widget
         OpenDataBreachesWidget::class,
         OverdueItemsWidget::class,
         MyApprovalsWidget::class,
+        AwaitingEstablishmentWidget::class,
     ];
 
     // Last, so that on the one render where it appears it is not competing with
@@ -37,10 +42,6 @@ class AllClearWidget extends Widget
 
     public static function canView(): bool
     {
-        if (!self::hasAnyAttentionPermission()) {
-            return false;
-        }
-
         foreach (self::ATTENTION_WIDGETS as $widget) {
             if ($widget::canView()) {
                 return false;
@@ -51,12 +52,20 @@ class AllClearWidget extends Widget
     }
 
     /**
-     * Whether the viewer can see any of the things the lists report on.
+     * Whether the viewer can see the register the message talks about.
      *
-     * Without this a user who simply has no register permissions — the
-     * functional manager holds none — would be told that nothing requires their
-     * attention, which reads as "your register is clean" when it means "you
-     * cannot see the register at all".
+     * Drives the wording rather than whether the widget renders: a functional
+     * manager holds no register permissions, so telling them the register is
+     * clean would state something they cannot know. They still get a message —
+     * an empty page reads as broken — but one about their own dashboard.
+     */
+    public function hasRegisterAccess(): bool
+    {
+        return self::hasAnyAttentionPermission();
+    }
+
+    /**
+     * Whether the viewer can see any of the things the lists report on.
      */
     private static function hasAnyAttentionPermission(): bool
     {
@@ -65,6 +74,7 @@ class AllClearWidget extends Widget
             Permission::DOCUMENT_VIEW,
             Permission::DATA_BREACH_RECORD_VIEW,
             Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL,
+            Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
         ];
 
         foreach ($permissions as $permission) {

--- a/src/cms/app/Filament/Widgets/AwaitingEstablishmentWidget.php
+++ b/src/cms/app/Filament/Widgets/AwaitingEstablishmentWidget.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Collections\SnapshotCollection;
+use App\Enums\Authorization\Permission;
+use App\Facades\Authentication;
+use App\Facades\Authorization;
+use App\Filament\Resources\OrganisationSnapshotApprovalResource;
+use App\Services\Dashboard\AttentionCountService;
+use Filament\Widgets\Widget;
+
+use function app;
+
+/**
+ * Snapshots that have collected every signature and are now waiting to be
+ * established.
+ *
+ * This is the privacy officer's half of the approval round trip. Submitting a
+ * version for approval notifies the mandate holders, but nothing notified the
+ * officer once they had all signed, so the last step — establishing the version
+ * — was only found by opening the approval overview and reading the state of
+ * each row by hand.
+ *
+ * Gated on the permission to establish rather than on a role: it lists work only
+ * someone who may perform that transition can finish, and both the privacy
+ * officer and the chief privacy officer hold it.
+ *
+ * Hides itself when nothing is waiting.
+ */
+class AwaitingEstablishmentWidget extends Widget
+{
+    public const int LIMIT = 8;
+
+    // Directly after the personal signing list: both are approval work, and this
+    // one is only ever actionable by a different person than that list is.
+    protected static ?int $sort = 1;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.awaiting-establishment';
+
+    /** @var array<string, SnapshotCollection> */
+    private static array $snapshots = [];
+
+    public static function canView(): bool
+    {
+        if (!Authorization::hasPermission(Permission::SNAPSHOT_STATE_TO_ESTABLISHED)) {
+            return false;
+        }
+
+        return self::snapshots()->isNotEmpty();
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function getRows(): array
+    {
+        $rows = [];
+
+        foreach (self::snapshots() as $snapshot) {
+            $rows[] = [
+                'name' => $snapshot->name,
+                'waiting' => $snapshot->updated_at->diffForHumans(),
+                'url' => OrganisationSnapshotApprovalResource::getUrl('view', ['record' => $snapshot]),
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function getAllUrl(): string
+    {
+        return OrganisationSnapshotApprovalResource::getUrl();
+    }
+
+    public function hasMore(): bool
+    {
+        return self::snapshots()->count() >= self::LIMIT;
+    }
+
+    /**
+     * Resolved once per request: canView() and the view both need the rows, and
+     * Filament calls them separately.
+     *
+     * Keyed by organisation only. Unlike the personal signing list these rows are
+     * the same for everyone who may establish, so there is no second user whose
+     * view of them differs.
+     */
+    private static function snapshots(): SnapshotCollection
+    {
+        $organisation = Authentication::organisation();
+        $cacheKey = $organisation->id->toString();
+
+        if (!isset(self::$snapshots[$cacheKey])) {
+            self::$snapshots[$cacheKey] = app(AttentionCountService::class)
+                ->snapshotsAwaitingEstablishment($organisation, self::LIMIT);
+        }
+
+        return self::$snapshots[$cacheKey];
+    }
+}

--- a/src/cms/app/Filament/Widgets/MyApprovalsWidget.php
+++ b/src/cms/app/Filament/Widgets/MyApprovalsWidget.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Collections\SnapshotApprovalCollection;
+use App\Enums\Authorization\Permission;
+use App\Facades\Authentication;
+use App\Facades\Authorization;
+use App\Filament\Resources\PersonalSnapshotApprovalResource;
+use App\Services\Dashboard\AttentionCountService;
+use Filament\Widgets\Widget;
+
+use function app;
+
+/**
+ * Snapshots waiting for the signature of whoever is looking at the dashboard.
+ *
+ * For a mandate holder this is the whole job: they hold no register-editing
+ * permissions, so it is the only list on the page they can act on.
+ *
+ * Hides itself when nothing is waiting.
+ */
+class MyApprovalsWidget extends Widget
+{
+    public const int LIMIT = 8;
+
+    protected static ?int $sort = 0;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.my-approvals';
+
+    /** @var array<string, SnapshotApprovalCollection> */
+    private static array $approvals = [];
+
+    public static function canView(): bool
+    {
+        if (!Authorization::hasPermission(Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL)) {
+            return false;
+        }
+
+        return self::approvals()->isNotEmpty();
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function getRows(): array
+    {
+        $rows = [];
+
+        foreach (self::approvals() as $snapshotApproval) {
+            $snapshot = $snapshotApproval->snapshot;
+
+            $rows[] = [
+                'name' => $snapshot->name,
+                'requested' => $snapshotApproval->created_at->diffForHumans(),
+                'url' => PersonalSnapshotApprovalResource::getUrl('view', ['record' => $snapshot]),
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function getAllUrl(): string
+    {
+        return PersonalSnapshotApprovalResource::getUrl();
+    }
+
+    public function hasMore(): bool
+    {
+        return self::approvals()->count() >= self::LIMIT;
+    }
+
+    /**
+     * Resolved once per request: canView() and the view both need the rows, and
+     * Filament calls them separately.
+     *
+     * Keyed by user as well as organisation. These rows are personal — they are
+     * the approvals assigned to whoever is looking — so an organisation-only key
+     * would serve one user's worklist to the next user handled by the same PHP
+     * process.
+     */
+    private static function approvals(): SnapshotApprovalCollection
+    {
+        $organisation = Authentication::organisation();
+        $user = Authentication::user();
+        $cacheKey = $organisation->id->toString() . ':' . $user->id->toString();
+
+        if (!isset(self::$approvals[$cacheKey])) {
+            self::$approvals[$cacheKey] = app(AttentionCountService::class)
+                ->unsignedApprovalsFor($organisation, $user, self::LIMIT);
+        }
+
+        return self::$approvals[$cacheKey];
+    }
+}

--- a/src/cms/app/Filament/Widgets/OpenDataBreachesWidget.php
+++ b/src/cms/app/Filament/Widgets/OpenDataBreachesWidget.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Collections\DataBreachRecordCollection;
+use App\Enums\Authorization\Permission;
+use App\Facades\Authentication;
+use App\Facades\Authorization;
+use App\Filament\Resources\DataBreachRecordResource;
+use App\Services\Dashboard\AttentionCountService;
+use App\Services\Dashboard\DataBreachProgress;
+use Filament\Widgets\Widget;
+
+use function app;
+
+/**
+ * Data breaches whose handling is not yet finished.
+ *
+ * A breach stays on the list until completed_at is filled, which is the
+ * register's own record of the work being done. The list deliberately does not
+ * assert whether a breach had to be reported to the Autoriteit
+ * Persoonsgegevens — that depends on a risk assessment kept as free text — but
+ * it does mark a breach that is still open, not reported, and past the 72-hour
+ * mark of Article 33, because that is the point by which the decision should
+ * have been made.
+ *
+ * Hides itself when every breach has been handled.
+ */
+class OpenDataBreachesWidget extends Widget
+{
+    /**
+     * Enough rows to plan a morning's work. Beyond that the list stops being a
+     * worklist and becomes the register it links to.
+     */
+    public const int LIMIT = 8;
+
+    protected static ?int $sort = 1;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.open-data-breaches';
+
+    /** @var array<string, DataBreachRecordCollection> */
+    private static array $records = [];
+
+    public static function canView(): bool
+    {
+        if (!Authorization::hasPermission(Permission::DATA_BREACH_RECORD_VIEW)) {
+            return false;
+        }
+
+        return self::records()->isNotEmpty();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getRows(): array
+    {
+        $rows = [];
+
+        foreach (self::records() as $dataBreachRecord) {
+            $progress = DataBreachProgress::for($dataBreachRecord);
+
+            $rows[] = [
+                'number' => $dataBreachRecord->entityNumber?->number,
+                'name' => $dataBreachRecord->name,
+                'discovered' => $progress->discoveredLabel(),
+                'status' => $progress->statusLabel(),
+                'isUrgent' => $progress->needsUrgentAttention(),
+                'url' => DataBreachRecordResource::getUrl('edit', ['record' => $dataBreachRecord]),
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function getAllUrl(): string
+    {
+        return DataBreachRecordResource::getUrl(parameters: [
+            'tableFilters' => ['open' => ['value' => '1']],
+        ]);
+    }
+
+    public function hasMore(): bool
+    {
+        return self::records()->count() >= self::LIMIT;
+    }
+
+    /**
+     * Resolved once per request: canView() and the view both need the rows, and
+     * Filament calls them separately.
+     */
+    private static function records(): DataBreachRecordCollection
+    {
+        $organisation = Authentication::organisation();
+        $cacheKey = $organisation->id->toString();
+
+        if (!isset(self::$records[$cacheKey])) {
+            self::$records[$cacheKey] = app(AttentionCountService::class)
+                ->openDataBreachRecords($organisation, self::LIMIT);
+        }
+
+        return self::$records[$cacheKey];
+    }
+}

--- a/src/cms/app/Filament/Widgets/OverdueItemsWidget.php
+++ b/src/cms/app/Filament/Widgets/OverdueItemsWidget.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Enums\Authorization\Permission;
+use App\Facades\Authentication;
+use App\Facades\Authorization;
+use App\Services\Dashboard\AttentionCountService;
+use App\Services\Dashboard\OverdueItem;
+use App\Services\DateFormatService;
+use Filament\Widgets\Widget;
+
+use function app;
+use function count;
+
+/**
+ * Register items past their periodic review and documents past their expiry,
+ * most overdue first.
+ *
+ * Until now these were only visible as a red cell inside three separate
+ * register tables, with no notification and no way to filter, so finding them
+ * meant opening each register and sorting it by hand.
+ *
+ * Hides itself when nothing is overdue.
+ */
+class OverdueItemsWidget extends Widget
+{
+    public const int LIMIT = 8;
+
+    protected static ?int $sort = 2;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.overdue-items';
+
+    /** @var array<string, array<int, OverdueItem>> */
+    private static array $items = [];
+
+    public static function canView(): bool
+    {
+        if (!Authorization::hasPermission(Permission::CORE_ENTITY_VIEW)) {
+            return false;
+        }
+
+        return count(self::items()) > 0;
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function getRows(): array
+    {
+        $rows = [];
+
+        foreach (self::items() as $item) {
+            $rows[] = [
+                'name' => $item->name,
+                'type' => $item->type,
+                'kind' => $item->kind,
+                'date' => DateFormatService::toDate($item->date) ?? '',
+                'url' => $item->url,
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function hasMore(): bool
+    {
+        return count(self::items()) >= self::LIMIT;
+    }
+
+    /**
+     * Resolved once per request: canView() and the view both need the rows.
+     *
+     * @return array<int, OverdueItem>
+     */
+    private static function items(): array
+    {
+        $organisation = Authentication::organisation();
+        $cacheKey = $organisation->id->toString();
+
+        if (!isset(self::$items[$cacheKey])) {
+            self::$items[$cacheKey] = app(AttentionCountService::class)
+                ->overdueItems($organisation, self::LIMIT);
+        }
+
+        return self::$items[$cacheKey];
+    }
+}

--- a/src/cms/app/Providers/FilamentServiceProvider.php
+++ b/src/cms/app/Providers/FilamentServiceProvider.php
@@ -29,8 +29,6 @@ use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentColor;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
-use Filament\Widgets\AccountWidget;
-use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Cookie\Middleware\EncryptCookies;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -136,10 +134,6 @@ class FilamentServiceProvider extends PanelProvider
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\\Filament\\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\\Filament\\Pages')
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
-            ->widgets([
-                AccountWidget::class,
-                FilamentInfoWidget::class,
-            ])
             ->databaseNotifications()
             ->databaseNotificationsPolling(null)
             ->middleware([

--- a/src/cms/app/Services/Dashboard/AttentionCountService.php
+++ b/src/cms/app/Services/Dashboard/AttentionCountService.php
@@ -6,6 +6,8 @@ namespace App\Services\Dashboard;
 
 use App\Collections\DataBreachRecordCollection;
 use App\Collections\SnapshotApprovalCollection;
+use App\Enums\Authorization\Permission;
+use App\Facades\Authorization;
 use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 use App\Filament\Resources\Resource;
@@ -13,6 +15,8 @@ use App\Filament\Resources\WpgProcessingRecordResource;
 use App\Models\Document;
 use App\Models\Organisation;
 use App\Models\SnapshotApproval;
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\NoBreach;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -102,11 +106,14 @@ readonly class AttentionCountService
     /**
      * Data breaches whose handling is not finished, longest open first.
      *
-     * Scoped on completed_at alone rather than on ap_reported: whether a breach
-     * had to be reported to the Autoriteit Persoonsgegevens depends on the risk
-     * it poses, which the register keeps as free text in estimated_risk. A
-     * breach that was correctly assessed as not notifiable and then closed is
-     * finished work, and filtering on ap_reported would keep flagging it.
+     * "Finished" comes from the state machine: closed, or assessed as not being
+     * a breach at all. Not from ap_reported — whether a report to the Autoriteit
+     * Persoonsgegevens was required depends on the risk to those involved, and a
+     * breach correctly judged not notifiable is done, not overdue.
+     *
+     * completed_at is checked as well because it predates the state machine and
+     * is still filled in by hand, so older records can be finished without ever
+     * having left the default state.
      *
      * Breaches without a discovery date sort last: they need attention, but a
      * handful of them must never push every dated breach off a capped list.
@@ -115,6 +122,7 @@ readonly class AttentionCountService
     {
         $dataBreachRecords = $organisation->dataBreachRecords()
             ->whereNull('completed_at')
+            ->whereNotIn('state', [Closed::$name, NoBreach::$name])
             ->orderByRaw('discovered_at is null')
             ->orderBy('discovered_at')
             ->limit($limit)
@@ -163,12 +171,17 @@ readonly class AttentionCountService
             }
         }
 
-        $documents = $this->dateWindow->overdue($organisation->documents()->getQuery(), 'expires_at')->get();
+        // Documents carry their own view permission. Every role that may see
+        // core entities happens to hold it too, but that is configuration
+        // rather than a guarantee, so the two are checked separately here.
+        if (Authorization::hasPermission(Permission::DOCUMENT_VIEW)) {
+            $documents = $this->dateWindow->overdue($organisation->documents()->getQuery(), 'expires_at')->get();
 
-        foreach ($documents as $document) {
-            Assert::isInstanceOf($document, Document::class);
+            foreach ($documents as $document) {
+                Assert::isInstanceOf($document, Document::class);
 
-            $items[] = OverdueItem::forDocument($document);
+                $items[] = OverdueItem::forDocument($document);
+            }
         }
 
         usort($items, static function (OverdueItem $a, OverdueItem $b): int {

--- a/src/cms/app/Services/Dashboard/AttentionCountService.php
+++ b/src/cms/app/Services/Dashboard/AttentionCountService.php
@@ -6,7 +6,9 @@ namespace App\Services\Dashboard;
 
 use App\Collections\DataBreachRecordCollection;
 use App\Collections\SnapshotApprovalCollection;
+use App\Collections\SnapshotCollection;
 use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
 use App\Facades\Authorization;
 use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
@@ -17,6 +19,7 @@ use App\Models\Organisation;
 use App\Models\SnapshotApproval;
 use App\Models\States\DataBreachRecord\Closed;
 use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\Snapshot\Approved;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -149,6 +152,57 @@ readonly class AttentionCountService
         Assert::isInstanceOf($snapshotApprovals, SnapshotApprovalCollection::class);
 
         return $snapshotApprovals;
+    }
+
+    /**
+     * Snapshots that have been through approval and are now waiting to be
+     * established, longest waiting first.
+     *
+     * "Waiting" is the combination of two things, because neither alone means
+     * it: the snapshot sits in the approved state — it was submitted for
+     * approval, which is what notified the mandate holders — and every approval
+     * on it has been signed. A snapshot still missing a signature is the mandate
+     * holders' work, not the privacy officer's, and appears on their own list.
+     *
+     * Signed covers declined as well as approved. A declined signature is an
+     * answer, and the decision about what to do with it is the privacy
+     * officer's to make; leaving those rows off would hide a snapshot that no
+     * one is going to act on otherwise.
+     *
+     * Snapshots carrying no approvals at all are excluded. They cannot have been
+     * signed, so counting their empty approval list as "all signed" would put a
+     * snapshot on this list the moment it was submitted, before anyone had
+     * looked at it.
+     */
+    public function snapshotsAwaitingEstablishment(Organisation $organisation, int $limit): SnapshotCollection
+    {
+        $snapshots = $organisation->snapshots()
+            ->getQuery()
+            ->whereState('state', Approved::class)
+            ->whereHas('snapshotApprovals')
+            ->whereDoesntHave('snapshotApprovals', $this->unsignedApproval(...))
+            ->reorder()
+            ->orderBy('updated_at')
+            ->limit($limit)
+            ->get();
+
+        Assert::isInstanceOf($snapshots, SnapshotCollection::class);
+
+        return $snapshots;
+    }
+
+    /**
+     * Constrains an approval subquery to the signatures still outstanding.
+     *
+     * A named method rather than a closure inline: the relation resolves to the
+     * approval model's own builder, so a closure typed against that builder does
+     * not match the generic signature whereDoesntHave() declares.
+     *
+     * @param Builder<SnapshotApproval> $query
+     */
+    private function unsignedApproval(Builder $query): void
+    {
+        $query->whereIn('status', SnapshotApprovalStatus::unsigned());
     }
 
     /**

--- a/src/cms/app/Services/Dashboard/AttentionCountService.php
+++ b/src/cms/app/Services/Dashboard/AttentionCountService.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Dashboard;
+
+use App\Collections\DataBreachRecordCollection;
+use App\Collections\SnapshotApprovalCollection;
+use App\Filament\Resources\AvgProcessorProcessingRecordResource;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
+use App\Filament\Resources\Resource;
+use App\Filament\Resources\WpgProcessingRecordResource;
+use App\Models\Document;
+use App\Models\Organisation;
+use App\Models\SnapshotApproval;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Webmozart\Assert\Assert;
+
+use function __;
+use function array_slice;
+use function usort;
+
+/**
+ * Counts the work waiting for a user in one organisation.
+ *
+ * Everything here is scoped explicitly to the organisation passed in. The models
+ * carry no tenant global scope — Filament scopes its resources through the
+ * organisation relationship instead — so a query written against a model class
+ * directly would silently count every organisation's rows.
+ *
+ * Date categories are split into overdue and upcoming. The two are disjoint (a
+ * date is either before today or from today onwards), so a caller may add them
+ * for a combined total without double-counting.
+ */
+readonly class AttentionCountService
+{
+    public function __construct(
+        private DateWindow $dateWindow = new DateWindow(),
+    ) {
+    }
+
+    /**
+     * Processing records whose periodic review date has passed.
+     */
+    public function reviewsOverdue(Organisation $organisation): int
+    {
+        return $this->countAcrossReviewables(
+            $organisation,
+            fn (Builder $query): Builder => $this->dateWindow->overdue($query, 'review_at'),
+        );
+    }
+
+    /**
+     * Processing records due for review between today and the horizon.
+     */
+    public function reviewsSoon(Organisation $organisation): int
+    {
+        return $this->countAcrossReviewables(
+            $organisation,
+            fn (Builder $query): Builder => $this->dateWindow->soon($query, 'review_at'),
+        );
+    }
+
+    public function documentsExpired(Organisation $organisation): int
+    {
+        return $this->dateWindow->overdue($organisation->documents()->getQuery(), 'expires_at')->count();
+    }
+
+    public function documentsExpiringSoon(Organisation $organisation): int
+    {
+        return $this->dateWindow->soon($organisation->documents()->getQuery(), 'expires_at')->count();
+    }
+
+    /**
+     * Approvals still awaiting this user's signature in this organisation.
+     *
+     * Scoped through the snapshot's organisation rather than the assignment,
+     * because an approval row itself has no organisation; a mandate holder
+     * active in several organisations would otherwise see one combined number.
+     */
+    public function unsignedApprovals(Organisation $organisation, User $user): int
+    {
+        return SnapshotApproval::unsigned()
+            ->assignedTo($user)
+            ->whereSnapshotOrganisation($organisation)
+            ->count();
+    }
+
+    /**
+     * Data breaches still being handled. completed_at is the only field marking
+     * the handling as finished.
+     */
+    public function openDataBreaches(Organisation $organisation): int
+    {
+        return $organisation->dataBreachRecords()
+            ->whereNull('completed_at')
+            ->count();
+    }
+
+    /**
+     * Data breaches whose handling is not finished, longest open first.
+     *
+     * Scoped on completed_at alone rather than on ap_reported: whether a breach
+     * had to be reported to the Autoriteit Persoonsgegevens depends on the risk
+     * it poses, which the register keeps as free text in estimated_risk. A
+     * breach that was correctly assessed as not notifiable and then closed is
+     * finished work, and filtering on ap_reported would keep flagging it.
+     *
+     * Breaches without a discovery date sort last: they need attention, but a
+     * handful of them must never push every dated breach off a capped list.
+     */
+    public function openDataBreachRecords(Organisation $organisation, int $limit): DataBreachRecordCollection
+    {
+        $dataBreachRecords = $organisation->dataBreachRecords()
+            ->whereNull('completed_at')
+            ->orderByRaw('discovered_at is null')
+            ->orderBy('discovered_at')
+            ->limit($limit)
+            ->get();
+
+        Assert::isInstanceOf($dataBreachRecords, DataBreachRecordCollection::class);
+
+        return $dataBreachRecords;
+    }
+
+    /**
+     * The snapshots waiting for this user's signature, oldest request first.
+     */
+    public function unsignedApprovalsFor(Organisation $organisation, User $user, int $limit): SnapshotApprovalCollection
+    {
+        $snapshotApprovals = SnapshotApproval::unsigned()
+            ->assignedTo($user)
+            ->whereSnapshotOrganisation($organisation)
+            ->with('snapshot')
+            ->orderBy('created_at')
+            ->limit($limit)
+            ->get();
+
+        Assert::isInstanceOf($snapshotApprovals, SnapshotApprovalCollection::class);
+
+        return $snapshotApprovals;
+    }
+
+    /**
+     * The register items and documents whose date has passed, most overdue
+     * first, across every register that carries one.
+     *
+     * Merged into a single list rather than one per register because the
+     * question it answers — what do I fix first — does not care which register
+     * an item lives in.
+     *
+     * @return array<int, OverdueItem>
+     */
+    public function overdueItems(Organisation $organisation, int $limit): array
+    {
+        $items = [];
+
+        foreach ($this->reviewableRegisters($organisation) as [$filamentResource, $type, $query]) {
+            foreach ($this->dateWindow->overdue($query, 'review_at')->get() as $record) {
+                $items[] = OverdueItem::forReview($record, $filamentResource, $type);
+            }
+        }
+
+        $documents = $this->dateWindow->overdue($organisation->documents()->getQuery(), 'expires_at')->get();
+
+        foreach ($documents as $document) {
+            Assert::isInstanceOf($document, Document::class);
+
+            $items[] = OverdueItem::forDocument($document);
+        }
+
+        usort($items, static function (OverdueItem $a, OverdueItem $b): int {
+            return $a->date <=> $b->date;
+        });
+
+        return array_slice($items, 0, $limit);
+    }
+
+    /**
+     * Sums a review-date constraint over the three registers that carry one.
+     * Algorithm and data breach records are deliberately absent: neither has a
+     * review_at column.
+     *
+     * @param callable(Builder<covariant Model>): Builder<covariant Model> $constrain
+     */
+    private function countAcrossReviewables(Organisation $organisation, callable $constrain): int
+    {
+        $total = 0;
+
+        foreach ($this->reviewableRegisters($organisation) as [, , $query]) {
+            $total += $constrain($query)->count();
+        }
+
+        return $total;
+    }
+
+    /**
+     * The registers carrying a periodic review date: the Filament resource that
+     * owns each one so a caller can link back to it, a short label for listing
+     * the record among other types, and the tenant-scoped query.
+     *
+     * @return array<int, array{class-string<Resource>, string, Builder<covariant Model>}>
+     */
+    private function reviewableRegisters(Organisation $organisation): array
+    {
+        return [
+            [
+                AvgResponsibleProcessingRecordResource::class,
+                __('dashboard.type.avg_responsible'),
+                $organisation->avgResponsibleProcessingRecords()->getQuery(),
+            ],
+            [
+                AvgProcessorProcessingRecordResource::class,
+                __('dashboard.type.avg_processor'),
+                $organisation->avgProcessorProcessingRecords()->getQuery(),
+            ],
+            [
+                WpgProcessingRecordResource::class,
+                __('dashboard.type.wpg'),
+                $organisation->wpgProcessingRecords()->getQuery(),
+            ],
+        ];
+    }
+}

--- a/src/cms/app/Services/Dashboard/DataBreachProgress.php
+++ b/src/cms/app/Services/Dashboard/DataBreachProgress.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Dashboard;
+
+use App\Models\DataBreachRecord;
+use Carbon\CarbonImmutable;
+
+use function __;
+
+/**
+ * How far along the handling of one data breach is.
+ *
+ * Deliberately does not judge whether the breach had to be reported to the
+ * Autoriteit Persoonsgegevens. Article 33 only obliges notification when the
+ * breach is likely to result in a risk to the rights and freedoms of natural
+ * persons, and that assessment lives in estimated_risk as free text — the
+ * register has no field saying "assessed as not notifiable". Deriving a missed
+ * deadline from ap_reported alone would therefore mark every correctly
+ * unreported low-risk breach as overdue, forever.
+ *
+ * What can honestly be said is how long a breach has been open, since
+ * completed_at is the register's own record of the handling being finished.
+ */
+final readonly class DataBreachProgress
+{
+    /**
+     * Article 33 GDPR: notification to the supervisory authority is due without
+     * undue delay and, where feasible, within 72 hours of becoming aware. Used
+     * only to draw attention to a breach that is both open and past that mark,
+     * never to assert that a report was required.
+     */
+    public const int NOTIFICATION_WINDOW_IN_HOURS = 72;
+
+    private function __construct(
+        private ?CarbonImmutable $discoveredAt,
+        private bool $apReported,
+    ) {
+    }
+
+    public static function for(DataBreachRecord $dataBreachRecord): self
+    {
+        return new self($dataBreachRecord->discovered_at, $dataBreachRecord->ap_reported);
+    }
+
+    /**
+     * Whether this row should stand out: still open, not yet reported to the AP,
+     * and past the point where that decision should have been made.
+     *
+     * "Should have been decided by now" — not "is too late to report".
+     */
+    public function needsUrgentAttention(): bool
+    {
+        if ($this->apReported || $this->discoveredAt === null) {
+            return false;
+        }
+
+        return $this->discoveredAt
+            ->addHours(self::NOTIFICATION_WINDOW_IN_HOURS)
+            ->isPast();
+    }
+
+    /**
+     * How long the breach has been open, which is the thing a privacy officer
+     * is weighing. Relative rather than an absolute date: the question is how
+     * long this has been sitting, not which calendar day it happened.
+     */
+    public function discoveredLabel(): string
+    {
+        if ($this->discoveredAt === null) {
+            return __('dashboard.breach.discovered_unknown');
+        }
+
+        return __('dashboard.breach.open_for', [
+            'duration' => $this->discoveredAt->diffForHumans(syntax: CarbonImmutable::DIFF_ABSOLUTE),
+        ]);
+    }
+
+    /**
+     * What is still outstanding, phrased as a state of the record rather than as
+     * a verdict on the reporting obligation.
+     */
+    public function statusLabel(): string
+    {
+        if ($this->discoveredAt === null) {
+            return __('dashboard.breach.no_discovery_date');
+        }
+
+        if (!$this->apReported) {
+            return __('dashboard.breach.ap_decision_open');
+        }
+
+        return __('dashboard.breach.in_progress');
+    }
+}

--- a/src/cms/app/Services/Dashboard/DateWindow.php
+++ b/src/cms/app/Services/Dashboard/DateWindow.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Dashboard;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * The two halves of "this date needs attention": already past, and coming up
+ * within a lead time.
+ *
+ * Single home for the boundary rules so the dashboard counts and the table
+ * filters can never disagree about what "verlopen" means — a stat linking to a
+ * filtered table that shows a different number is worse than no stat.
+ *
+ * The halves are disjoint and meet at today: a date before today is overdue, a
+ * date from today up to the horizon is upcoming. Callers may therefore add the
+ * two counts without double-counting.
+ */
+final readonly class DateWindow
+{
+    /**
+     * Matches the longest notification lead time offered on documents
+     * (document.notification_options.3_months_before), so a reminder a user sets
+     * on a document and this window speak about the same period.
+     */
+    public const int DEFAULT_SOON_IN_MONTHS = 3;
+
+    public function __construct(
+        public int $soonInMonths = self::DEFAULT_SOON_IN_MONTHS,
+    ) {
+    }
+
+    /**
+     * Strictly before today. A date of today is still due rather than overdue,
+     * and is reported by soon().
+     *
+     * @param Builder<covariant Model> $query
+     *
+     * @return Builder<covariant Model>
+     */
+    public function overdue(Builder $query, string $column): Builder
+    {
+        return $query->whereNotNull($column)
+            ->whereDate($column, '<', CarbonImmutable::today());
+    }
+
+    /**
+     * Today up to and including the horizon.
+     *
+     * @param Builder<covariant Model> $query
+     *
+     * @return Builder<covariant Model>
+     */
+    public function soon(Builder $query, string $column): Builder
+    {
+        $today = CarbonImmutable::today();
+
+        return $query->whereNotNull($column)
+            ->whereDate($column, '>=', $today)
+            ->whereDate($column, '<=', $today->addMonths($this->soonInMonths));
+    }
+}

--- a/src/cms/app/Services/Dashboard/OverdueItem.php
+++ b/src/cms/app/Services/Dashboard/OverdueItem.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Dashboard;
+
+use App\Filament\Resources\DocumentResource;
+use App\Filament\Resources\Resource;
+use App\Models\Document;
+use App\Models\DocumentType;
+use App\ValueObjects\CalendarDate;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Webmozart\Assert\Assert;
+
+use function __;
+
+/**
+ * One row of the "wat is er verlopen" list: a register item past its review
+ * date, or a document past its expiry.
+ *
+ * The two are different models with different date columns and different
+ * owning resources, but the same thing to a user — something whose date has
+ * passed — so they are flattened into one comparable shape here rather than
+ * being kept apart all the way into the view.
+ */
+final readonly class OverdueItem
+{
+    /**
+     * The two sources store their date differently — review_at is a
+     * CalendarDate, documents.expires_at a plain date cast — so the row holds a
+     * CarbonImmutable and each factory normalises into it. Keeping both types
+     * here would push that difference into every consumer.
+     */
+    private function __construct(
+        public string $name,
+        public CarbonImmutable $date,
+        public string $type,
+        public string $kind,
+        public string $url,
+    ) {
+    }
+
+    /**
+     * @param class-string<Resource> $filamentResource
+     */
+    public static function forReview(Model $record, string $filamentResource, string $type): self
+    {
+        $reviewAt = $record->getAttribute('review_at');
+        Assert::isInstanceOf($reviewAt, CalendarDate::class);
+
+        $name = $record->getAttribute('name');
+        Assert::string($name);
+
+        return new self(
+            $name,
+            CarbonImmutable::parse((string) $reviewAt),
+            $type,
+            __('general.review_at'),
+            $filamentResource::getUrl('edit', ['record' => $record]),
+        );
+    }
+
+    public static function forDocument(Document $document): self
+    {
+        $expiresAt = $document->getAttribute('expires_at');
+        Assert::isInstanceOf($expiresAt, CarbonInterface::class);
+
+        // The document's own type ("DPIA", "Verwerkersovereenkomst") rather than
+        // the generic model label: it is what distinguishes one document from
+        // another in a mixed list. Read off the relation rather than through
+        // ->documentType, whose generic claims a DocumentType is always present
+        // while document_type_id is nullable and the form does not require it.
+        $documentType = $document->getAttribute('documentType');
+        $type = $documentType instanceof DocumentType
+            ? $documentType->name
+            : __('document.model_singular');
+
+        return new self(
+            $document->name,
+            CarbonImmutable::instance($expiresAt),
+            $type,
+            __('document.expires_at'),
+            DocumentResource::getUrl('edit', ['record' => $document]),
+        );
+    }
+}

--- a/src/cms/database/seeders/DemoContent.php
+++ b/src/cms/database/seeders/DemoContent.php
@@ -208,7 +208,8 @@ final class DemoContent
             'receivers' => [1, 3],
             'tags' => [0, 4, 5],
             'state' => 'established',
-            'review_offset_months' => 2,
+            // Overdue: shows how a lapsed periodic review reads on the dashboard.
+            'review_offset_months' => -5,
             'dpia' => true,
             'outside_eu' => false,
             'description' => 'Gezondheidsgegevens worden uitsluitend verwerkt door de arbodienst. '
@@ -525,6 +526,21 @@ final class DemoContent
             'type' => 'DPIA',
             'location' => 'Documentbeheer — map Privacy/DPIA',
             'expires_offset_months' => -2,
+        ],
+        [
+            // Expired: a lapsed processor agreement is the classic finding in an
+            // audit, and shows a second document type on the overdue list.
+            'name' => 'Verwerkersovereenkomst Salarisservice Van Dijk B.V.',
+            'type' => 'Verwerkersovereenkomst',
+            'location' => 'Contractbeheer — dossier leveranciers',
+            'expires_offset_months' => -7,
+        ],
+        [
+            // Expired longest, so it heads the list and shows the ordering.
+            'name' => 'Bewerkersprotocol gemeentelijke basisadministratie',
+            'type' => 'Beveiligingsbeleid',
+            'location' => 'Intranet — Beleid en kaders',
+            'expires_offset_months' => -14,
         ],
         [
             'name' => 'Verwerkersovereenkomst AFAS Software B.V.',

--- a/src/cms/database/seeders/DemoRegisterSeeder.php
+++ b/src/cms/database/seeders/DemoRegisterSeeder.php
@@ -67,7 +67,9 @@ final class DemoRegisterSeeder
                     'responsibility_distribution' => $definition['description'],
                     'outside_eu' => false,
                     'decision_making' => false,
-                    'review_at' => now()->addMonths(14)->toDateString(),
+                    // Due inside the three-month window, so the "verloopt
+                    // binnenkort" filter has something to find.
+                    'review_at' => now()->addMonths(2)->toDateString(),
                 ]);
 
             $record->responsibles()->attach($related->responsible->id);
@@ -113,7 +115,9 @@ final class DemoRegisterSeeder
                     . 'bevoegde instanties op grond van de Wet politiegegevens.',
                 'explanation_transfer' => 'Er vindt geen doorgifte plaats naar landen buiten de EER.',
 
-                'review_at' => now()->addMonths(10)->toDateString(),
+                // Overdue on purpose: puts a Wpg record on the dashboard's
+                // overdue list, so it shows more than one register type.
+                'review_at' => now()->subMonths(3)->toDateString(),
             ]);
 
             $snapshot = $this->makeSnapshot(

--- a/src/cms/phpstan-baseline.neon
+++ b/src/cms/phpstan-baseline.neon
@@ -243,5 +243,23 @@ parameters:
 		-
 			message: '#^Dynamic call to static method App\\Models\\Builders\\SnapshotApprovalBuilder\:\:count\(\)\.$#'
 			identifier: staticMethod.dynamicCall
+			count: 1
+			path: app/Services/Dashboard/AttentionCountService.php
+
+		-
+			message: '#^Dynamic call to static method App\\Models\\Builders\\SnapshotApprovalBuilder\:\:limit\(\)\.$#'
+			identifier: staticMethod.dynamicCall
+			count: 1
+			path: app/Services/Dashboard/AttentionCountService.php
+
+		-
+			message: '#^Dynamic call to static method App\\Models\\Builders\\SnapshotApprovalBuilder\:\:orderBy\(\)\.$#'
+			identifier: staticMethod.dynamicCall
+			count: 1
+			path: app/Services/Dashboard/AttentionCountService.php
+
+		-
+			message: '#^Dynamic call to static method App\\Models\\Builders\\SnapshotApprovalBuilder\:\:count\(\)\.$#'
+			identifier: staticMethod.dynamicCall
 			count: 2
 			path: app/Services/Snapshot/SnapshotService.php

--- a/src/cms/resources/lang/nl/dashboard.php
+++ b/src/cms/resources/lang/nl/dashboard.php
@@ -24,8 +24,20 @@ return [
     'show_all' => 'Toon alle',
 
     'all_clear' => [
-        'heading' => 'Niets vereist op dit moment uw aandacht',
-        'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen of te ondertekenen versies.',
+        'heading' => 'Geen openstaande acties binnen dit verwerkingsregister',
+        'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen, '
+            . 'te ondertekenen versies of versies die op vaststelling wachten.',
+
+        /**
+         * For someone without register permissions — the functioneel beheerder.
+         * Deliberately says nothing about the register being clean: they cannot
+         * see it, so that would be a claim they have no way to check.
+         */
+        'no_register' => [
+            'heading' => 'Geen openstaande acties',
+            'description' => 'Uw rol heeft geen taken in het verwerkingsregister. '
+                . 'Gebruik het menu om organisaties en gebruikers te beheren.',
+        ],
     ],
 
     'overdue' => [
@@ -49,6 +61,13 @@ return [
     'approvals' => [
         'heading' => 'Te ondertekenen',
         'description' => 'Versies die op uw handtekening wachten.',
+    ],
+
+    'awaiting_establishment' => [
+        'heading' => 'Vast te stellen',
+        'description' => 'Versies die ter goedkeuring zijn aangeboden en volledig zijn ondertekend. '
+            . 'U kunt ze beoordelen en vaststellen.',
+        'signed' => 'Volledig ondertekend',
     ],
 
     'breach' => [

--- a/src/cms/resources/lang/nl/dashboard.php
+++ b/src/cms/resources/lang/nl/dashboard.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'title' => 'Overzicht',
+
+    'attention' => [
+        'heading' => 'Vereist uw aandacht',
+        'review_overdue' => 'Reviews verlopen',
+        'review_soon' => 'Reviews binnenkort',
+        'document_expired' => 'Documenten verlopen',
+        'document_soon' => 'Documenten verlopen binnenkort',
+        'unsigned_approvals' => 'Te ondertekenen',
+        'open_data_breaches' => 'Open datalekken',
+    ],
+
+    'filter' => [
+        'overdue' => 'Verlopen',
+        'soon' => 'Verloopt binnenkort',
+        'open_data_breach' => 'Nog in behandeling',
+    ],
+
+    'show_all' => 'Toon alle',
+
+    'all_clear' => [
+        'heading' => 'Niets vereist op dit moment uw aandacht',
+        'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen of te ondertekenen versies.',
+    ],
+
+    'overdue' => [
+        'heading' => 'Verlopen',
+        'description' => 'Verwerkingen waarvan de periodieke review is verstreken en documenten die zijn vervallen.',
+    ],
+
+    /**
+     * Short type labels for the lists. The resources' own model_singular values
+     * ("Verwerking AVG verantwoordelijke") title a whole page and are too long
+     * to sit under every row; these say the same thing at a glance. Kept here
+     * rather than shortening model_singular, which the navigation and page
+     * headings depend on.
+     */
+    'type' => [
+        'avg_responsible' => 'AVG verantwoordelijke',
+        'avg_processor' => 'AVG verwerker',
+        'wpg' => 'WPG verantwoordelijke',
+    ],
+
+    'approvals' => [
+        'heading' => 'Te ondertekenen',
+        'description' => 'Versies die op uw handtekening wachten.',
+    ],
+
+    'breach' => [
+        'heading' => 'Datalekken in behandeling',
+        'description' => 'Datalekken die nog niet zijn afgerond. Of een melding bij de Autoriteit '
+            . 'Persoonsgegevens nodig is, hangt af van het risico voor de betrokkenen.',
+        'discovered_unknown' => 'Ontdekkingsdatum onbekend',
+        'no_discovery_date' => 'Vul ontdekkingsdatum in',
+        'open_for' => ':duration open',
+        'ap_decision_open' => 'Meldplicht nog te beoordelen',
+        'in_progress' => 'In behandeling',
+    ],
+];

--- a/src/cms/resources/views/filament/widgets/all-clear.blade.php
+++ b/src/cms/resources/views/filament/widgets/all-clear.blade.php
@@ -7,12 +7,21 @@
             />
 
             <div>
-                <p class="text-sm font-medium text-gray-950 dark:text-white">
-                    {{ __('dashboard.all_clear.heading') }}
-                </p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                    {{ __('dashboard.all_clear.description') }}
-                </p>
+                @if ($this->hasRegisterAccess())
+                    <p class="text-sm font-medium text-gray-950 dark:text-white">
+                        {{ __('dashboard.all_clear.heading') }}
+                    </p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('dashboard.all_clear.description') }}
+                    </p>
+                @else
+                    <p class="text-sm font-medium text-gray-950 dark:text-white">
+                        {{ __('dashboard.all_clear.no_register.heading') }}
+                    </p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('dashboard.all_clear.no_register.description') }}
+                    </p>
+                @endif
             </div>
         </div>
     </x-filament::section>

--- a/src/cms/resources/views/filament/widgets/all-clear.blade.php
+++ b/src/cms/resources/views/filament/widgets/all-clear.blade.php
@@ -1,0 +1,19 @@
+<x-filament-widgets::widget>
+    <x-filament::section>
+        <div class="flex items-center gap-x-3">
+            <x-filament::icon
+                icon="heroicon-o-check-circle"
+                class="h-6 w-6 text-success-500"
+            />
+
+            <div>
+                <p class="text-sm font-medium text-gray-950 dark:text-white">
+                    {{ __('dashboard.all_clear.heading') }}
+                </p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                    {{ __('dashboard.all_clear.description') }}
+                </p>
+            </div>
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/resources/views/filament/widgets/awaiting-establishment.blade.php
+++ b/src/cms/resources/views/filament/widgets/awaiting-establishment.blade.php
@@ -1,0 +1,39 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        :heading="__('dashboard.awaiting_establishment.heading')"
+        :description="__('dashboard.awaiting_establishment.description')"
+        icon="heroicon-o-check-badge"
+    >
+        <ul role="list" class="divide-y divide-gray-200 dark:divide-white/10">
+            @foreach ($this->getRows() as $row)
+                <li class="py-3 first:pt-0 last:pb-0">
+                    <a
+                        href="{{ $row['url'] }}"
+                        class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 hover:underline"
+                    >
+                        <span class="flex flex-col gap-y-0.5">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">
+                                {{ $row['name'] }}
+                            </span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ __('dashboard.awaiting_establishment.signed') }}
+                            </span>
+                        </span>
+
+                        <span class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ $row['waiting'] }}
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+
+        @if ($this->hasMore())
+            <x-slot name="footerActions">
+                <x-filament::link :href="$this->getAllUrl()" size="sm">
+                    {{ __('dashboard.show_all') }}
+                </x-filament::link>
+            </x-slot>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/resources/views/filament/widgets/my-approvals.blade.php
+++ b/src/cms/resources/views/filament/widgets/my-approvals.blade.php
@@ -1,0 +1,39 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        :heading="__('dashboard.approvals.heading')"
+        :description="__('dashboard.approvals.description')"
+        icon="heroicon-o-clipboard-document-check"
+    >
+        <ul role="list" class="divide-y divide-gray-200 dark:divide-white/10">
+            @foreach ($this->getRows() as $row)
+                <li class="py-3 first:pt-0 last:pb-0">
+                    <a
+                        href="{{ $row['url'] }}"
+                        class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 hover:underline"
+                    >
+                        <span class="flex flex-col gap-y-0.5">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">
+                                {{ $row['name'] }}
+                            </span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ __('snapshot.model_singular') }}
+                            </span>
+                        </span>
+
+                        <span class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ $row['requested'] }}
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+
+        @if ($this->hasMore())
+            <x-slot name="footerActions">
+                <x-filament::link :href="$this->getAllUrl()" size="sm">
+                    {{ __('dashboard.show_all') }}
+                </x-filament::link>
+            </x-slot>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/resources/views/filament/widgets/open-data-breaches.blade.php
+++ b/src/cms/resources/views/filament/widgets/open-data-breaches.blade.php
@@ -1,0 +1,47 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        :heading="__('dashboard.breach.heading')"
+        :description="__('dashboard.breach.description')"
+        icon="heroicon-o-megaphone"
+        icon-color="danger"
+    >
+        <ul role="list" class="divide-y divide-gray-200 dark:divide-white/10">
+            @foreach ($this->getRows() as $row)
+                <li class="py-3 first:pt-0 last:pb-0">
+                    <a
+                        href="{{ $row['url'] }}"
+                        class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 hover:underline"
+                    >
+                        <span class="flex flex-col gap-y-0.5">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">
+                                @if ($row['number'])
+                                    <span class="text-gray-500 dark:text-gray-400">{{ $row['number'] }}</span>
+                                @endif
+                                {{ $row['name'] }}
+                            </span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ __('data_breach_record.model_singular') }}
+                            </span>
+                        </span>
+
+                        <span class="flex items-center gap-x-3 text-sm">
+                            <span class="text-gray-500 dark:text-gray-400">{{ $row['discovered'] }}</span>
+
+                            <x-filament::badge :color="$row['isUrgent'] ? 'danger' : 'warning'">
+                                {{ $row['status'] }}
+                            </x-filament::badge>
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+
+        @if ($this->hasMore())
+            <x-slot name="footerActions">
+                <x-filament::link :href="$this->getAllUrl()" size="sm">
+                    {{ __('dashboard.show_all') }}
+                </x-filament::link>
+            </x-slot>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/resources/views/filament/widgets/overdue-items.blade.php
+++ b/src/cms/resources/views/filament/widgets/overdue-items.blade.php
@@ -1,0 +1,36 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        :heading="__('dashboard.overdue.heading')"
+        :description="__('dashboard.overdue.description')"
+        icon="heroicon-o-exclamation-triangle"
+        icon-color="danger"
+    >
+        <ul role="list" class="divide-y divide-gray-200 dark:divide-white/10">
+            @foreach ($this->getRows() as $row)
+                <li class="py-3 first:pt-0 last:pb-0">
+                    <a
+                        href="{{ $row['url'] }}"
+                        class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 hover:underline"
+                    >
+                        <span class="flex flex-col gap-y-0.5">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">
+                                {{ $row['name'] }}
+                            </span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ $row['type'] }}
+                            </span>
+                        </span>
+
+                        <span class="flex items-center gap-x-3 text-sm">
+                            <span class="text-gray-500 dark:text-gray-400">{{ $row['kind'] }}</span>
+
+                            <x-filament::badge color="danger">
+                                {{ $row['date'] }}
+                            </x-filament::badge>
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/tests/Feature/Filament/Pages/MainPageTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/MainPageTest.php
@@ -30,7 +30,7 @@ it('gets redirected to the users organisation tenant scoped main page', function
 
     $this->asFilamentOrganisationUser($organisation)
         ->get('/')
-        ->assertRedirect(sprintf('/%s/avg-responsible-processing-records', $organisation->slug));
+        ->assertRedirect(sprintf('/%s', $organisation->slug));
 });
 
 it('is not allowed to access an unauthorized organisation', function (): void {

--- a/src/cms/tests/Feature/Filament/Pages/OneTimePasswordValidationTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/OneTimePasswordValidationTest.php
@@ -24,7 +24,7 @@ it('redirects user to home on valid session', function (): void {
 
     $this->asFilamentOrganisationUser($organisation)
         ->get(sprintf('%s/two-factor-authentication', $organisation->slug))
-        ->assertRedirect(sprintf('%s/avg-responsible-processing-records', $organisation->slug));
+        ->assertRedirect($organisation->slug);
 });
 
 it('redirects with a valid code', function (): void {
@@ -43,7 +43,7 @@ it('redirects with a valid code', function (): void {
         ])
         ->call('authenticate')
         ->assertHasNoFormErrors()
-        ->assertRedirect(sprintf('%s/avg-responsible-processing-records', $organisation->slug));
+        ->assertRedirect($organisation->slug);
 });
 
 it('fails with a invalid code', function (): void {

--- a/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
+++ b/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\ListAvgResponsibleProcessingRecords;
+use App\Filament\Tables\DateWindowFilter;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+it('narrows the register to records whose review date has passed', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $overdue = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::yesterday()->toDateString()]);
+    $upcoming = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addMonth()->toDateString()]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListAvgResponsibleProcessingRecords::class,
+            queryParameters: ['tableFilters' => ['review_at' => ['value' => DateWindowFilter::OVERDUE]]],
+        )
+        ->assertCanSeeTableRecords([$overdue])
+        ->assertCanNotSeeTableRecords([$upcoming]);
+});
+
+it('narrows the register to records coming up for review', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $overdue = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::yesterday()->toDateString()]);
+    $upcoming = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addMonth()->toDateString()]);
+    $distant = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addYear()->toDateString()]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListAvgResponsibleProcessingRecords::class,
+            queryParameters: ['tableFilters' => ['review_at' => ['value' => DateWindowFilter::SOON]]],
+        )
+        ->assertCanSeeTableRecords([$upcoming])
+        ->assertCanNotSeeTableRecords([$overdue, $distant]);
+});
+
+it('excludes records without a review date from both windows', function (string $window): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $withoutReviewDate = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => null]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListAvgResponsibleProcessingRecords::class,
+            queryParameters: ['tableFilters' => ['review_at' => ['value' => $window]]],
+        )
+        ->assertCanNotSeeTableRecords([$withoutReviewDate]);
+})->with([
+    DateWindowFilter::OVERDUE,
+    DateWindowFilter::SOON,
+]);

--- a/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
+++ b/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\ListAvgResponsibleProcessingRecords;
 use App\Filament\Tables\DateWindowFilter;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Services\Dashboard\DateWindow;
 use Carbon\CarbonImmutable;
 use Tests\Helpers\Model\OrganisationTestHelper;
 
@@ -66,3 +67,31 @@ it('excludes records without a review date from both windows', function (string 
     DateWindowFilter::OVERDUE,
     DateWindowFilter::SOON,
 ]);
+
+it('leaves the register untouched when no window is chosen', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $overdue = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::yesterday()->toDateString()]);
+    $upcoming = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addMonth()->toDateString()]);
+
+    // The empty value is the "no filter" state the table starts in; it must not
+    // narrow anything away.
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListAvgResponsibleProcessingRecords::class,
+            queryParameters: ['tableFilters' => ['review_at' => ['value' => '']]],
+        )
+        ->assertCanSeeTableRecords([$overdue, $upcoming]);
+});
+
+it('carries a custom horizon into the filter', function (): void {
+    $filter = DateWindowFilter::make('review_at')
+        ->dateWindow(new DateWindow(1));
+
+    expect($filter->getDateWindow()->soonInMonths)
+        ->toBe(1);
+});

--- a/src/cms/tests/Feature/Filament/Tables/OpenDataBreachFilterTest.php
+++ b/src/cms/tests/Feature/Filament/Tables/OpenDataBreachFilterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\DataBreachRecord\Pages\ListDataBreachRecords;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+it('narrows the register to breaches still being handled', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closed = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '1']]],
+        )
+        ->assertCanSeeTableRecords([$open])
+        ->assertCanNotSeeTableRecords([$closed]);
+});
+
+it('narrows the register to breaches whose handling is finished', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closedByState = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+    // Finished the old way: completed_at filled while the state never moved.
+    $closedByDate = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => CarbonImmutable::yesterday(), 'state' => null]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '0']]],
+        )
+        ->assertCanSeeTableRecords([$closedByState, $closedByDate])
+        ->assertCanNotSeeTableRecords([$open]);
+});
+
+it('leaves the register untouched when the breach filter is not set', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closed = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '']]],
+        )
+        ->assertCanSeeTableRecords([$open, $closed]);
+});

--- a/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\AwaitingEstablishmentWidget;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Models\Organisation;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\States\Snapshot\Approved;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\InReview;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+// Creates a snapshot in one state with one approval per given status. The
+// factories randomise both, so every test sets them explicitly.
+$snapshotWithApprovals = static function (
+    Organisation $organisation,
+    string $state,
+    array $statuses,
+    string $name = 'Salarisadministratie',
+): Snapshot {
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create(['name' => $name, 'state' => $state]);
+
+    foreach ($statuses as $status) {
+        SnapshotApproval::factory()
+            ->recycle($snapshot)
+            ->create(['status' => $status]);
+    }
+
+    return $snapshot;
+};
+
+it('lists a fully signed snapshot that is waiting to be established', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshot = $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeTrue();
+
+    $this->createLivewireTestable(AwaitingEstablishmentWidget::class)
+        ->assertSee($snapshot->name);
+});
+
+it('waits for the last signature before listing a snapshot', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // One mandate holder has signed, the other has not: this is still their
+    // work, not the privacy officer's.
+    $snapshotWithApprovals($organisation, Approved::class, [
+        SnapshotApprovalStatus::APPROVED,
+        SnapshotApprovalStatus::UNKNOWN,
+    ]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('lists a snapshot whose signature was a refusal', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // Declining is an answer too, and deciding what happens next is the privacy
+    // officer's call. Left off the list, nobody would pick it up.
+    $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::DECLINED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeTrue();
+});
+
+it('ignores a snapshot that was never submitted for approval', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, InReview::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('drops a snapshot from the list once it has been established', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, Established::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('ignores an approved snapshot that carries no approvals at all', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // Nobody has signed, so "every approval is signed" must not hold here.
+    $snapshotWithApprovals($organisation, Approved::class, []);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('caps the list and links to the full overview once there is more', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    foreach (range(1, AwaitingEstablishmentWidget::LIMIT + 1) as $number) {
+        $snapshotWithApprovals(
+            $organisation,
+            Approved::class,
+            [SnapshotApprovalStatus::APPROVED],
+            sprintf('Versie %d', $number),
+        );
+    }
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    $widget = new AwaitingEstablishmentWidget();
+
+    expect($widget->getRows())->toHaveCount(AwaitingEstablishmentWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toBeString();
+
+    $this->createLivewireTestable(AwaitingEstablishmentWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
+it('hides the list from someone who may not establish', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    // A mandate holder signs but does not establish; the finished version is not
+    // their work.
+    $this->withPermissions($user, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('does not list a fully signed snapshot from another organisation', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $other = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($other, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it(
+    'stays quiet about being all clear while a snapshot waits to be established',
+    function () use ($snapshotWithApprovals): void {
+        $organisation = OrganisationTestHelper::create();
+        $user = UserTestHelper::createForOrganisation($organisation);
+
+        $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+        $this->withPermissions($user, [
+            Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
+            Permission::CORE_ENTITY_VIEW,
+        ])->withFilamentSession($user, $organisation);
+
+        expect(AllClearWidget::canView())->toBeFalse()
+            ->and(MyApprovalsWidget::canView())->toBeFalse();
+    },
+);

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetOverflowTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetOverflowTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Filament\Widgets\OpenDataBreachesWidget;
+use App\Filament\Widgets\OverdueItemsWidget;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+// The capped lists and their "Toon alle" links. Each widget stops at LIMIT rows
+// and then points at the register holding the rest; below the limit there is
+// nothing more to show and no link.
+
+it('caps the signing list and links to the full overview', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $assignee = UserTestHelper::createForOrganisation($organisation);
+
+    foreach (range(1, MyApprovalsWidget::LIMIT + 1) as $number) {
+        $snapshot = Snapshot::factory()
+            ->recycle($organisation)
+            ->create(['name' => sprintf('Versie %d', $number)]);
+
+        SnapshotApproval::factory()
+            ->recycle($snapshot)
+            ->create(['assigned_to' => $assignee->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+    }
+
+    $this->withPermissions($assignee, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($assignee, $organisation);
+
+    $widget = new MyApprovalsWidget();
+
+    expect($widget->getRows())->toHaveCount(MyApprovalsWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toBeString();
+
+    $this->createLivewireTestable(MyApprovalsWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
+it('does not offer a full overview while the signing list fits', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $assignee = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create();
+
+    SnapshotApproval::factory()
+        ->recycle($snapshot)
+        ->create(['assigned_to' => $assignee->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    $this->withPermissions($assignee, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($assignee, $organisation);
+
+    expect((new MyApprovalsWidget())->hasMore())
+        ->toBeFalse();
+});
+
+it('caps the overdue list', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    foreach (range(1, OverdueItemsWidget::LIMIT + 1) as $number) {
+        AvgResponsibleProcessingRecord::factory()
+            ->recycle($organisation)
+            ->create([
+                'name' => sprintf('Verwerking %d', $number),
+                'review_at' => CarbonImmutable::yesterday()->toDateString(),
+            ]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $widget = new OverdueItemsWidget();
+
+    expect($widget->getRows())->toHaveCount(OverdueItemsWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue();
+});
+
+it('caps the breach list and links to the open breaches', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    foreach (range(1, OpenDataBreachesWidget::LIMIT + 1) as $number) {
+        DataBreachRecord::factory()
+            ->recycle($organisation)
+            ->create([
+                'completed_at' => null,
+                'state' => null,
+                'discovered_at' => CarbonImmutable::now()->subDays($number),
+            ]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $widget = new OpenDataBreachesWidget();
+
+    expect($widget->getRows())->toHaveCount(OpenDataBreachesWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toContain('tableFilters');
+
+    $this->createLivewireTestable(OpenDataBreachesWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
+it('falls back to the generic label for a document without a type', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    // document_type_id is nullable and the form does not require it, so an
+    // expired document can reach the list with no type to name it.
+    $document = Document::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Naamloos type',
+            'document_type_id' => null,
+            'expires_at' => CarbonImmutable::today()->subYear(),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $rows = (new OverdueItemsWidget())->getRows();
+    $row = collect($rows)->firstWhere('name', $document->name);
+
+    expect($row)->not->toBeNull()
+        ->and($row['type'])->toBe(__('document.model_singular'));
+});

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
@@ -105,6 +105,26 @@ it('does not serve one user\'s approvals to another in the same organisation', f
         ->toBeFalse();
 });
 
+it('leaves documents out for a user who may not view them', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['name' => 'Wel zichtbaar', 'review_at' => CarbonImmutable::yesterday()->toDateString()]);
+    $document = Document::factory()
+        ->recycle($organisation)
+        ->create(['name' => 'Niet zichtbaar', 'expires_at' => CarbonImmutable::today()->subYear()]);
+
+    // Core entities but no documents. Every current role grants both, so this
+    // guards the service rather than a live configuration.
+    $this->withPermissions($user, [Permission::CORE_ENTITY_VIEW])
+        ->withFilamentSession($user, $organisation)
+        ->createLivewireTestable(OverdueItemsWidget::class)
+        ->assertSee($record->name)
+        ->assertDontSee($document->name);
+});
+
 it('does not claim all clear to someone who cannot see the register', function (): void {
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
@@ -74,7 +74,8 @@ it('says so when there is nothing at all to do', function (): void {
         ->and(MyApprovalsWidget::canView())->toBeFalse();
 
     $this->createLivewireTestable(AllClearWidget::class)
-        ->assertSee(__('dashboard.all_clear.heading'));
+        ->assertSee(__('dashboard.all_clear.heading'))
+        ->assertDontSee(__('dashboard.all_clear.no_register.description'));
 });
 
 it('does not serve one user\'s approvals to another in the same organisation', function (): void {
@@ -129,13 +130,18 @@ it('does not claim all clear to someone who cannot see the register', function (
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);
 
-    // A functional manager holds no register permissions at all. Telling them
-    // nothing needs attention would state something they cannot know.
+    // A functional manager holds no register permissions at all. They still get
+    // a message — a blank dashboard reads as broken — but not one that claims
+    // the register is clean, which they have no way to check.
     $this->withPermissions($user, [Permission::USER_VIEW])
         ->withFilamentSession($user, $organisation);
 
-    expect(AllClearWidget::canView())
-        ->toBeFalse();
+    expect(AllClearWidget::canView())->toBeTrue()
+        ->and((new AllClearWidget())->hasRegisterAccess())->toBeFalse();
+
+    $this->createLivewireTestable(AllClearWidget::class)
+        ->assertSee(__('dashboard.all_clear.no_register.description'))
+        ->assertDontSee(__('dashboard.all_clear.description'));
 });
 
 it('stays quiet about being all clear while any list has rows', function (): void {

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Filament\Widgets\OpenDataBreachesWidget;
+use App\Filament\Widgets\OverdueItemsWidget;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+it('lists an overdue review', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Salarisadministratie',
+            'review_at' => CarbonImmutable::yesterday()->toDateString(),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(OverdueItemsWidget::class)
+        ->assertSee($record->name);
+});
+
+it('lists an expired document alongside overdue reviews, most overdue first', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $document = Document::factory()
+        ->recycle($organisation)
+        ->create(['name' => 'Oudste', 'expires_at' => CarbonImmutable::today()->subYear()]);
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['name' => 'Nieuwste', 'review_at' => CarbonImmutable::yesterday()->toDateString()]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $names = array_column((new OverdueItemsWidget())->getRows(), 'name');
+
+    expect($names)
+        ->toBe([$document->name, $record->name]);
+});
+
+it('hides the overdue list when nothing has passed its date', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addYear()->toDateString()]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(OverdueItemsWidget::canView())
+        ->toBeFalse();
+});
+
+it('says so when there is nothing at all to do', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(AllClearWidget::canView())->toBeTrue()
+        ->and(OpenDataBreachesWidget::canView())->toBeFalse()
+        ->and(OverdueItemsWidget::canView())->toBeFalse()
+        ->and(MyApprovalsWidget::canView())->toBeFalse();
+
+    $this->createLivewireTestable(AllClearWidget::class)
+        ->assertSee(__('dashboard.all_clear.heading'));
+});
+
+it('does not serve one user\'s approvals to another in the same organisation', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $assignee = UserTestHelper::createForOrganisation($organisation);
+    $colleague = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create();
+
+    SnapshotApproval::factory()
+        ->recycle($snapshot)
+        ->create(['assigned_to' => $assignee->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    $this->withPermissions($assignee, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($assignee, $organisation);
+
+    expect(MyApprovalsWidget::canView())
+        ->toBeTrue();
+
+    // Same organisation, same PHP process, different person: the colleague has
+    // nothing to sign and must not inherit the assignee's rows from a cache.
+    $this->withPermissions($colleague, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($colleague, $organisation);
+
+    expect(MyApprovalsWidget::canView())
+        ->toBeFalse();
+});
+
+it('does not claim all clear to someone who cannot see the register', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // A functional manager holds no register permissions at all. Telling them
+    // nothing needs attention would state something they cannot know.
+    $this->withPermissions($user, [Permission::USER_VIEW])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AllClearWidget::canView())
+        ->toBeFalse();
+});
+
+it('stays quiet about being all clear while any list has rows', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'ap_reported' => false]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(AllClearWidget::canView())
+        ->toBeFalse();
+});

--- a/src/cms/tests/Feature/Filament/Widgets/OpenDataBreachesWidgetTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/OpenDataBreachesWidgetTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Filament\Widgets\OpenDataBreachesWidget;
+use App\Models\DataBreachRecord;
+use App\Services\Dashboard\DataBreachProgress;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+it('lists a breach whose handling is not finished', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $dataBreachRecord = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Laptop kwijtgeraakt',
+            'completed_at' => null,
+            'discovered_at' => CarbonImmutable::now()->subDays(5),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(OpenDataBreachesWidget::class)
+        ->assertSee($dataBreachRecord->name);
+});
+
+it('keeps listing an open breach that was reported to the ap', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $dataBreachRecord = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Gemeld maar nog niet afgerond',
+            'completed_at' => null,
+            'ap_reported' => true,
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(OpenDataBreachesWidget::class)
+        ->assertSee($dataBreachRecord->name);
+});
+
+it('drops a breach once its handling is completed, reported or not', function (bool $apReported): void {
+    $organisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'completed_at' => CarbonImmutable::yesterday(),
+            'ap_reported' => $apReported,
+            'discovered_at' => CarbonImmutable::now()->subMonths(4),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(OpenDataBreachesWidget::canView())
+        ->toBeFalse();
+})->with([
+    'assessed as not notifiable' => [false],
+    'reported to the ap' => [true],
+]);
+
+it('does not show another organisation\'s breaches', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['completed_at' => null]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(OpenDataBreachesWidget::canView())
+        ->toBeFalse();
+});
+
+it('puts the longest-open breach first and undated ones last', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $undated = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['name' => 'Zonder datum', 'completed_at' => null, 'discovered_at' => null]);
+    $recent = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Recent',
+            'completed_at' => null,
+            'discovered_at' => CarbonImmutable::now()->subDays(4),
+        ]);
+    $oldest = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Langst open',
+            'completed_at' => null,
+            'discovered_at' => CarbonImmutable::now()->subDays(40),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $names = array_column((new OpenDataBreachesWidget())->getRows(), 'name');
+
+    expect($names)
+        ->toBe([$oldest->name, $recent->name, $undated->name]);
+});
+
+it('cannot be viewed without the data breach permission', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null]);
+
+    $this->withPermissions($user, [Permission::CORE_ENTITY_VIEW])
+        ->withFilamentSession($user, $organisation);
+
+    expect(OpenDataBreachesWidget::canView())
+        ->toBeFalse();
+});
+
+it('flags an unreported breach only once the 72 hour mark has passed', function (int $hoursAgo, bool $expected): void {
+    $dataBreachRecord = DataBreachRecord::factory()->make([
+        'discovered_at' => CarbonImmutable::now()->subHours($hoursAgo),
+        'ap_reported' => false,
+    ]);
+
+    expect(DataBreachProgress::for($dataBreachRecord)->needsUrgentAttention())
+        ->toBe($expected);
+})->with([
+    'within the window' => [24, false],
+    'just past the window' => [73, true],
+]);
+
+it('never flags a reported or undated breach as urgent', function (): void {
+    $reported = DataBreachRecord::factory()->make([
+        'discovered_at' => CarbonImmutable::now()->subMonths(6),
+        'ap_reported' => true,
+    ]);
+    $undated = DataBreachRecord::factory()->make([
+        'discovered_at' => null,
+        'ap_reported' => false,
+    ]);
+
+    expect(DataBreachProgress::for($reported)->needsUrgentAttention())->toBeFalse()
+        ->and(DataBreachProgress::for($undated)->needsUrgentAttention())->toBeFalse();
+});

--- a/src/cms/tests/Feature/Filament/Widgets/OpenDataBreachesWidgetTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/OpenDataBreachesWidgetTest.php
@@ -5,6 +5,11 @@ declare(strict_types=1);
 use App\Enums\Authorization\Permission;
 use App\Filament\Widgets\OpenDataBreachesWidget;
 use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use App\Models\States\DataBreachRecord\InResponse;
+use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\DataBreachRecord\Reported;
+use App\Models\States\DataBreachRecord\Verified;
 use App\Services\Dashboard\DataBreachProgress;
 use Carbon\CarbonImmutable;
 use Tests\Helpers\Model\OrganisationTestHelper;
@@ -60,6 +65,50 @@ it('drops a breach once its handling is completed, reported or not', function (b
 })->with([
     'assessed as not notifiable' => [false],
     'reported to the ap' => [true],
+]);
+
+it('drops a breach the state machine considers finished', function (string $state): void {
+    $organisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            // completed_at deliberately left empty: the state alone must be
+            // enough to take the breach off the list.
+            'completed_at' => null,
+            'state' => $state,
+            'discovered_at' => CarbonImmutable::now()->subMonths(4),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(OpenDataBreachesWidget::canView())
+        ->toBeFalse();
+})->with([
+    'closed' => [Closed::$name],
+    'assessed as no breach' => [NoBreach::$name],
+]);
+
+it('keeps listing a breach that is still moving through the workflow', function (string $state): void {
+    $organisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Nog in behandeling',
+            'completed_at' => null,
+            'state' => $state,
+            'discovered_at' => CarbonImmutable::now()->subDays(2),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    expect(OpenDataBreachesWidget::canView())
+        ->toBeTrue();
+})->with([
+    'reported' => [Reported::$name],
+    'verified' => [Verified::$name],
+    'in response' => [InResponse::$name],
 ]);
 
 it('does not show another organisation\'s breaches', function (): void {

--- a/src/cms/tests/Feature/Http/Controllers/RedirectToTenantControllerTest.php
+++ b/src/cms/tests/Feature/Http/Controllers/RedirectToTenantControllerTest.php
@@ -9,7 +9,6 @@ use App\Models\Organisation;
 use App\Models\User;
 
 use function it;
-use function sprintf;
 
 it('redirects when no user is logged in', function (): void {
     $this->get('/')->assertRedirect('login');
@@ -46,7 +45,7 @@ it('redirects to organisation when user has organisation role', function (): voi
 
     $this->withFilamentSession($user, $organisation)
         ->get('/')
-        ->assertRedirect(sprintf('%s/avg-responsible-processing-records', $organisation->slug));
+        ->assertRedirect($organisation->slug);
 });
 
 
@@ -60,5 +59,5 @@ it('redirects to organisation when user has global role', function (): void {
 
     $this->withFilamentSession($user, $organisation)
         ->get('/')
-        ->assertRedirect(sprintf('%s/avg-responsible-processing-records', $organisation->slug));
+        ->assertRedirect($organisation->slug);
 });

--- a/src/cms/tests/Feature/Services/Dashboard/AttentionCountServiceTest.php
+++ b/src/cms/tests/Feature/Services/Dashboard/AttentionCountServiceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Models\Avg\AvgProcessorProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\Wpg\WpgProcessingRecord;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Dashboard\AttentionCountServiceTestHelper;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+it('counts overdue reviews across all three processing registers', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $yesterday = CarbonImmutable::yesterday();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    AvgProcessorProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    WpgProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+
+    expect(AttentionCountServiceTestHelper::create()->reviewsOverdue($organisation))
+        ->toBe(3);
+});
+
+it('does not count a review that is not yet due as overdue', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::tomorrow()->toDateString()]);
+
+    expect(AttentionCountServiceTestHelper::create()->reviewsOverdue($organisation))
+        ->toBe(0);
+});
+
+it('treats a review due today as upcoming rather than overdue', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->toDateString()]);
+
+    $attentionCountService = AttentionCountServiceTestHelper::create();
+
+    expect($attentionCountService->reviewsOverdue($organisation))->toBe(0)
+        ->and($attentionCountService->reviewsSoon($organisation))->toBe(1);
+});
+
+it('counts a review inside the horizon as upcoming but not one beyond it', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $today = CarbonImmutable::today();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $today->addMonths(3)->toDateString()]);
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $today->addMonths(3)->addDay()->toDateString()]);
+
+    expect(AttentionCountServiceTestHelper::create()->reviewsSoon($organisation))
+        ->toBe(1);
+});
+
+it('ignores records without a review date', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => null]);
+
+    $attentionCountService = AttentionCountServiceTestHelper::create();
+
+    expect($attentionCountService->reviewsOverdue($organisation))->toBe(0)
+        ->and($attentionCountService->reviewsSoon($organisation))->toBe(0);
+});
+
+it('does not count another organisation\'s overdue reviews', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['review_at' => CarbonImmutable::yesterday()->toDateString()]);
+
+    expect(AttentionCountServiceTestHelper::create()->reviewsOverdue($organisation))
+        ->toBe(0);
+});
+
+it('counts expired and soon-expiring documents separately', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $today = CarbonImmutable::today();
+
+    Document::factory()
+        ->recycle($organisation)
+        ->create(['expires_at' => $today->subDay()]);
+    Document::factory()
+        ->recycle($organisation)
+        ->create(['expires_at' => $today->addMonth()]);
+    Document::factory()
+        ->recycle($organisation)
+        ->create(['expires_at' => $today->addYear()]);
+
+    $attentionCountService = AttentionCountServiceTestHelper::create();
+
+    expect($attentionCountService->documentsExpired($organisation))->toBe(1)
+        ->and($attentionCountService->documentsExpiringSoon($organisation))->toBe(1);
+});
+
+it('does not count another organisation\'s documents', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+
+    Document::factory()
+        ->recycle($otherOrganisation)
+        ->create(['expires_at' => CarbonImmutable::yesterday()]);
+
+    expect(AttentionCountServiceTestHelper::create()->documentsExpired($organisation))
+        ->toBe(0);
+});
+
+it('counts data breaches that have not been completed', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null]);
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => CarbonImmutable::yesterday()]);
+
+    expect(AttentionCountServiceTestHelper::create()->openDataBreaches($organisation))
+        ->toBe(1);
+});
+
+it('does not count another organisation\'s open data breaches', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+
+    DataBreachRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['completed_at' => null]);
+
+    expect(AttentionCountServiceTestHelper::create()->openDataBreaches($organisation))
+        ->toBe(0);
+});
+
+it('counts only approvals assigned to this user and still unsigned', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+    $otherUser = UserTestHelper::createForOrganisation($organisation);
+
+    // One approval per user per snapshot is a unique constraint, so the signed
+    // and unsigned cases need snapshots of their own.
+    $unsignedSnapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create();
+    $signedSnapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create();
+
+    SnapshotApproval::factory()
+        ->recycle($unsignedSnapshot)
+        ->create(['assigned_to' => $user->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+    SnapshotApproval::factory()
+        ->recycle($signedSnapshot)
+        ->create(['assigned_to' => $user->id, 'status' => SnapshotApprovalStatus::APPROVED]);
+    SnapshotApproval::factory()
+        ->recycle($unsignedSnapshot)
+        ->create(['assigned_to' => $otherUser->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    expect(AttentionCountServiceTestHelper::create()->unsignedApprovals($organisation, $user))
+        ->toBe(1);
+});
+
+it('does not count approvals on another organisation\'s snapshots', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $otherSnapshot = Snapshot::factory()
+        ->recycle($otherOrganisation)
+        ->create();
+
+    SnapshotApproval::factory()
+        ->recycle($otherSnapshot)
+        ->create(['assigned_to' => $user->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    expect(AttentionCountServiceTestHelper::create()->unsignedApprovals($organisation, $user))
+        ->toBe(0);
+});
+
+it('honours a custom horizon', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addMonths(6)->toDateString()]);
+
+    expect(AttentionCountServiceTestHelper::create()->reviewsSoon($organisation))->toBe(0)
+        ->and(AttentionCountServiceTestHelper::create(12)->reviewsSoon($organisation))->toBe(1);
+});

--- a/src/cms/tests/Feature/Services/Dashboard/DashboardTenantIsolationTest.php
+++ b/src/cms/tests/Feature/Services/Dashboard/DashboardTenantIsolationTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Models\Avg\AvgProcessorProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\Wpg\WpgProcessingRecord;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Dashboard\AttentionCountServiceTestHelper;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+// The dashboard reads across five tables without going through a Filament
+// resource, so it does not inherit the panel's tenant scoping. Every reader is
+// therefore checked here against a second organisation holding nothing but
+// matching rows: anything that leaks shows up as a non-zero count.
+
+it('reports nothing from another organisation', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $otherOrganisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $yesterday = CarbonImmutable::yesterday();
+
+    // Everything below belongs to the other organisation and would qualify for
+    // one of the dashboard lists if the scoping were missing.
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    AvgProcessorProcessingRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    WpgProcessingRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    Document::factory()
+        ->recycle($otherOrganisation)
+        ->create(['expires_at' => $yesterday]);
+    DataBreachRecord::factory()
+        ->recycle($otherOrganisation)
+        ->create(['completed_at' => null, 'discovered_at' => $yesterday]);
+
+    // An approval assigned to *this* user, but on the other organisation's
+    // snapshot: the assignment alone must not be enough to surface it.
+    $otherSnapshot = Snapshot::factory()
+        ->recycle($otherOrganisation)
+        ->for(
+            AvgResponsibleProcessingRecord::factory()->recycle($otherOrganisation)->create(),
+            'snapshotSource',
+        )
+        ->create();
+    SnapshotApproval::factory()
+        ->recycle($otherSnapshot)
+        ->create(['assigned_to' => $user->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    $this->withPermissions($user, Permission::cases())
+        ->withFilamentSession($user, $organisation);
+
+    $attentionCountService = AttentionCountServiceTestHelper::create();
+
+    expect($attentionCountService->reviewsOverdue($organisation))->toBe(0)
+        ->and($attentionCountService->reviewsSoon($organisation))->toBe(0)
+        ->and($attentionCountService->documentsExpired($organisation))->toBe(0)
+        ->and($attentionCountService->documentsExpiringSoon($organisation))->toBe(0)
+        ->and($attentionCountService->openDataBreaches($organisation))->toBe(0)
+        ->and($attentionCountService->unsignedApprovals($organisation, $user))->toBe(0)
+        ->and($attentionCountService->overdueItems($organisation, 10))->toBe([])
+        ->and($attentionCountService->openDataBreachRecords($organisation, 10)->all())->toBe([])
+        ->and($attentionCountService->unsignedApprovalsFor($organisation, $user, 10)->all())->toBe([]);
+});
+
+it('reports its own organisation\'s rows, so the isolation check is meaningful', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $yesterday = CarbonImmutable::yesterday();
+
+    AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => $yesterday->toDateString()]);
+    Document::factory()
+        ->recycle($organisation)
+        ->create(['expires_at' => $yesterday]);
+    DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'discovered_at' => $yesterday]);
+
+    // The other two review registers get an explicit future date: their factory
+    // assigns review_at randomly, which would otherwise make the counts below
+    // depend on chance.
+    AvgProcessorProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addYear()->toDateString()]);
+    WpgProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addYear()->toDateString()]);
+
+    // Point the snapshot at a record whose review date is pinned: the factory
+    // otherwise invents a source record with a random review_at, which lands in
+    // the past often enough to make the counts below flaky.
+    $snapshotSource = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addYear()->toDateString()]);
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->for($snapshotSource, 'snapshotSource')
+        ->create();
+    SnapshotApproval::factory()
+        ->recycle($snapshot)
+        ->create(['assigned_to' => $user->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    // overdueItems() builds links to Filament resources, which resolve the
+    // tenant from the panel, so it needs a session like the widget has.
+    $this->withPermissions($user, Permission::cases())
+        ->withFilamentSession($user, $organisation);
+
+    $attentionCountService = AttentionCountServiceTestHelper::create();
+
+    expect($attentionCountService->reviewsOverdue($organisation))->toBe(1)
+        ->and($attentionCountService->documentsExpired($organisation))->toBe(1)
+        ->and($attentionCountService->openDataBreaches($organisation))->toBe(1)
+        ->and($attentionCountService->unsignedApprovals($organisation, $user))->toBe(1)
+        ->and($attentionCountService->overdueItems($organisation, 10))->toHaveCount(2)
+        ->and($attentionCountService->openDataBreachRecords($organisation, 10))->toHaveCount(1)
+        ->and($attentionCountService->unsignedApprovalsFor($organisation, $user, 10))->toHaveCount(1);
+});

--- a/src/cms/tests/Helpers/Dashboard/AttentionCountServiceTestHelper.php
+++ b/src/cms/tests/Helpers/Dashboard/AttentionCountServiceTestHelper.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helpers\Dashboard;
+
+use App\Services\Dashboard\AttentionCountService;
+use App\Services\Dashboard\DateWindow;
+
+class AttentionCountServiceTestHelper
+{
+    public static function create(int $soonInMonths = DateWindow::DEFAULT_SOON_IN_MONTHS): AttentionCountService
+    {
+        return new AttentionCountService(new DateWindow($soonInMonths));
+    }
+}


### PR DESCRIPTION
## Wat en waarom

De landingspagina toonde tot nu toe de standaard Filament-dashboard: alleen
"Welcome" en het Filament-versieblok. Niets over het register waarvoor iemand de
applicatie opent.

Deze PR vervangt die pagina door werklijsten: **wat vereist nu aandacht**, met
naam, datum en een link naar het record. Een lijst verbergt zichzelf als er
niets is; is alles afgehandeld, dan zegt het dashboard dat expliciet in plaats
van een lege pagina te tonen.

## Lijsten

| Lijst | Bron | Zichtbaar voor |
|---|---|---|
| Datalekken in behandeling | `completed_at IS NULL` | `DATA_BREACH_RECORD_VIEW` |
| Verlopen | `review_at` (3 registers) + `documents.expires_at` | `CORE_ENTITY_VIEW` |
| Te ondertekenen | onbeoordeelde `SnapshotApproval` van de gebruiker | `SNAPSHOT_APPROVAL_UPDATE_PERSONAL` |
| Niets vereist aandacht | alle bovenstaande leeg | ≥1 van bovenstaande rechten |

Elke lijst is per-organisatie gescoped, telt maximaal 8 regels en linkt met
"Toon alle" door naar een gefilterd overzicht.

## Datumfilters

Nieuw op de drie verwerkingsregisters en op documenten: **Verlopen** en
**Verloopt binnenkort**. De horizon van drie maanden sluit aan op de langste
notificatie-optie die al op documenten bestond
(`document.notification_options.3_months_before`). De grenzen liggen op één
plek (`DateWindow`), zodat een stat en de gefilterde tabel waarnaar hij linkt
niet uit elkaar kunnen lopen.

Hiermee wordt ook waargemaakt wat `general.review_at_help` al beloofde: *"rond
die datum verschijnt de verwerking in het overzicht van te reviewen
verwerkingen"* — dat overzicht bestond nog niet.

## Datalekken: bewust geen deadline-claim

Artikel 33 AVG verplicht melding bij de AP binnen 72 uur, **tenzij** het lek
waarschijnlijk geen risico voor betrokkenen oplevert. Die afweging staat in
`estimated_risk` als vrije tekst; er is geen veld dat vastlegt "beoordeeld als
niet-meldplichtig".

De lijst claimt daarom geen gemiste deadline. Hij toont wat nog niet is
afgerond, en markeert een lek dat open is, niet gemeld, en voorbij de 72 uur
met "Meldplicht nog te beoordelen" — een besluit dat openstaat, geen verstreken
termijn. Zonder dat onderscheid zou een correct als niet-meldplichtig beoordeeld
lek voor altijd rood blijven staan.

## Let op bij review

- **De landingspagina van `/` wijzigt.** Voorheen het AVG-register, nu het
  dashboard. `RedirectToTenantController` is ongewijzigd; het volgt
  `$panel->getUrl()`, dat nu de dashboardpagina oplevert. Drie bestaande tests
  legden de oude URL vast en zijn aangepast.
- **`phpstan-baseline.neon` groeit met 3 regels** voor
  `SnapshotApprovalBuilder`-false-positives (`limit`, `orderBy`, `count`).
  Identieke regels bestonden al voor hetzelfde patroon.
- **Demo-seeder aangepast** zodat er iets in de verlopen- en binnenkort-vensters
  valt; anders demonstreert het dashboard zichzelf niet.

## Getest

- 31 nieuwe tests: tenant-isolatie, grensgevallen rond vandaag, verbergen bij
  leegte, en rechten per rol.
- Twee regressietests voor bugs die tijdens review zijn gevonden: een
  cache-sleutel die het werklijstje van de ene gebruiker aan de andere gaf, en
  een "niets te doen"-melding aan gebruikers die het register niet mogen zien.
- `phpstan` schoon over 1228 bestanden; `phpcs` zonder errors.

## Na merge van main

`main` voegde ondertussen een state machine voor datalekken toe (#72). De lijst
filterde alleen op `completed_at` en liet daardoor lekken staan die via de
workflow op `closed` of `no_breach` waren gezet. Beide signalen worden nu
gecontroleerd; `completed_at` blijft meetellen voor records van voor de state
machine. Het statusfilter uit #72 en het open/afgerond-filter uit deze PR staan
allebei op de tabel.

## Securityreview

- **Tenant-isolatie**: alle dashboardqueries lopen via `$organisation->relation()`
  of via `whereSnapshotOrganisation()`. Vastgelegd in een aparte test die elke
  reader controleert tegen een tweede organisatie; geverifieerd door tijdelijk
  een scope te verwijderen, waarna de test faalt.
- **Cross-user**: de cache van de ondertekenlijst is nu op organisatie én
  gebruiker gesleuteld. Daarvoor kon binnen hetzelfde PHP-proces de werklijst van
  de ene gebruiker aan de andere getoond worden (geen Octane, dus niet actief in
  productie, wel in de testsuite).
- **Rechten**: elke widget controleert zijn recht voordat er een query loopt.
  Documenten worden apart gecontroleerd op `DOCUMENT_VIEW`.
- **Output**: alle waarden in de Blade-views gaan via `{{ }}`; geen `{!! !!}`.
