### PR TITLE
ci: use pcov instead of xdebug for coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           php-version: 8.4
           extensions: pgsql
-          coverage: xdebug
+          coverage: pcov
 
       - name: Install exiftool
         run: sudo apt-get update && sudo apt-get install -y exiftool


### PR DESCRIPTION
Experiment: measure impact of swapping the coverage driver.

Baseline on main: CI ~18-19 min, of which the Phpunit step is ~16m24s.

pcov is typically 2-4x faster than xdebug for line coverage. No other changes.