### PR TITLE
ci: run tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,6 @@ jobs:
         run: vendor/bin/phpmd app github ./phpmd.xml
 
       - name: Phpunit
-        run: vendor/bin/pest --coverage --coverage-text --min=100 --log-junit=reports/report-phpunit.xml --coverage-clover=reports/coverage-phpunit.xml
+        run: php artisan test --parallel --coverage --min=100 --log-junit=reports/report-phpunit.xml --coverage-clover=reports/coverage-phpunit.xml
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/src/cms/composer.json
+++ b/src/cms/composer.json
@@ -75,7 +75,10 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Helpers/TransferHelpers.php"
+        ]
     },
     "scripts": {
         "post-autoload-dump": [

--- a/src/cms/tests/Feature/Transfer/CrossOrgCopyTest.php
+++ b/src/cms/tests/Feature/Transfer/CrossOrgCopyTest.php
@@ -7,10 +7,8 @@ use App\Enums\Authorization\Role;
 use App\Enums\Media\MediaGroup;
 use App\Models\Avg\AvgGoal;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
-use App\Models\Avg\AvgResponsibleProcessingRecordService;
 use App\Models\Document;
 use App\Models\Organisation;
-use App\Models\Processor;
 use App\Models\System;
 use App\Models\Tag;
 use App\Models\User;
@@ -21,51 +19,6 @@ use App\Transfer\Import\PreviewBuilder;
 use App\Transfer\TransferEntityType;
 use App\Transfer\TransferException;
 use Illuminate\Support\Facades\Storage;
-
-/**
- * @return array{0: AvgResponsibleProcessingRecord, 1: Processor, 2: System, 3: Tag}
- */
-function seedCopyableRecord(Organisation $organisation): array
-{
-    $service = AvgResponsibleProcessingRecordService::factory()
-        ->for($organisation)
-        ->create(['name' => 'Burgerzaken']);
-
-    $record = AvgResponsibleProcessingRecord::factory()
-        ->for($organisation)
-        ->create([
-            'name' => 'Bijstandsuitkeringen',
-            'avg_responsible_processing_record_service_id' => $service->id,
-            'has_processors' => true,
-            'has_systems' => true,
-        ]);
-
-    $processor = Processor::factory()->for($organisation)->create(['name' => 'KoboToolbox']);
-    $system = System::factory()->for($organisation)->create(['description' => 'BRP Koppeling']);
-    $tag = Tag::factory()->for($organisation)->create(['name' => 'AVG-kritisch']);
-    $goal = AvgGoal::factory()->for($organisation)->create(['goal' => 'Participatiewet']);
-
-    $record->processors()->attach($processor);
-    $record->systems()->attach($system);
-    $record->tags()->attach($tag);
-    $record->avgGoals()->attach($goal);
-
-    return [$record, $processor, $system, $tag];
-}
-
-function copyableUser(Organisation ...$organisations): User
-{
-    $user = User::factory()->hasAttached(collect($organisations))->create();
-
-    foreach ($organisations as $organisation) {
-        $user->organisationRoles()->create([
-            'organisation_id' => $organisation->id,
-            'role' => Role::CHIEF_PRIVACY_OFFICER,
-        ]);
-    }
-
-    return $user;
-}
 
 it('copies a record and its related graph into another organisation', function (): void {
     $source = Organisation::factory()->create();

--- a/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
+++ b/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
@@ -2,66 +2,13 @@
 
 declare(strict_types=1);
 
-use App\Models\Avg\AvgGoal;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecordService;
 use App\Models\Organisation;
 use App\Models\Processor;
-use App\Models\Tag;
 use App\Models\User;
-use App\Transfer\Export\BundleExporter;
 use App\Transfer\Import\BundleImporter;
-use App\Transfer\TransferEntityType;
 use Illuminate\Support\Facades\Storage;
-
-function createExportedBundle(Organisation $sourceOrganisation, User $user): array
-{
-    $service = AvgResponsibleProcessingRecordService::factory()
-        ->for($sourceOrganisation)
-        ->create(['name' => 'Dienst X']);
-
-    $record = AvgResponsibleProcessingRecord::factory()
-        ->for($sourceOrganisation)
-        ->create([
-            'name' => 'Verwerking A',
-            'avg_responsible_processing_record_service_id' => $service->id,
-            // the record observer deletes attached processors/systems when these flags are false
-            'has_processors' => true,
-            'has_systems' => true,
-        ]);
-
-    $processor = Processor::factory()->for($sourceOrganisation)->create(['name' => 'Verwerker 1']);
-    $processor->address()->create(['city' => 'Amsterdam']);
-
-    $tag = Tag::factory()->for($sourceOrganisation)->create(['name' => 'Label 1']);
-    $avgGoal = AvgGoal::factory()->for($sourceOrganisation)->create(['goal' => 'Doel 1']);
-
-    $record->processors()->attach($processor);
-    $record->tags()->attach($tag);
-    $record->avgGoals()->attach($avgGoal);
-    $record->fgRemark()->create(['body' => 'FG opmerking']);
-    $record->remarks()->create(['body' => 'Notitie', 'user_id' => $user->id]);
-
-    $path = app(BundleExporter::class)->export(
-        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
-        [$record->id->toString()],
-        [
-            'processors' => [$processor->id->toString()],
-            'tags' => [$tag->id->toString()],
-            'avgGoals' => [$avgGoal->id->toString()],
-        ],
-        $sourceOrganisation,
-    );
-
-    $plan = [
-        $record->id->toString() => ['selected' => true, 'strategy' => null],
-        $processor->id->toString() => ['selected' => true, 'strategy' => null],
-        $tag->id->toString() => ['selected' => true, 'strategy' => null],
-        $avgGoal->id->toString() => ['selected' => true, 'strategy' => null],
-    ];
-
-    return [$path, $plan, $record, $processor];
-}
 
 it('exports records with related items and imports them into another organisation', function (): void {
     Storage::fake('filament');

--- a/src/cms/tests/Helpers/TransferHelpers.php
+++ b/src/cms/tests/Helpers/TransferHelpers.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Role;
+use App\Models\Avg\AvgGoal;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecordService;
+use App\Models\Organisation;
+use App\Models\Processor;
+use App\Models\System;
+use App\Models\Tag;
+use App\Models\User;
+use App\Transfer\Export\BundleExporter;
+use App\Transfer\TransferEntityType;
+
+/**
+ * @return array{0: AvgResponsibleProcessingRecord, 1: Processor, 2: System, 3: Tag}
+ */
+function seedCopyableRecord(Organisation $organisation): array
+{
+    $service = AvgResponsibleProcessingRecordService::factory()
+        ->for($organisation)
+        ->create(['name' => 'Burgerzaken']);
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->for($organisation)
+        ->create([
+            'name' => 'Bijstandsuitkeringen',
+            'avg_responsible_processing_record_service_id' => $service->id,
+            'has_processors' => true,
+            'has_systems' => true,
+        ]);
+
+    $processor = Processor::factory()->for($organisation)->create(['name' => 'KoboToolbox']);
+    $system = System::factory()->for($organisation)->create(['description' => 'BRP Koppeling']);
+    $tag = Tag::factory()->for($organisation)->create(['name' => 'AVG-kritisch']);
+    $goal = AvgGoal::factory()->for($organisation)->create(['goal' => 'Participatiewet']);
+
+    $record->processors()->attach($processor);
+    $record->systems()->attach($system);
+    $record->tags()->attach($tag);
+    $record->avgGoals()->attach($goal);
+
+    return [$record, $processor, $system, $tag];
+}
+
+function copyableUser(Organisation ...$organisations): User
+{
+    $user = User::factory()->hasAttached(collect($organisations))->create();
+
+    foreach ($organisations as $organisation) {
+        $user->organisationRoles()->create([
+            'organisation_id' => $organisation->id,
+            'role' => Role::CHIEF_PRIVACY_OFFICER,
+        ]);
+    }
+
+    return $user;
+}
+
+/**
+ * @return array{0: string, 1: array<string, array<string, mixed>>, 2: AvgResponsibleProcessingRecord, 3: Processor}
+ */
+function createExportedBundle(Organisation $sourceOrganisation, User $user): array
+{
+    $service = AvgResponsibleProcessingRecordService::factory()
+        ->for($sourceOrganisation)
+        ->create(['name' => 'Dienst X']);
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->for($sourceOrganisation)
+        ->create([
+            'name' => 'Verwerking A',
+            'avg_responsible_processing_record_service_id' => $service->id,
+            // the record observer deletes attached processors/systems when these flags are false
+            'has_processors' => true,
+            'has_systems' => true,
+        ]);
+
+    $processor = Processor::factory()->for($sourceOrganisation)->create(['name' => 'Verwerker 1']);
+    $processor->address()->create(['city' => 'Amsterdam']);
+
+    $tag = Tag::factory()->for($sourceOrganisation)->create(['name' => 'Label 1']);
+    $avgGoal = AvgGoal::factory()->for($sourceOrganisation)->create(['goal' => 'Doel 1']);
+
+    $record->processors()->attach($processor);
+    $record->tags()->attach($tag);
+    $record->avgGoals()->attach($avgGoal);
+    $record->fgRemark()->create(['body' => 'FG opmerking']);
+    $record->remarks()->create(['body' => 'Notitie', 'user_id' => $user->id]);
+
+    $path = app(BundleExporter::class)->export(
+        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
+        [$record->id->toString()],
+        [
+            'processors' => [$processor->id->toString()],
+            'tags' => [$tag->id->toString()],
+            'avgGoals' => [$avgGoal->id->toString()],
+        ],
+        $sourceOrganisation,
+    );
+
+    $plan = [
+        $record->id->toString() => ['selected' => true, 'strategy' => null],
+        $processor->id->toString() => ['selected' => true, 'strategy' => null],
+        $tag->id->toString() => ['selected' => true, 'strategy' => null],
+        $avgGoal->id->toString() => ['selected' => true, 'strategy' => null],
+    ];
+
+    return [$path, $plan, $record, $processor];
+}


### PR DESCRIPTION
Experiment: measure impact of running the test suite in parallel.

Baseline on main: CI ~18-19 min, Phpunit step ~16m24s single-threaded.

Uses `php artisan test --parallel` (not raw `pest --parallel`) because Laravel creates and migrates a per-worker database; the suite uses `DatabaseTransactions`, which assumes an already-migrated DB.

Also moves three test helpers (`seedCopyableRecord`, `copyableUser`, `createExportedBundle`) out of individual test files into an autoloaded `tests/Helpers/TransferHelpers.php`. They were defined in one test file and called from another, which only works when everything loads into a single process. In parallel those callers landed in different workers and failed with `Call to undefined function`.

Local: 313s serial -> 88s parallel (3.6x, 10 cores). Verified junit + clover reports are still written.