### PR TITLE
ci: speed up CI from ~19min to ~5min

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           php-version: 8.4
           extensions: pgsql
-          coverage: xdebug
+          coverage: pcov
 
       - name: Install exiftool
         run: sudo apt-get update && sudo apt-get install -y exiftool

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,6 @@ jobs:
         run: vendor/bin/phpmd app github ./phpmd.xml
 
       - name: Phpunit
-        run: vendor/bin/pest --coverage --coverage-text --min=100 --log-junit=reports/report-phpunit.xml --coverage-clover=reports/coverage-phpunit.xml
+        run: php artisan test --parallel --coverage --min=100 --log-junit=reports/report-phpunit.xml --coverage-clover=reports/coverage-phpunit.xml
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/src/cms/composer.json
+++ b/src/cms/composer.json
@@ -75,7 +75,10 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "tests/Helpers/TransferHelpers.php"
+        ]
     },
     "scripts": {
         "post-autoload-dump": [

--- a/src/cms/tests/Feature/Transfer/CrossOrgCopyTest.php
+++ b/src/cms/tests/Feature/Transfer/CrossOrgCopyTest.php
@@ -7,10 +7,8 @@ use App\Enums\Authorization\Role;
 use App\Enums\Media\MediaGroup;
 use App\Models\Avg\AvgGoal;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
-use App\Models\Avg\AvgResponsibleProcessingRecordService;
 use App\Models\Document;
 use App\Models\Organisation;
-use App\Models\Processor;
 use App\Models\System;
 use App\Models\Tag;
 use App\Models\User;
@@ -21,51 +19,6 @@ use App\Transfer\Import\PreviewBuilder;
 use App\Transfer\TransferEntityType;
 use App\Transfer\TransferException;
 use Illuminate\Support\Facades\Storage;
-
-/**
- * @return array{0: AvgResponsibleProcessingRecord, 1: Processor, 2: System, 3: Tag}
- */
-function seedCopyableRecord(Organisation $organisation): array
-{
-    $service = AvgResponsibleProcessingRecordService::factory()
-        ->for($organisation)
-        ->create(['name' => 'Burgerzaken']);
-
-    $record = AvgResponsibleProcessingRecord::factory()
-        ->for($organisation)
-        ->create([
-            'name' => 'Bijstandsuitkeringen',
-            'avg_responsible_processing_record_service_id' => $service->id,
-            'has_processors' => true,
-            'has_systems' => true,
-        ]);
-
-    $processor = Processor::factory()->for($organisation)->create(['name' => 'KoboToolbox']);
-    $system = System::factory()->for($organisation)->create(['description' => 'BRP Koppeling']);
-    $tag = Tag::factory()->for($organisation)->create(['name' => 'AVG-kritisch']);
-    $goal = AvgGoal::factory()->for($organisation)->create(['goal' => 'Participatiewet']);
-
-    $record->processors()->attach($processor);
-    $record->systems()->attach($system);
-    $record->tags()->attach($tag);
-    $record->avgGoals()->attach($goal);
-
-    return [$record, $processor, $system, $tag];
-}
-
-function copyableUser(Organisation ...$organisations): User
-{
-    $user = User::factory()->hasAttached(collect($organisations))->create();
-
-    foreach ($organisations as $organisation) {
-        $user->organisationRoles()->create([
-            'organisation_id' => $organisation->id,
-            'role' => Role::CHIEF_PRIVACY_OFFICER,
-        ]);
-    }
-
-    return $user;
-}
 
 it('copies a record and its related graph into another organisation', function (): void {
     $source = Organisation::factory()->create();

--- a/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
+++ b/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
@@ -2,66 +2,13 @@
 
 declare(strict_types=1);
 
-use App\Models\Avg\AvgGoal;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecordService;
 use App\Models\Organisation;
 use App\Models\Processor;
-use App\Models\Tag;
 use App\Models\User;
-use App\Transfer\Export\BundleExporter;
 use App\Transfer\Import\BundleImporter;
-use App\Transfer\TransferEntityType;
 use Illuminate\Support\Facades\Storage;
-
-function createExportedBundle(Organisation $sourceOrganisation, User $user): array
-{
-    $service = AvgResponsibleProcessingRecordService::factory()
-        ->for($sourceOrganisation)
-        ->create(['name' => 'Dienst X']);
-
-    $record = AvgResponsibleProcessingRecord::factory()
-        ->for($sourceOrganisation)
-        ->create([
-            'name' => 'Verwerking A',
-            'avg_responsible_processing_record_service_id' => $service->id,
-            // the record observer deletes attached processors/systems when these flags are false
-            'has_processors' => true,
-            'has_systems' => true,
-        ]);
-
-    $processor = Processor::factory()->for($sourceOrganisation)->create(['name' => 'Verwerker 1']);
-    $processor->address()->create(['city' => 'Amsterdam']);
-
-    $tag = Tag::factory()->for($sourceOrganisation)->create(['name' => 'Label 1']);
-    $avgGoal = AvgGoal::factory()->for($sourceOrganisation)->create(['goal' => 'Doel 1']);
-
-    $record->processors()->attach($processor);
-    $record->tags()->attach($tag);
-    $record->avgGoals()->attach($avgGoal);
-    $record->fgRemark()->create(['body' => 'FG opmerking']);
-    $record->remarks()->create(['body' => 'Notitie', 'user_id' => $user->id]);
-
-    $path = app(BundleExporter::class)->export(
-        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
-        [$record->id->toString()],
-        [
-            'processors' => [$processor->id->toString()],
-            'tags' => [$tag->id->toString()],
-            'avgGoals' => [$avgGoal->id->toString()],
-        ],
-        $sourceOrganisation,
-    );
-
-    $plan = [
-        $record->id->toString() => ['selected' => true, 'strategy' => null],
-        $processor->id->toString() => ['selected' => true, 'strategy' => null],
-        $tag->id->toString() => ['selected' => true, 'strategy' => null],
-        $avgGoal->id->toString() => ['selected' => true, 'strategy' => null],
-    ];
-
-    return [$path, $plan, $record, $processor];
-}
 
 it('exports records with related items and imports them into another organisation', function (): void {
     Storage::fake('filament');

--- a/src/cms/tests/Helpers/TransferHelpers.php
+++ b/src/cms/tests/Helpers/TransferHelpers.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Role;
+use App\Models\Avg\AvgGoal;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecordService;
+use App\Models\Organisation;
+use App\Models\Processor;
+use App\Models\System;
+use App\Models\Tag;
+use App\Models\User;
+use App\Transfer\Export\BundleExporter;
+use App\Transfer\TransferEntityType;
+
+/**
+ * @return array{0: AvgResponsibleProcessingRecord, 1: Processor, 2: System, 3: Tag}
+ */
+function seedCopyableRecord(Organisation $organisation): array
+{
+    $service = AvgResponsibleProcessingRecordService::factory()
+        ->for($organisation)
+        ->create(['name' => 'Burgerzaken']);
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->for($organisation)
+        ->create([
+            'name' => 'Bijstandsuitkeringen',
+            'avg_responsible_processing_record_service_id' => $service->id,
+            'has_processors' => true,
+            'has_systems' => true,
+        ]);
+
+    $processor = Processor::factory()->for($organisation)->create(['name' => 'KoboToolbox']);
+    $system = System::factory()->for($organisation)->create(['description' => 'BRP Koppeling']);
+    $tag = Tag::factory()->for($organisation)->create(['name' => 'AVG-kritisch']);
+    $goal = AvgGoal::factory()->for($organisation)->create(['goal' => 'Participatiewet']);
+
+    $record->processors()->attach($processor);
+    $record->systems()->attach($system);
+    $record->tags()->attach($tag);
+    $record->avgGoals()->attach($goal);
+
+    return [$record, $processor, $system, $tag];
+}
+
+function copyableUser(Organisation ...$organisations): User
+{
+    $user = User::factory()->hasAttached(collect($organisations))->create();
+
+    foreach ($organisations as $organisation) {
+        $user->organisationRoles()->create([
+            'organisation_id' => $organisation->id,
+            'role' => Role::CHIEF_PRIVACY_OFFICER,
+        ]);
+    }
+
+    return $user;
+}
+
+/**
+ * @return array{0: string, 1: array<string, array<string, mixed>>, 2: AvgResponsibleProcessingRecord, 3: Processor}
+ */
+function createExportedBundle(Organisation $sourceOrganisation, User $user): array
+{
+    $service = AvgResponsibleProcessingRecordService::factory()
+        ->for($sourceOrganisation)
+        ->create(['name' => 'Dienst X']);
+
+    $record = AvgResponsibleProcessingRecord::factory()
+        ->for($sourceOrganisation)
+        ->create([
+            'name' => 'Verwerking A',
+            'avg_responsible_processing_record_service_id' => $service->id,
+            // the record observer deletes attached processors/systems when these flags are false
+            'has_processors' => true,
+            'has_systems' => true,
+        ]);
+
+    $processor = Processor::factory()->for($sourceOrganisation)->create(['name' => 'Verwerker 1']);
+    $processor->address()->create(['city' => 'Amsterdam']);
+
+    $tag = Tag::factory()->for($sourceOrganisation)->create(['name' => 'Label 1']);
+    $avgGoal = AvgGoal::factory()->for($sourceOrganisation)->create(['goal' => 'Doel 1']);
+
+    $record->processors()->attach($processor);
+    $record->tags()->attach($tag);
+    $record->avgGoals()->attach($avgGoal);
+    $record->fgRemark()->create(['body' => 'FG opmerking']);
+    $record->remarks()->create(['body' => 'Notitie', 'user_id' => $user->id]);
+
+    $path = app(BundleExporter::class)->export(
+        TransferEntityType::AVG_RESPONSIBLE_PROCESSING_RECORD,
+        [$record->id->toString()],
+        [
+            'processors' => [$processor->id->toString()],
+            'tags' => [$tag->id->toString()],
+            'avgGoals' => [$avgGoal->id->toString()],
+        ],
+        $sourceOrganisation,
+    );
+
+    $plan = [
+        $record->id->toString() => ['selected' => true, 'strategy' => null],
+        $processor->id->toString() => ['selected' => true, 'strategy' => null],
+        $tag->id->toString() => ['selected' => true, 'strategy' => null],
+        $avgGoal->id->toString() => ['selected' => true, 'strategy' => null],
+    ];
+
+    return [$path, $plan, $record, $processor];
+}


### PR DESCRIPTION
Speeds up CI by running the test suite in parallel and swapping the coverage driver.

## Measured impact

All numbers from real CI runs; each variant was measured in isolation first.

| Variant | Phpunit step | Total CI |
|---|---|---|
| `main` (baseline) | 16m24s | 18m50s |
| pcov only | 5m52s | 8m15s |
| parallel only | 5m09s | 7m44s |
| **both (this PR)** | **2m41s** | **4m58s** |

The test step was 87% of CI wall-clock, so it was the only thing worth touching. The two changes are independent and compound: **3.8x faster overall**, test step 6.1x.

## Changes

**1. pcov instead of xdebug** — pcov is substantially faster for line coverage, which is all the `--min=100` gate needs.

**2. `php artisan test --parallel`** — deliberately not raw `pest --parallel`: the suite uses `DatabaseTransactions`, which assumes an already-migrated database. Laravel's runner creates and migrates a database per worker; raw paratest does not, and every worker crashes without it.

**3. Moved three shared test helpers into an autoloaded file.** `seedCopyableRecord`, `copyableUser` and `createExportedBundle` were defined in one test file and called from *other* test files. That only works because serial execution loads every test file into one process. In parallel the callers landed in different workers and failed with `Call to undefined function`. They now live in `tests/Helpers/TransferHelpers.php`, registered via `autoload-dev.files`.

This third point was a latent bug in the test suite, surfaced rather than caused by parallelisation.

## Verification

- CI green on this branch.
- Verified the JUnit and Clover reports are still written correctly in parallel mode (834 files in coverage, all 1563 tests in the JUnit report) — paratest merges per-worker coverage, but worth confirming rather than assuming.
- Locally: 313s serial -> 88s parallel, same pass/fail set.