### PR TITLE
feat: dashboardpaneel voor vast te stellen versies

### DIFF
--- a/src/cms/app/Filament/Pages/Dashboard.php
+++ b/src/cms/app/Filament/Pages/Dashboard.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Pages;
 
 use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\AwaitingEstablishmentWidget;
 use App\Filament\Widgets\MyApprovalsWidget;
 use App\Filament\Widgets\OpenDataBreachesWidget;
 use App\Filament\Widgets\OverdueItemsWidget;
@@ -43,6 +44,7 @@ class Dashboard extends BaseDashboard
     {
         return [
             MyApprovalsWidget::class,
+            AwaitingEstablishmentWidget::class,
             OpenDataBreachesWidget::class,
             OverdueItemsWidget::class,
             AllClearWidget::class,

--- a/src/cms/app/Filament/Widgets/AllClearWidget.php
+++ b/src/cms/app/Filament/Widgets/AllClearWidget.php
@@ -9,7 +9,7 @@ use App\Facades\Authorization;
 use Filament\Widgets\Widget;
 
 /**
- * Shown only when every attention list is empty.
+ * Shown whenever every attention list is empty.
  *
  * Without it, a user with nothing to do gets a dashboard that is literally
  * blank, which reads as a broken page rather than as good news. This says the
@@ -17,6 +17,10 @@ use Filament\Widgets\Widget;
  *
  * It asks each list widget whether it would render, so a new list added later
  * only has to be named here to be accounted for.
+ *
+ * Someone who may see no register at all still gets a message; only the wording
+ * changes, via hasRegisterAccess(). Rendering nothing for them would leave the
+ * page blank, which is the failure this widget exists to prevent.
  */
 class AllClearWidget extends Widget
 {
@@ -38,10 +42,6 @@ class AllClearWidget extends Widget
 
     public static function canView(): bool
     {
-        if (!self::hasAnyAttentionPermission()) {
-            return false;
-        }
-
         foreach (self::ATTENTION_WIDGETS as $widget) {
             if ($widget::canView()) {
                 return false;
@@ -52,12 +52,20 @@ class AllClearWidget extends Widget
     }
 
     /**
-     * Whether the viewer can see any of the things the lists report on.
+     * Whether the viewer can see the register the message talks about.
      *
-     * Without this a user who simply has no register permissions — the
-     * functional manager holds none — would be told that nothing requires their
-     * attention, which reads as "your register is clean" when it means "you
-     * cannot see the register at all".
+     * Drives the wording rather than whether the widget renders: a functional
+     * manager holds no register permissions, so telling them the register is
+     * clean would state something they cannot know. They still get a message —
+     * an empty page reads as broken — but one about their own dashboard.
+     */
+    public function hasRegisterAccess(): bool
+    {
+        return self::hasAnyAttentionPermission();
+    }
+
+    /**
+     * Whether the viewer can see any of the things the lists report on.
      */
     private static function hasAnyAttentionPermission(): bool
     {

--- a/src/cms/app/Filament/Widgets/AllClearWidget.php
+++ b/src/cms/app/Filament/Widgets/AllClearWidget.php
@@ -27,6 +27,7 @@ class AllClearWidget extends Widget
         OpenDataBreachesWidget::class,
         OverdueItemsWidget::class,
         MyApprovalsWidget::class,
+        AwaitingEstablishmentWidget::class,
     ];
 
     // Last, so that on the one render where it appears it is not competing with
@@ -65,6 +66,7 @@ class AllClearWidget extends Widget
             Permission::DOCUMENT_VIEW,
             Permission::DATA_BREACH_RECORD_VIEW,
             Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL,
+            Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
         ];
 
         foreach ($permissions as $permission) {

--- a/src/cms/app/Filament/Widgets/AwaitingEstablishmentWidget.php
+++ b/src/cms/app/Filament/Widgets/AwaitingEstablishmentWidget.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Widgets;
+
+use App\Collections\SnapshotCollection;
+use App\Enums\Authorization\Permission;
+use App\Facades\Authentication;
+use App\Facades\Authorization;
+use App\Filament\Resources\OrganisationSnapshotApprovalResource;
+use App\Services\Dashboard\AttentionCountService;
+use Filament\Widgets\Widget;
+
+use function app;
+
+/**
+ * Snapshots that have collected every signature and are now waiting to be
+ * established.
+ *
+ * This is the privacy officer's half of the approval round trip. Submitting a
+ * version for approval notifies the mandate holders, but nothing notified the
+ * officer once they had all signed, so the last step — establishing the version
+ * — was only found by opening the approval overview and reading the state of
+ * each row by hand.
+ *
+ * Gated on the permission to establish rather than on a role: it lists work only
+ * someone who may perform that transition can finish, and both the privacy
+ * officer and the chief privacy officer hold it.
+ *
+ * Hides itself when nothing is waiting.
+ */
+class AwaitingEstablishmentWidget extends Widget
+{
+    public const int LIMIT = 8;
+
+    // Directly after the personal signing list: both are approval work, and this
+    // one is only ever actionable by a different person than that list is.
+    protected static ?int $sort = 1;
+    protected int|string|array $columnSpan = 'full';
+    protected static string $view = 'filament.widgets.awaiting-establishment';
+
+    /** @var array<string, SnapshotCollection> */
+    private static array $snapshots = [];
+
+    public static function canView(): bool
+    {
+        if (!Authorization::hasPermission(Permission::SNAPSHOT_STATE_TO_ESTABLISHED)) {
+            return false;
+        }
+
+        return self::snapshots()->isNotEmpty();
+    }
+
+    /**
+     * @return array<int, array<string, string>>
+     */
+    public function getRows(): array
+    {
+        $rows = [];
+
+        foreach (self::snapshots() as $snapshot) {
+            $rows[] = [
+                'name' => $snapshot->name,
+                'waiting' => $snapshot->updated_at->diffForHumans(),
+                'url' => OrganisationSnapshotApprovalResource::getUrl('view', ['record' => $snapshot]),
+            ];
+        }
+
+        return $rows;
+    }
+
+    public function getAllUrl(): string
+    {
+        return OrganisationSnapshotApprovalResource::getUrl();
+    }
+
+    public function hasMore(): bool
+    {
+        return self::snapshots()->count() >= self::LIMIT;
+    }
+
+    /**
+     * Resolved once per request: canView() and the view both need the rows, and
+     * Filament calls them separately.
+     *
+     * Keyed by organisation only. Unlike the personal signing list these rows are
+     * the same for everyone who may establish, so there is no second user whose
+     * view of them differs.
+     */
+    private static function snapshots(): SnapshotCollection
+    {
+        $organisation = Authentication::organisation();
+        $cacheKey = $organisation->id->toString();
+
+        if (!isset(self::$snapshots[$cacheKey])) {
+            self::$snapshots[$cacheKey] = app(AttentionCountService::class)
+                ->snapshotsAwaitingEstablishment($organisation, self::LIMIT);
+        }
+
+        return self::$snapshots[$cacheKey];
+    }
+}

--- a/src/cms/app/Services/Dashboard/AttentionCountService.php
+++ b/src/cms/app/Services/Dashboard/AttentionCountService.php
@@ -6,7 +6,9 @@ namespace App\Services\Dashboard;
 
 use App\Collections\DataBreachRecordCollection;
 use App\Collections\SnapshotApprovalCollection;
+use App\Collections\SnapshotCollection;
 use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
 use App\Facades\Authorization;
 use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
@@ -17,6 +19,7 @@ use App\Models\Organisation;
 use App\Models\SnapshotApproval;
 use App\Models\States\DataBreachRecord\Closed;
 use App\Models\States\DataBreachRecord\NoBreach;
+use App\Models\States\Snapshot\Approved;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -149,6 +152,57 @@ readonly class AttentionCountService
         Assert::isInstanceOf($snapshotApprovals, SnapshotApprovalCollection::class);
 
         return $snapshotApprovals;
+    }
+
+    /**
+     * Snapshots that have been through approval and are now waiting to be
+     * established, longest waiting first.
+     *
+     * "Waiting" is the combination of two things, because neither alone means
+     * it: the snapshot sits in the approved state — it was submitted for
+     * approval, which is what notified the mandate holders — and every approval
+     * on it has been signed. A snapshot still missing a signature is the mandate
+     * holders' work, not the privacy officer's, and appears on their own list.
+     *
+     * Signed covers declined as well as approved. A declined signature is an
+     * answer, and the decision about what to do with it is the privacy
+     * officer's to make; leaving those rows off would hide a snapshot that no
+     * one is going to act on otherwise.
+     *
+     * Snapshots carrying no approvals at all are excluded. They cannot have been
+     * signed, so counting their empty approval list as "all signed" would put a
+     * snapshot on this list the moment it was submitted, before anyone had
+     * looked at it.
+     */
+    public function snapshotsAwaitingEstablishment(Organisation $organisation, int $limit): SnapshotCollection
+    {
+        $snapshots = $organisation->snapshots()
+            ->getQuery()
+            ->whereState('state', Approved::class)
+            ->whereHas('snapshotApprovals')
+            ->whereDoesntHave('snapshotApprovals', $this->unsignedApproval(...))
+            ->reorder()
+            ->orderBy('updated_at')
+            ->limit($limit)
+            ->get();
+
+        Assert::isInstanceOf($snapshots, SnapshotCollection::class);
+
+        return $snapshots;
+    }
+
+    /**
+     * Constrains an approval subquery to the signatures still outstanding.
+     *
+     * A named method rather than a closure inline: the relation resolves to the
+     * approval model's own builder, so a closure typed against that builder does
+     * not match the generic signature whereDoesntHave() declares.
+     *
+     * @param Builder<SnapshotApproval> $query
+     */
+    private function unsignedApproval(Builder $query): void
+    {
+        $query->whereIn('status', SnapshotApprovalStatus::unsigned());
     }
 
     /**

--- a/src/cms/resources/lang/nl/dashboard.php
+++ b/src/cms/resources/lang/nl/dashboard.php
@@ -24,8 +24,9 @@ return [
     'show_all' => 'Toon alle',
 
     'all_clear' => [
-        'heading' => 'Niets vereist op dit moment uw aandacht',
-        'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen of te ondertekenen versies.',
+        'heading' => 'Geen openstaande acties binnen dit verwerkingsregister',
+        'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen, '
+            . 'te ondertekenen versies of versies die op vaststelling wachten.',
     ],
 
     'overdue' => [
@@ -49,6 +50,13 @@ return [
     'approvals' => [
         'heading' => 'Te ondertekenen',
         'description' => 'Versies die op uw handtekening wachten.',
+    ],
+
+    'awaiting_establishment' => [
+        'heading' => 'Vast te stellen',
+        'description' => 'Versies die ter goedkeuring zijn aangeboden en volledig zijn ondertekend. '
+            . 'U kunt ze beoordelen en vaststellen.',
+        'signed' => 'Volledig ondertekend',
     ],
 
     'breach' => [

--- a/src/cms/resources/lang/nl/dashboard.php
+++ b/src/cms/resources/lang/nl/dashboard.php
@@ -27,6 +27,17 @@ return [
         'heading' => 'Geen openstaande acties binnen dit verwerkingsregister',
         'description' => 'Er zijn geen verlopen reviews, verlopen documenten, openstaande meldingen, '
             . 'te ondertekenen versies of versies die op vaststelling wachten.',
+
+        /**
+         * For someone without register permissions — the functioneel beheerder.
+         * Deliberately says nothing about the register being clean: they cannot
+         * see it, so that would be a claim they have no way to check.
+         */
+        'no_register' => [
+            'heading' => 'Geen openstaande acties',
+            'description' => 'Uw rol heeft geen taken in het verwerkingsregister. '
+                . 'Gebruik het menu om organisaties en gebruikers te beheren.',
+        ],
     ],
 
     'overdue' => [

--- a/src/cms/resources/views/filament/widgets/all-clear.blade.php
+++ b/src/cms/resources/views/filament/widgets/all-clear.blade.php
@@ -7,12 +7,21 @@
             />
 
             <div>
-                <p class="text-sm font-medium text-gray-950 dark:text-white">
-                    {{ __('dashboard.all_clear.heading') }}
-                </p>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
-                    {{ __('dashboard.all_clear.description') }}
-                </p>
+                @if ($this->hasRegisterAccess())
+                    <p class="text-sm font-medium text-gray-950 dark:text-white">
+                        {{ __('dashboard.all_clear.heading') }}
+                    </p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('dashboard.all_clear.description') }}
+                    </p>
+                @else
+                    <p class="text-sm font-medium text-gray-950 dark:text-white">
+                        {{ __('dashboard.all_clear.no_register.heading') }}
+                    </p>
+                    <p class="text-sm text-gray-500 dark:text-gray-400">
+                        {{ __('dashboard.all_clear.no_register.description') }}
+                    </p>
+                @endif
             </div>
         </div>
     </x-filament::section>

--- a/src/cms/resources/views/filament/widgets/awaiting-establishment.blade.php
+++ b/src/cms/resources/views/filament/widgets/awaiting-establishment.blade.php
@@ -1,0 +1,39 @@
+<x-filament-widgets::widget>
+    <x-filament::section
+        :heading="__('dashboard.awaiting_establishment.heading')"
+        :description="__('dashboard.awaiting_establishment.description')"
+        icon="heroicon-o-check-badge"
+    >
+        <ul role="list" class="divide-y divide-gray-200 dark:divide-white/10">
+            @foreach ($this->getRows() as $row)
+                <li class="py-3 first:pt-0 last:pb-0">
+                    <a
+                        href="{{ $row['url'] }}"
+                        class="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 hover:underline"
+                    >
+                        <span class="flex flex-col gap-y-0.5">
+                            <span class="text-sm font-medium text-gray-950 dark:text-white">
+                                {{ $row['name'] }}
+                            </span>
+                            <span class="text-xs text-gray-500 dark:text-gray-400">
+                                {{ __('dashboard.awaiting_establishment.signed') }}
+                            </span>
+                        </span>
+
+                        <span class="text-sm text-gray-500 dark:text-gray-400">
+                            {{ $row['waiting'] }}
+                        </span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+
+        @if ($this->hasMore())
+            <x-slot name="footerActions">
+                <x-filament::link :href="$this->getAllUrl()" size="sm">
+                    {{ __('dashboard.show_all') }}
+                </x-filament::link>
+            </x-slot>
+        @endif
+    </x-filament::section>
+</x-filament-widgets::widget>

--- a/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
+++ b/src/cms/tests/Feature/Filament/Tables/DateWindowFilterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\ListAvgResponsibleProcessingRecords;
 use App\Filament\Tables\DateWindowFilter;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Services\Dashboard\DateWindow;
 use Carbon\CarbonImmutable;
 use Tests\Helpers\Model\OrganisationTestHelper;
 
@@ -66,3 +67,31 @@ it('excludes records without a review date from both windows', function (string 
     DateWindowFilter::OVERDUE,
     DateWindowFilter::SOON,
 ]);
+
+it('leaves the register untouched when no window is chosen', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $overdue = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::yesterday()->toDateString()]);
+    $upcoming = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['review_at' => CarbonImmutable::today()->addMonth()->toDateString()]);
+
+    // The empty value is the "no filter" state the table starts in; it must not
+    // narrow anything away.
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListAvgResponsibleProcessingRecords::class,
+            queryParameters: ['tableFilters' => ['review_at' => ['value' => '']]],
+        )
+        ->assertCanSeeTableRecords([$overdue, $upcoming]);
+});
+
+it('carries a custom horizon into the filter', function (): void {
+    $filter = DateWindowFilter::make('review_at')
+        ->dateWindow(new DateWindow(1));
+
+    expect($filter->getDateWindow()->soonInMonths)
+        ->toBe(1);
+});

