### PR TITLE
fix: dropdowns niet meer afgekapt in one-page secties

### DIFF
--- a/src/cms/resources/css/filament/admin/theme.css
+++ b/src/cms/resources/css/filament/admin/theme.css
@@ -147,10 +147,15 @@
 
 /* Accent bar on the header block itself rather than just the heading text,
    so it reads as a marker for the whole header (heading + description)
-   instead of underlining just the words. Clipping to the card's rounded
-   corner is added to the overflow-hidden below, on the section itself. */
+   instead of underlining just the words.
+
+   The bar follows the card's rounded top-left corner via its own
+   border-radius rather than by clipping it at the section. The section must
+   stay overflow-visible so select dropdowns can escape the card (see below),
+   which rules out the overflow-hidden this used to rely on. */
 .onepage-layout [data-onepage-section] > .fi-section-header {
     @apply border-l-4 border-primary-600 dark:border-primary-400;
+    border-top-left-radius: theme('borderRadius.xl');
 }
 
 /* Nested information blocks are cards inside a card; flatten them so each
@@ -160,10 +165,14 @@
 }
 
 /* Land jump targets below the sticky topbar instead of flush under it.
-   overflow-hidden clips the header's accent bar to the card's rounded
-   corner instead of letting its square edge poke past the curve. */
+
+   Deliberately overflow-visible: the searchable multi-selects render their
+   dropdown as a sibling inside the section, so any clipping here cuts the
+   option list off at the card edge -- and a select near the bottom of a
+   section loses its dropdown entirely. The accent bar rounds its own corner
+   (above) so nothing needs the section to clip. */
 .onepage-layout [data-onepage-section] {
-    @apply overflow-hidden;
+    overflow: visible;
     scroll-margin-top: 5rem;
 }
 


### PR DESCRIPTION
## Probleem

In de "Alles onder elkaar"-view hadden de secties `overflow: hidden`. De searchable multi-selects (Choices.js, via `TagsInput` e.d.) renderen hun dropdown als sibling *binnen* de sectie, dus die werd afgekapt op de rand van de kaart:

- selects midden in een sectie: dropdown gedeeltelijk zichtbaar
- selects onderaan een sectie: dropdown volledig onzichtbaar

## Oorzaak

De `overflow-hidden` stond er om één cosmetische reden, zoals de comment zelf aangaf: het accentbalkje in de header afronden naar de ronde hoek van de kaart.

## Oplossing

Twee wijzigingen in `theme.css`:

- Het accentbalkje rondt nu zijn eigen hoek af via `border-top-left-radius`, dus het leunt niet meer op clipping door de sectie.
- De sectie is nu expliciet `overflow: visible`, met een comment die vastlegt *waarom* dat zo moet blijven.

## Getest

Handmatig in de browser (native dev, geen Docker):

- Alle 8 dropdowns op het AVG-verantwoordelijke formulier vallen nu volledig binnen beeld, inclusief de lange lijst van 248px bij "Primair contact". Daarvoor werden er twee met 28px afgekapt.
- Met zoekresultaten (44 opties) loopt de lijst 232px voorbij de sectierand — die was voorheen vrijwel volledig onzichtbaar.
- Alle 5 one-page registers gecontroleerd (AVG-verantwoordelijke, AVG-verwerker, WPG, Algoritmes, Datalekken): geen afgekapte dropdowns, geen horizontale overflow.
- Geen regressies: accentbalkjes ronden nog steeds correct af (12px), dropdowns tekenen *boven* de volgende sectie (`z-index: 10` vs `auto`), en de breakpoint op 1279px verbergt de nav en klapt netjes terug naar één kolom.

Testsuite: 86 tests groen over de vier andere registers, 47 groen op AVG-verantwoordelijke.

Let op: er is één bestaande faal in `CreateAvgResponsibleProcessingRecordTest` ("tags of another organisation", `assertDatabaseEmpty` vindt 3 rijen). Die staat los van deze wijziging — hij faalt identiek op main zonder deze commit.