### PR TITLE
fix: link relation table rows to their record

### DIFF
--- a/src/cms/app/Filament/Forms/Components/RelationTableColumns.php
+++ b/src/cms/app/Filament/Forms/Components/RelationTableColumns.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Forms\Components;
 
 use App\Enums\Media\MediaGroup;
-use App\Filament\Resources\DocumentResource;
 use App\Filament\Resources\Resource;
 use App\Models\Algorithm\AlgorithmRecord;
 use App\Models\Avg\AvgProcessorProcessingRecord;
@@ -70,7 +69,7 @@ class RelationTableColumns
             [
                 'label' => __('document.name'),
                 'get' => static fn (Model $record): string => self::as($record, Document::class)->name,
-                'href' => static fn (Model $record): string => DocumentResource::getUrl('view', ['record' => $record]),
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
                 // When the document has an uploaded file, a download icon follows the name.
                 'download' => static fn (Model $record): ?string => self::as($record, Document::class)
                     ->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->getFullUrl(),
@@ -91,7 +90,7 @@ class RelationTableColumns
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function responsibles(): array
     {
@@ -99,12 +98,13 @@ class RelationTableColumns
             [
                 'label' => __('responsible.name'),
                 'get' => static fn (Model $record): string => self::as($record, Responsible::class)->name,
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
         ];
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function processors(): array
     {
@@ -112,6 +112,7 @@ class RelationTableColumns
             [
                 'label' => __('processor.name'),
                 'get' => static fn (Model $record): string => self::as($record, Processor::class)->name,
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
             [
                 'label' => __('processor.email'),
@@ -127,7 +128,7 @@ class RelationTableColumns
     /**
      * Receiver and System are both titled by their `description` attribute.
      *
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function simpleDescription(): array
     {
@@ -139,12 +140,13 @@ class RelationTableColumns
 
                     return is_string($description) ? $description : null;
                 },
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
         ];
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function contactPersons(): array
     {
@@ -152,6 +154,7 @@ class RelationTableColumns
             [
                 'label' => __('general.name'),
                 'get' => static fn (Model $record): string => self::as($record, ContactPerson::class)->name,
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
             [
                 'label' => __('contact_person_position.model_singular'),
@@ -169,7 +172,7 @@ class RelationTableColumns
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function users(): array
     {
@@ -177,6 +180,7 @@ class RelationTableColumns
             [
                 'label' => __('user.name'),
                 'get' => static fn (Model $record): string => self::as($record, User::class)->name,
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
             [
                 'label' => __('user.email'),
@@ -210,7 +214,7 @@ class RelationTableColumns
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function algorithmRecords(): array
     {
@@ -218,6 +222,7 @@ class RelationTableColumns
             [
                 'label' => __('processing_record.number'),
                 'get' => static fn (Model $record): ?string => self::entityNumber($record),
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
             [
                 'label' => __('general.name'),
@@ -227,7 +232,7 @@ class RelationTableColumns
     }
 
     /**
-     * @return array<int, array{label: string, get: Closure(Model): (string|null)}>
+     * @return array<int, array{label: string, get: Closure(Model): (string|null), href?: Closure(Model): (string|null)}>
      */
     private static function dataBreachRecords(): array
     {
@@ -235,6 +240,7 @@ class RelationTableColumns
             [
                 'label' => __('processing_record.number'),
                 'get' => static fn (Model $record): ?string => self::entityNumber($record),
+                'href' => static fn (Model $record): ?string => self::recordUrl($record),
             ],
             [
                 'label' => __('general.name'),
@@ -251,7 +257,10 @@ class RelationTableColumns
 
     /**
      * The edit (or, without update rights, view) page of the linked record,
-     * resolved through its Filament resource.
+     * resolved through its Filament resource. Returns null when the model has
+     * no resource, the resource does not register the page (e.g. a register
+     * without a separate view page) or the user may not open it — the column
+     * then renders as plain text.
      */
     private static function recordUrl(Model $record): ?string
     {
@@ -262,7 +271,15 @@ class RelationTableColumns
             return null;
         }
 
-        return $resource::getUrl($resource::canEdit($record) ? 'edit' : 'view', ['record' => $record]);
+        if ($resource::hasPage('edit') && $resource::canEdit($record)) {
+            return $resource::getUrl('edit', ['record' => $record]);
+        }
+
+        if ($resource::hasPage('view') && $resource::canView($record)) {
+            return $resource::getUrl('view', ['record' => $record]);
+        }
+
+        return null;
     }
 
     /**

--- a/src/cms/tests/Feature/Filament/Forms/Components/RelationTableColumnsTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/RelationTableColumnsTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use App\Enums\Authorization\Permission;
 use App\Filament\Forms\Components\RelationTableColumns;
+use App\Filament\Resources\SystemResource;
 use App\Models\Algorithm\AlgorithmRecord;
 use App\Models\Avg\AvgProcessorProcessingRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
@@ -17,6 +19,8 @@ use App\Models\System;
 use App\Models\User;
 use App\Models\Wpg\WpgProcessingRecord;
 use Illuminate\Database\Eloquent\Model;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
 
 /**
  * @param array<int, array{label: string, get: Closure(Model): (string|null)}> $columns
@@ -90,6 +94,22 @@ it('links the first column of every supported model to the record', function (st
     User::class,
     WpgProcessingRecord::class,
 ]);
+
+it('links to the view page when the user may not edit the record', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation);
+    $system = System::factory()->recycle($organisation)->create();
+
+    // Read-only rights: the edit page is off limits, so the link falls back to
+    // the view page.
+    $this->withFilamentSession($user, $organisation)
+        ->withPermissions($user, [Permission::MANAGEMENT_VIEW]);
+
+    $columns = RelationTableColumns::for(System::class);
+
+    expect(($columns[0]['href'])($system))
+        ->toBe(SystemResource::getUrl('view', ['record' => $system, 'tenant' => $organisation]));
+});
 
 it('has no link for a resource without an edit or view page the user may open', function (): void {
     // DataBreachRecordResource registers no view page, so a record the user

--- a/src/cms/tests/Feature/Filament/Forms/Components/RelationTableColumnsTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/RelationTableColumnsTest.php
@@ -3,7 +3,18 @@
 declare(strict_types=1);
 
 use App\Filament\Forms\Components\RelationTableColumns;
+use App\Models\Algorithm\AlgorithmRecord;
+use App\Models\Avg\AvgProcessorProcessingRecord;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\ContactPerson;
+use App\Models\DataBreachRecord;
+use App\Models\Document;
 use App\Models\EntityNumber;
+use App\Models\Processor;
+use App\Models\Receiver;
+use App\Models\Responsible;
+use App\Models\System;
+use App\Models\User;
 use App\Models\Wpg\WpgProcessingRecord;
 use Illuminate\Database\Eloquent\Model;
 
@@ -59,6 +70,33 @@ it('has no number link for a model without a filament resource', function (): vo
         expect(($column['href'] ?? null))->not->toBeNull()
             ->and(($column['href'])(new EntityNumber()))->toBeNull();
     }
+});
+
+it('links the first column of every supported model to the record', function (string $model): void {
+    $columns = RelationTableColumns::for($model);
+
+    expect($columns[0]['href'] ?? null)->not->toBeNull();
+})->with([
+    AlgorithmRecord::class,
+    AvgProcessorProcessingRecord::class,
+    AvgResponsibleProcessingRecord::class,
+    ContactPerson::class,
+    DataBreachRecord::class,
+    Document::class,
+    Processor::class,
+    Receiver::class,
+    Responsible::class,
+    System::class,
+    User::class,
+    WpgProcessingRecord::class,
+]);
+
+it('has no link for a resource without an edit or view page the user may open', function (): void {
+    // DataBreachRecordResource registers no view page, so a record the user
+    // may not edit has nowhere to link to and must render as plain text.
+    $columns = RelationTableColumns::for(DataBreachRecord::class);
+
+    expect(($columns[0]['href'])(new DataBreachRecord()))->toBeNull();
 });
 
 it('throws when no columns are defined for a model', function (): void {

--- a/src/cms/tests/Feature/Filament/Forms/Components/RelationTableTest.php
+++ b/src/cms/tests/Feature/Filament/Forms/Components/RelationTableTest.php
@@ -7,9 +7,11 @@ use App\Filament\Forms\Components\RelationTable;
 use App\Filament\Resources\AlgorithmRecordResource\Pages\EditAlgorithmRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
 use App\Filament\Resources\DocumentResource;
+use App\Filament\Resources\SystemResource;
 use App\Models\Algorithm\AlgorithmRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Document;
+use App\Models\System;
 use Illuminate\Support\Facades\Storage;
 use Tests\Helpers\Model\OrganisationTestHelper;
 use Tests\Helpers\Model\UserTestHelper;
@@ -59,9 +61,10 @@ it('links a document name to its screen and adds a download icon when it has an 
         ->createLivewireTestable(EditAlgorithmRecord::class, [
             'record' => $algorithmRecord->getRouteKey(),
         ])
-        // Both names link to the document's own screen.
-        ->assertSeeHtml('href="' . DocumentResource::getUrl('view', ['record' => $withFile, 'tenant' => $organisation]) . '"')
-        ->assertSeeHtml('href="' . DocumentResource::getUrl('view', ['record' => $withoutFile, 'tenant' => $organisation]) . '"')
+        // Both names link to the document's own screen; the user may edit, so
+        // the link goes straight to the edit page.
+        ->assertSeeHtml('href="' . DocumentResource::getUrl('edit', ['record' => $withFile, 'tenant' => $organisation]) . '"')
+        ->assertSeeHtml('href="' . DocumentResource::getUrl('edit', ['record' => $withoutFile, 'tenant' => $organisation]) . '"')
         // Only the document with an attachment gets the direct-download icon.
         ->assertSeeHtml('href="' . $downloadUrl . '"');
 });
@@ -139,6 +142,25 @@ it('ignores the remove action when no id is given', function (): void {
         ])
         ->callFormComponentAction('document_id', RelationTable::REMOVE_ACTION, arguments: [])
         ->assertFormSet(['document_id' => [$document->getKey()->toString()]]);
+});
+
+it('links a linked system to its own screen', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $system = System::factory()->recycle($organisation)->create();
+
+    $processingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create(['has_systems' => true]);
+    $processingRecord->systems()->attach($system);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(EditAvgResponsibleProcessingRecord::class, [
+            'record' => $processingRecord->getRouteKey(),
+        ])
+        ->assertSeeHtml('href="' . SystemResource::getUrl('edit', [
+            'record' => $system,
+            'tenant' => $organisation,
+        ]) . '"');
 });
 
 it('shows the linked users with name and email as table rows', function (): void {


### PR DESCRIPTION
Most relation table widgets rendered their linked records as dead text. Only documents and processing records had a link, so systems, receivers, responsibles, processors, contact persons, users, algorithm records and data breach records could not be opened from the table.

A column in `RelationTableColumns` only becomes a link when it declares an `href` closure; the identifying column (name/number/description) of every remaining model now declares one, reusing the `recordUrl()` helper that was already in the file.

`recordUrl()` itself needed hardening first. It did `getUrl($resource::canEdit($record) ? 'edit' : 'view', ...)`, which throws for a resource that registers no view page — `DataBreachRecordResource` is exactly that, so wiring it up naively would have crashed the widget for users without edit rights. It now checks `hasPage()` alongside the permission for each target and returns null (plain text) when neither is reachable.

The document column also moved to `recordUrl()`, replacing a hardcoded `DocumentResource::getUrl('view', ...)`. Documents now link to the edit page when the user may edit, consistent with every other model, and no longer hit the same no-permission problem.

Secondary columns (emails, phone numbers, dates) stay plain text, matching the existing convention.

## Tests

- A linked system on the AVG edit page renders an href to its edit page.
- A parameterised test asserting all twelve supported models expose an href, so a future model added to `for()` without a link is caught.
- A read-only user (`MANAGEMENT_VIEW` without update rights) falls back to the view page.
- The `DataBreachRecord` fallback (no view page → null, not an exception).
- Updated the existing document assertion from `view` to `edit`.

`RelationTableColumns` is at 100% coverage; full suite green in CI.