--- a/src/cms/tests/Feature/Filament/Tables/OpenDataBreachFilterTest.php
+++ b/src/cms/tests/Feature/Filament/Tables/OpenDataBreachFilterTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Resources\DataBreachRecord\Pages\ListDataBreachRecords;
+use App\Models\DataBreachRecord;
+use App\Models\States\DataBreachRecord\Closed;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+
+it('narrows the register to breaches still being handled', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closed = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '1']]],
+        )
+        ->assertCanSeeTableRecords([$open])
+        ->assertCanNotSeeTableRecords([$closed]);
+});
+
+it('narrows the register to breaches whose handling is finished', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closedByState = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+    // Finished the old way: completed_at filled while the state never moved.
+    $closedByDate = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => CarbonImmutable::yesterday(), 'state' => null]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '0']]],
+        )
+        ->assertCanSeeTableRecords([$closedByState, $closedByDate])
+        ->assertCanNotSeeTableRecords([$open]);
+});
+
+it('leaves the register untouched when the breach filter is not set', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    $open = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => null]);
+    $closed = DataBreachRecord::factory()
+        ->recycle($organisation)
+        ->create(['completed_at' => null, 'state' => Closed::class]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(
+            ListDataBreachRecords::class,
+            queryParameters: ['tableFilters' => ['open' => ['value' => '']]],
+        )
+        ->assertCanSeeTableRecords([$open, $closed]);
+});

