### PR TITLE
fix: pdf export gebruikt primary color ipv oude oranje

### DIFF
--- a/src/cms/resources/views/export/pdf.blade.php
+++ b/src/cms/resources/views/export/pdf.blade.php
@@ -6,20 +6,20 @@
         }
 
         h1, h2, h3, h4, h5, h6 {
-            color: #d97706;
+            color: #F84F39;
             margin: 1rem 0 0.5rem 0;
         }
 
         h1 {
             font-size: 1.5rem;
             padding: 0.5rem;
-            background-color: #e4cfb6ff;
+            background-color: #fedcd7;
             border-radius: 0.2rem;
         }
 
         body > h1:first-of-type {
             color: #fff;
-            background-color: #d97706;
+            background-color: #F84F39;
         }
 
         h2 { font-size: 1.4rem; }


### PR DESCRIPTION
De PDF-export gebruikte nog de oude oranje huisstijlkleur. Vervangen door de OpenVWR primary color `#F84F39` (zie `FilamentServiceProvider`).

| | Oud | Nieuw |
|---|---|---|
| Kopteksten (h1–h6) | `#d97706` | `#F84F39` |
| h1 achtergrond-tint | `#e4cfb6ff` | `#fedcd7` |
| Eerste h1 (titelbalk) | `#d97706` | `#F84F39` |

De tint is een ~20% mix van primary met wit. De oude `#e4cfb6` was geen zuivere mix van `#d97706`, dus de visuele rol is aangehouden in plaats van de exacte verhouding.

## Scope

De rest van de app is doorzocht op oranje/amber hexes, Tailwind `amber-*`/`orange-*` classes en Filament `Color::Amber`/`Color::Orange`. De PDF-template was de enige plek met de oude kleur.

De amber in de versie- en datalek-workflows (`StateColor::WARNING`) is bewust *niet* aangepast: dat is een statuskleur, geen huisstijlkleur. De Vaststellen-knop is amber zolang goedkeuringen of gerelateerde registers nog niet rond zijn, en groen als alles klaar is (`EstablishAction.php:33`). `Approved` gebruikt al `StateColor::PRIMARY` en pikt de huisstijlkleur dus vanzelf op.

## Test

`it can export to pdf` en `it can not export to pdf is no snapshot-data available` slagen.

## Los hiervan

- `docs/accessibility.md:45` legt vast dat wit op `#F84F39` 3.40:1 haalt, onder WCAG AA voor normale tekst. De eerste h1 in de PDF is die combinatie; op 1.5rem telt dat waarschijnlijk als grote tekst (norm 3.0:1), maar het is dezelfde open keuze als bij de primaire knoppen.
- De screenshots in `docs/handleiding/imgs/` tonen nog de oude oranje UI.