### PR TITLE
fix: statuswijziging en audit-trail atomisch (IB-bevinding #77)

### DIFF
--- a/src/cms/app/Models/States/Transitions/DataBreachRecord/DataBreachRecordStateTransition.php
+++ b/src/cms/app/Models/States/Transitions/DataBreachRecord/DataBreachRecordStateTransition.php
@@ -10,6 +10,7 @@ use App\Models\DataBreachRecordTransition;
 use App\Models\States\DataBreachRecordState;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\DB;
 use Spatie\ModelStates\Transition;
 
 abstract class DataBreachRecordStateTransition extends Transition
@@ -22,18 +23,24 @@ abstract class DataBreachRecordStateTransition extends Transition
     abstract public function handle(): DataBreachRecord;
 
     /**
+     * The status change and its audit record are written together: a status that
+     * ended up in the register without a matching trail entry would be an
+     * untraceable change, so either both land or neither does.
+     *
      * @param class-string<DataBreachRecordState> $stateClass
      */
     protected function transitionToState(string $stateClass): void
     {
-        $this->dataBreachRecord->state = new $stateClass($this->dataBreachRecord);
-        $this->dataBreachRecord->save();
+        DB::transaction(function () use ($stateClass): void {
+            $this->dataBreachRecord->state = new $stateClass($this->dataBreachRecord);
+            $this->dataBreachRecord->save();
 
-        DataBreachRecordTransition::create([
-            'data_breach_record_id' => $this->dataBreachRecord->id,
-            'created_by' => $this->getActingUserId(),
-            'state' => $this->dataBreachRecord->state,
-        ]);
+            DataBreachRecordTransition::create([
+                'data_breach_record_id' => $this->dataBreachRecord->id,
+                'created_by' => $this->getActingUserId(),
+                'state' => $this->dataBreachRecord->state,
+            ]);
+        });
     }
 
     /**

--- a/src/cms/tests/Feature/Models/States/DataBreachRecordStateTest.php
+++ b/src/cms/tests/Feature/Models/States/DataBreachRecordStateTest.php
@@ -10,11 +10,13 @@ use App\Filament\Actions\DataBreachRecordTransition\ReportAction;
 use App\Filament\Actions\DataBreachRecordTransition\RespondAction;
 use App\Filament\Actions\DataBreachRecordTransition\VerifyAction;
 use App\Models\DataBreachRecord;
+use App\Models\DataBreachRecordTransition;
 use App\Models\States\DataBreachRecord\Closed;
 use App\Models\States\DataBreachRecord\InResponse;
 use App\Models\States\DataBreachRecord\NoBreach;
 use App\Models\States\DataBreachRecord\Reported;
 use App\Models\States\DataBreachRecord\Verified;
+use RuntimeException;
 use Spatie\ModelStates\Exceptions\TransitionNotFound;
 
 use function expect;
@@ -68,6 +70,27 @@ it('orders transitionable states along the workflow, with no breach last', funct
 
     expect($dataBreachRecord->state->orderedTransitionableStates())
         ->toBe([Reported::$name, InResponse::$name, NoBreach::$name]);
+});
+
+it('does not persist a status change when the audit record cannot be written', function (): void {
+    $dataBreachRecord = DataBreachRecord::factory()->inState(Reported::class)->create();
+
+    // Force the second write to fail, so only the status change would remain.
+    DataBreachRecordTransition::creating(static function (): void {
+        throw new RuntimeException('audit trail unavailable');
+    });
+
+    try {
+        expect(static fn () => $dataBreachRecord->state->transitionTo(Verified::class))
+            ->toThrow(RuntimeException::class);
+
+        // A status without a trail entry would be an untraceable change.
+        $dataBreachRecord->refresh();
+        expect($dataBreachRecord->state)->toBeInstanceOf(Reported::class)
+            ->and(DataBreachRecordTransition::query()->count())->toBe(0);
+    } finally {
+        DataBreachRecordTransition::flushEventListeners();
+    }
 });
 
 it('does not allow skipping steps', function (string $state, string $newState): void {


### PR DESCRIPTION
Opvolging van de IB-review op #77 (bevinding 1, ernst Laag).

## Bevinding

De statuswijziging en het audit-trail-record werden als twee losse writes uitgevoerd. Faalde de tweede, dan bleef de nieuwe status staan zonder bijbehorende regel in `data_breach_record_transitions` — een statuswijziging zonder spoor.

Grondslag: CONTROL-8-15 (logbestanden dienen te worden aangemaakt, opgeslagen, beschermd en geanalyseerd).

## Wijziging

Beide writes staan nu in één `DB::transaction()` in `transitionToState()`: of ze landen allebei, of geen van beide.

De transactie zit bewust in de transitie-klasse en niet in de Filament-actie, zodat ook transities buiten een webrequest (seeders, console commands) gedekt zijn. Bij snapshots zit een vergelijkbare transactie op serviceniveau (`SnapshotStateTransitionService`), maar voor datalekken loopt de aanroep rechtstreeks via `transitionTo()`.

## Getest

Nieuwe test die de tweede write laat falen en controleert dat de status ongewijzigd blijft en er geen trail-regel achterblijft. De test faalt aantoonbaar op de oude code:

```
⨯ it does not persist a status change when the audit record cannot be written
  Failed asserting that an instance of class ...\Verified
  is an instance of class ...\Reported.
```

Dat is exact het scenario uit de bevinding: status gewijzigd, geen spoor.

Verder: volledige suite groen (op de 4 Hugo-tests na, die lokaal falen omdat `static-website/build.sh` hier ontbreekt — niet geraakt door deze wijziging), phpstan en phpcs schoon, coverage op 100% voor alle datalek-bestanden.

## Niet meegenomen

De tweede observatie uit de review (geen granulaire permissies per transitie) is geen bevinding maar een bevestiging van de gedocumenteerde afweging. Dat blijft een aparte vervolgstap, omdat bestaande rollen dan geseed moeten worden.