--- a/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Filament\Widgets\AllClearWidget;
+use App\Filament\Widgets\AwaitingEstablishmentWidget;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Models\Organisation;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use App\Models\States\Snapshot\Approved;
+use App\Models\States\Snapshot\Established;
+use App\Models\States\Snapshot\InReview;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+// Creates a snapshot in one state with one approval per given status. The
+// factories randomise both, so every test sets them explicitly.
+$snapshotWithApprovals = static function (
+    Organisation $organisation,
+    string $state,
+    array $statuses,
+    string $name = 'Salarisadministratie',
+): Snapshot {
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create(['name' => $name, 'state' => $state]);
+
+    foreach ($statuses as $status) {
+        SnapshotApproval::factory()
+            ->recycle($snapshot)
+            ->create(['status' => $status]);
+    }
+
+    return $snapshot;
+};
+
+it('lists a fully signed snapshot that is waiting to be established', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshot = $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeTrue();
+
+    $this->createLivewireTestable(AwaitingEstablishmentWidget::class)
+        ->assertSee($snapshot->name);
+});
+
+it('waits for the last signature before listing a snapshot', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // One mandate holder has signed, the other has not: this is still their
+    // work, not the privacy officer's.
+    $snapshotWithApprovals($organisation, Approved::class, [
+        SnapshotApprovalStatus::APPROVED,
+        SnapshotApprovalStatus::UNKNOWN,
+    ]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('lists a snapshot whose signature was a refusal', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // Declining is an answer too, and deciding what happens next is the privacy
+    // officer's call. Left off the list, nobody would pick it up.
+    $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::DECLINED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeTrue();
+});
+
+it('ignores a snapshot that was never submitted for approval', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, InReview::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('drops a snapshot from the list once it has been established', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, Established::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('ignores an approved snapshot that carries no approvals at all', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    // Nobody has signed, so "every approval is signed" must not hold here.
+    $snapshotWithApprovals($organisation, Approved::class, []);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('hides the list from someone who may not establish', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    // A mandate holder signs but does not establish; the finished version is not
+    // their work.
+    $this->withPermissions($user, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it('does not list a fully signed snapshot from another organisation', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $other = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshotWithApprovals($other, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
+});
+
+it(
+    'stays quiet about being all clear while a snapshot waits to be established',
+    function () use ($snapshotWithApprovals): void {
+        $organisation = OrganisationTestHelper::create();
+        $user = UserTestHelper::createForOrganisation($organisation);
+
+        $snapshotWithApprovals($organisation, Approved::class, [SnapshotApprovalStatus::APPROVED]);
+
+        $this->withPermissions($user, [
+            Permission::SNAPSHOT_STATE_TO_ESTABLISHED,
+            Permission::CORE_ENTITY_VIEW,
+        ])->withFilamentSession($user, $organisation);
+
+        expect(AllClearWidget::canView())->toBeFalse()
+            ->and(MyApprovalsWidget::canView())->toBeFalse();
+    },
+);

--- a/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/AwaitingEstablishmentWidgetTest.php
@@ -120,6 +120,32 @@ it('ignores an approved snapshot that carries no approvals at all', function () 
     expect(AwaitingEstablishmentWidget::canView())->toBeFalse();
 });
 
+it('caps the list and links to the full overview once there is more', function () use ($snapshotWithApprovals): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+
+    foreach (range(1, AwaitingEstablishmentWidget::LIMIT + 1) as $number) {
+        $snapshotWithApprovals(
+            $organisation,
+            Approved::class,
+            [SnapshotApprovalStatus::APPROVED],
+            sprintf('Versie %d', $number),
+        );
+    }
+
+    $this->withPermissions($user, [Permission::SNAPSHOT_STATE_TO_ESTABLISHED])
+        ->withFilamentSession($user, $organisation);
+
+    $widget = new AwaitingEstablishmentWidget();
+
+    expect($widget->getRows())->toHaveCount(AwaitingEstablishmentWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toBeString();
+
+    $this->createLivewireTestable(AwaitingEstablishmentWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
 it('hides the list from someone who may not establish', function () use ($snapshotWithApprovals): void {
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetOverflowTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetOverflowTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Permission;
+use App\Enums\Snapshot\SnapshotApprovalStatus;
+use App\Filament\Widgets\MyApprovalsWidget;
+use App\Filament\Widgets\OpenDataBreachesWidget;
+use App\Filament\Widgets\OverdueItemsWidget;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
+use App\Models\Snapshot;
+use App\Models\SnapshotApproval;
+use Carbon\CarbonImmutable;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+// The capped lists and their "Toon alle" links. Each widget stops at LIMIT rows
+// and then points at the register holding the rest; below the limit there is
+// nothing more to show and no link.
+
+it('caps the signing list and links to the full overview', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $assignee = UserTestHelper::createForOrganisation($organisation);
+
+    foreach (range(1, MyApprovalsWidget::LIMIT + 1) as $number) {
+        $snapshot = Snapshot::factory()
+            ->recycle($organisation)
+            ->create(['name' => sprintf('Versie %d', $number)]);
+
+        SnapshotApproval::factory()
+            ->recycle($snapshot)
+            ->create(['assigned_to' => $assignee->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+    }
+
+    $this->withPermissions($assignee, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($assignee, $organisation);
+
+    $widget = new MyApprovalsWidget();
+
+    expect($widget->getRows())->toHaveCount(MyApprovalsWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toBeString();
+
+    $this->createLivewireTestable(MyApprovalsWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
+it('does not offer a full overview while the signing list fits', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $assignee = UserTestHelper::createForOrganisation($organisation);
+
+    $snapshot = Snapshot::factory()
+        ->recycle($organisation)
+        ->create();
+
+    SnapshotApproval::factory()
+        ->recycle($snapshot)
+        ->create(['assigned_to' => $assignee->id, 'status' => SnapshotApprovalStatus::UNKNOWN]);
+
+    $this->withPermissions($assignee, [Permission::SNAPSHOT_APPROVAL_UPDATE_PERSONAL])
+        ->withFilamentSession($assignee, $organisation);
+
+    expect((new MyApprovalsWidget())->hasMore())
+        ->toBeFalse();
+});
+
+it('caps the overdue list', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    foreach (range(1, OverdueItemsWidget::LIMIT + 1) as $number) {
+        AvgResponsibleProcessingRecord::factory()
+            ->recycle($organisation)
+            ->create([
+                'name' => sprintf('Verwerking %d', $number),
+                'review_at' => CarbonImmutable::yesterday()->toDateString(),
+            ]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $widget = new OverdueItemsWidget();
+
+    expect($widget->getRows())->toHaveCount(OverdueItemsWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue();
+});
+
+it('caps the breach list and links to the open breaches', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    foreach (range(1, OpenDataBreachesWidget::LIMIT + 1) as $number) {
+        DataBreachRecord::factory()
+            ->recycle($organisation)
+            ->create([
+                'completed_at' => null,
+                'state' => null,
+                'discovered_at' => CarbonImmutable::now()->subDays($number),
+            ]);
+    }
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $widget = new OpenDataBreachesWidget();
+
+    expect($widget->getRows())->toHaveCount(OpenDataBreachesWidget::LIMIT)
+        ->and($widget->hasMore())->toBeTrue()
+        ->and($widget->getAllUrl())->toContain('tableFilters');
+
+    $this->createLivewireTestable(OpenDataBreachesWidget::class)
+        ->assertSee(__('dashboard.show_all'));
+});
+
+it('falls back to the generic label for a document without a type', function (): void {
+    $organisation = OrganisationTestHelper::create();
+
+    // document_type_id is nullable and the form does not require it, so an
+    // expired document can reach the list with no type to name it.
+    $document = Document::factory()
+        ->recycle($organisation)
+        ->create([
+            'name' => 'Naamloos type',
+            'document_type_id' => null,
+            'expires_at' => CarbonImmutable::today()->subYear(),
+        ]);
+
+    $this->asFilamentOrganisationUser($organisation);
+
+    $rows = (new OverdueItemsWidget())->getRows();
+    $row = collect($rows)->firstWhere('name', $document->name);
+
+    expect($row)->not->toBeNull()
+        ->and($row['type'])->toBe(__('document.model_singular'));
+});

--- a/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
+++ b/src/cms/tests/Feature/Filament/Widgets/DashboardWidgetsTest.php
@@ -74,7 +74,8 @@ it('says so when there is nothing at all to do', function (): void {
         ->and(MyApprovalsWidget::canView())->toBeFalse();
 
     $this->createLivewireTestable(AllClearWidget::class)
-        ->assertSee(__('dashboard.all_clear.heading'));
+        ->assertSee(__('dashboard.all_clear.heading'))
+        ->assertDontSee(__('dashboard.all_clear.no_register.description'));
 });
 
 it('does not serve one user\'s approvals to another in the same organisation', function (): void {
@@ -129,13 +130,18 @@ it('does not claim all clear to someone who cannot see the register', function (
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);
 
-    // A functional manager holds no register permissions at all. Telling them
-    // nothing needs attention would state something they cannot know.
+    // A functional manager holds no register permissions at all. They still get
+    // a message — a blank dashboard reads as broken — but not one that claims
+    // the register is clean, which they have no way to check.
     $this->withPermissions($user, [Permission::USER_VIEW])
         ->withFilamentSession($user, $organisation);
 
-    expect(AllClearWidget::canView())
-        ->toBeFalse();
+    expect(AllClearWidget::canView())->toBeTrue()
+        ->and((new AllClearWidget())->hasRegisterAccess())->toBeFalse();
+
+    $this->createLivewireTestable(AllClearWidget::class)
+        ->assertSee(__('dashboard.all_clear.no_register.description'))
+        ->assertDontSee(__('dashboard.all_clear.description'));
 });
 
 it('stays quiet about being all clear while any list has rows', function (): void {


### PR DESCRIPTION
## Wat

Voegt een dashboardpaneel toe voor de privacy officer: **Vast te stellen** — versies die ter goedkeuring zijn aangeboden én volledig zijn ondertekend, en dus beoordeeld en vastgesteld kunnen worden.

Tot nu toe was er geen signaal richting de privacy officer zodra alle mandaathouders getekend hadden. `MyApprovalsWidget` toont alleen de eigen te ondertekenen versies, en de PO heeft `SNAPSHOT_APPROVAL_UPDATE_PERSONAL` niet — die laatste stap was dus alleen handmatig te vinden via het goedkeuringsoverzicht.

## Wanneer verschijnt een versie

Beide voorwaarden, want geen van beide is op zichzelf genoeg:

- de snapshot staat in state `approved` (aangeboden ter goedkeuring — dat is wat de mandaathouders notificeert), en
- élke `snapshotApproval` is ondertekend.

Verder:

- **Ondertekend = ook afgewezen.** Een afwijzing is een antwoord; wat er vervolgens gebeurt is aan de privacy officer. Weglaten zou de versie onzichtbaar maken.
- **Zonder ondertekeningen telt niet als "alles getekend".** Anders zou een versie direct na aanbieden in de lijst staan.
- Gated op `SNAPSHOT_STATE_TO_ESTABLISHED` (privacy officer + chief privacy officer), niet op een rol.
- Verbergt zichzelf als er niets wacht, en is meegenomen in `AllClearWidget`.

## Lege dashboard

Tweede commit: het dashboard toonde een **volledig lege pagina** voor de functioneel beheerder — die houdt geen enkele registerrechten, waardoor `AllClearWidget` zichzelf verborg. Dat bestond al vóór deze branch.

Nu verschijnt er altijd een melding; alleen de tekst verschilt:

- mét registertoegang: "Geen openstaande acties binnen dit verwerkingsregister"
- zonder: "Geen openstaande acties" — bewust geen bewering dat het register schoon is, want dat kan die gebruiker niet controleren.

## Tests en coverage

54 groen (`tests/Feature/Filament/Widgets/`, `tests/Feature/Services/Dashboard/`), waarvan 10 nieuw: workflow-regels, afwijzing, geen ondertekeningen, permissiecheck, tenant-isolatie en de cap + "Toon alle"-link. PHPStan en PHPCS schoon. Beide nieuwe/gewijzigde widgets staan op 100% coverage.

**Let op:** de CI-coveragedrempel (100%) faalde al vóór deze branch — `a875da1` zat op 99.7%. Deze branch brengt dat naar 99.8%; de resterende gaten zitten in bestaande bestanden (`MyApprovalsWidget` 47.6%, `OpenDataBreachesWidget`, `OverdueItemsWidget`, `OverdueItem`) en vallen buiten de scope hiervan.