### PR TITLE
fix: layout-toggle en section styling ook op de aanmaakpagina

### DIFF
--- a/src/cms/app/Filament/Actions/ToggleRegisterLayoutAction.php
+++ b/src/cms/app/Filament/Actions/ToggleRegisterLayoutAction.php
@@ -7,6 +7,7 @@ namespace App\Filament\Actions;
 use App\Enums\RegisterLayout;
 use App\Facades\Authentication;
 use Filament\Actions\Action;
+use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\ViewRecord;
 
@@ -38,17 +39,19 @@ class ToggleRegisterLayoutAction extends Action
             ->color('gray')
             // The layout is chosen when the form schema is built, so switching
             // it has to reload the page rather than re-render in place.
-            ->action(static function (Action $action, EditRecord|ViewRecord $livewire): void {
+            ->action(static function (Action $action, CreateRecord|EditRecord|ViewRecord $livewire): void {
                 $user = Authentication::user();
                 $user->register_layout = self::targetLayout();
                 $user->save();
 
                 // Livewire's own URL is the AJAX endpoint, so rebuild the
-                // record page URL from the page class instead of the referer.
-                $action->redirect(
-                    $livewire::getUrl(['record' => $livewire->getRecord()]),
-                    navigate: false,
-                );
+                // page URL from the page class instead of the referer. A create
+                // page has no record yet, so it takes no record parameter.
+                $parameters = $livewire instanceof CreateRecord
+                    ? []
+                    : ['record' => $livewire->getRecord()];
+
+                $action->redirect($livewire::getUrl($parameters), navigate: false);
             });
     }
 

--- a/src/cms/app/Filament/OnePageLayoutRenderHooks.php
+++ b/src/cms/app/Filament/OnePageLayoutRenderHooks.php
@@ -11,6 +11,7 @@ use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Filament\Resources\WpgProcessingRecordResource;
+use Filament\Resources\Pages\CreateRecord;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Support\Facades\FilamentView;
@@ -76,7 +77,9 @@ class OnePageLayoutRenderHooks
      *
      * Matching on the record-page contract rather than on the project's own
      * base classes: not every register page extends those, and the layout is
-     * chosen per resource, not per base class.
+     * chosen per resource, not per base class. Create pages count too: the
+     * resource builds the same one-page schema there, so without this the new
+     * record form loses the section styling the edit form has.
      */
     private static function isOnePageRegisterPage(): bool
     {
@@ -86,7 +89,7 @@ class OnePageLayoutRenderHooks
 
         $page = self::getLivewireComponent();
 
-        if (!$page instanceof EditRecord && !$page instanceof ViewRecord) {
+        if (!$page instanceof EditRecord && !$page instanceof ViewRecord && !$page instanceof CreateRecord) {
             return false;
         }
 
@@ -98,7 +101,7 @@ class OnePageLayoutRenderHooks
      * which is what the navigation reads. Resources without them (users,
      * organisations, lookup lists) are left untouched.
      */
-    private static function rendersOnePageLayout(EditRecord|ViewRecord $page): bool
+    private static function rendersOnePageLayout(CreateRecord|EditRecord|ViewRecord $page): bool
     {
         return in_array($page::getResource(), self::ONE_PAGE_RESOURCES, true);
     }

--- a/src/cms/app/Filament/Resources/AlgorithmRecordResource/Pages/CreateAlgorithmRecord.php
+++ b/src/cms/app/Filament/Resources/AlgorithmRecordResource/Pages/CreateAlgorithmRecord.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\AlgorithmRecordResource\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\EntityNumberCreateRecord;
 use App\Filament\Resources\AlgorithmRecordResource;
 
 class CreateAlgorithmRecord extends EntityNumberCreateRecord
 {
     protected static string $resource = AlgorithmRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ToggleRegisterLayoutAction::make(),
+        ];
+    }
 }

--- a/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/Pages/CreateAvgProcessorProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/AvgProcessorProcessingRecordResource/Pages/CreateAvgProcessorProcessingRecord.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\AvgProcessorProcessingRecordResource\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\EntityNumberCreateRecord;
 use App\Filament\Resources\AvgProcessorProcessingRecordResource;
 
 class CreateAvgProcessorProcessingRecord extends EntityNumberCreateRecord
 {
     protected static string $resource = AvgProcessorProcessingRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ToggleRegisterLayoutAction::make(),
+        ];
+    }
 }

--- a/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/CreateAvgResponsibleProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/AvgResponsibleProcessingRecordResource/Pages/CreateAvgResponsibleProcessingRecord.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\EntityNumberCreateRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
 
 class CreateAvgResponsibleProcessingRecord extends EntityNumberCreateRecord
 {
     protected static string $resource = AvgResponsibleProcessingRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ToggleRegisterLayoutAction::make(),
+        ];
+    }
 }

--- a/src/cms/app/Filament/Resources/DataBreachRecord/Pages/CreateDataBreachRecord.php
+++ b/src/cms/app/Filament/Resources/DataBreachRecord/Pages/CreateDataBreachRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\DataBreachRecord\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\EntityNumberCreateRecord;
 use App\Filament\Resources\DataBreachRecordResource;
 use App\Models\DataBreachRecord;
@@ -14,6 +15,13 @@ use Webmozart\Assert\Assert;
 class CreateDataBreachRecord extends EntityNumberCreateRecord
 {
     protected static string $resource = DataBreachRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ToggleRegisterLayoutAction::make(),
+        ];
+    }
 
     protected function afterCreate(): void
     {

--- a/src/cms/app/Filament/Resources/WpgProcessingRecordResource/Pages/CreateWpgProcessingRecord.php
+++ b/src/cms/app/Filament/Resources/WpgProcessingRecordResource/Pages/CreateWpgProcessingRecord.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace App\Filament\Resources\WpgProcessingRecordResource\Pages;
 
+use App\Filament\Actions\ToggleRegisterLayoutAction;
 use App\Filament\Pages\EntityNumberCreateRecord;
 use App\Filament\Resources\WpgProcessingRecordResource;
 
 class CreateWpgProcessingRecord extends EntityNumberCreateRecord
 {
     protected static string $resource = WpgProcessingRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            ToggleRegisterLayoutAction::make(),
+        ];
+    }
 }

--- a/src/cms/tests/Feature/Filament/Actions/ToggleRegisterLayoutActionTest.php
+++ b/src/cms/tests/Feature/Filament/Actions/ToggleRegisterLayoutActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\RegisterLayout;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\CreateAvgResponsibleProcessingRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\EditAvgResponsibleProcessingRecord;
 use App\Filament\Resources\AvgResponsibleProcessingRecordResource\Pages\ViewAvgResponsibleProcessingRecord;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
@@ -54,6 +55,21 @@ it('switches the layout from the view page', function (): void {
         ->assertRedirect(ViewAvgResponsibleProcessingRecord::getUrl([
             'record' => $avgResponsibleProcessingRecord,
         ]));
+
+    expect($user->refresh()->register_layout)
+        ->toBe(RegisterLayout::ONE_PAGE);
+});
+
+it('switches the layout from the create page', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation, [
+        'register_layout' => RegisterLayout::STEPS,
+    ]);
+
+    $this->asFilamentUser($user)
+        ->createLivewireTestable(CreateAvgResponsibleProcessingRecord::class)
+        ->callAction('toggle_register_layout')
+        ->assertRedirect(CreateAvgResponsibleProcessingRecord::getUrl());
 
     expect($user->refresh()->register_layout)
         ->toBe(RegisterLayout::ONE_PAGE);

--- a/src/cms/tests/Feature/Filament/OnePageLayoutRenderHooksTest.php
+++ b/src/cms/tests/Feature/Filament/OnePageLayoutRenderHooksTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\RegisterLayout;
+use App\Filament\Resources\AvgResponsibleProcessingRecordResource;
+use App\Models\Avg\AvgResponsibleProcessingRecord;
+use Tests\Helpers\Model\OrganisationTestHelper;
+use Tests\Helpers\Model\UserTestHelper;
+
+it('wraps the one-page layout on the create page', function (): void {
+    $user = UserTestHelper::create(['register_layout' => RegisterLayout::ONE_PAGE]);
+
+    $this->asFilamentUser($user)
+        ->get(AvgResponsibleProcessingRecordResource::getUrl('create'))
+        ->assertOk()
+        ->assertSee('onepage-layout', escape: false);
+});
+
+it('wraps the one-page layout on the edit page', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $user = UserTestHelper::createForOrganisation($organisation, [
+        'register_layout' => RegisterLayout::ONE_PAGE,
+    ]);
+
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+
+    $this->asFilamentUser($user)
+        ->get(AvgResponsibleProcessingRecordResource::getUrl('edit', [
+            'record' => $avgResponsibleProcessingRecord,
+        ]))
+        ->assertOk()
+        ->assertSee('onepage-layout', escape: false);
+});
+
+it('does not wrap the create page when the stepwise layout is selected', function (): void {
+    $user = UserTestHelper::create(['register_layout' => RegisterLayout::STEPS]);
+
+    $this->asFilamentUser($user)
+        ->get(AvgResponsibleProcessingRecordResource::getUrl('create'))
+        ->assertOk()
+        ->assertDontSee('onepage-layout', escape: false);
+});


### PR DESCRIPTION
De aanmaakpagina miste twee dingen die de bewerkpagina wél had: de stapsgewijs/onder-elkaar toggle en de styling van de section headings.

## Oorzaak

Beide symptomen hadden dezelfde oorzaak: de create-pagina's vielen buiten een `EditRecord|ViewRecord` type-restrictie op twee plekken. Het formulier-schema zelf was niet het probleem — `Resource::form()` schakelt al op de layout-voorkeur van de gebruiker, dus create-pagina's renderden de one-page secties wél. Alleen ongestyled en zonder toggle.

1. **Toggle-knop** — `ToggleRegisterLayoutAction` stond alleen geregistreerd op Edit/View-pagina's, en de closure was getypeerd als `EditRecord|ViewRecord`. De redirect riep bovendien `$livewire->getRecord()` aan, wat op een create-pagina niet bestaat.

2. **Section styling** — Alle heading-CSS (`text-xl font-semibold`, de primary accent-balk, het platslaan van geneste kaarten) is gescoped onder `.onepage-layout`. Die wrapper komt uit `OnePageLayoutRenderHooks`, die vroegtijdig stopte tenzij de pagina een `EditRecord` of `ViewRecord` was — create-pagina's kregen dus wel de secties, maar geen visuele hiërarchie.

## Wijzigingen

- `OnePageLayoutRenderHooks` accepteert nu ook `CreateRecord`, waardoor de wrapper (en daarmee de section-styling + snelnavigatie) op de aanmaakpagina rendert.
- `ToggleRegisterLayoutAction` is verbreed en de redirect is record-bewust: een create-pagina krijgt geen `record`-parameter.
- `ToggleRegisterLayoutAction` geregistreerd in `getHeaderActions()` op alle vijf de register-aanmaakpagina's (Algorithm, AVG Processor, AVG Responsible, Datalek, WPG). Geen daarvan had al header-actions, dus dit is puur additief.

## Tests

- 121 tests groen over de vijf registers plus de actions-suite.
- Nieuwe `OnePageLayoutRenderHooksTest`. De create-test faalt zonder de fix en slaagt ermee, dus hij dekt de bug echt af in plaats van triviaal te slagen.
- PHPStan schoon; phpcs en phpmd schoon op alle gewijzigde bestanden.

## Aandachtspunt voor de reviewer

Van layout wisselen midden in het aanmaken doet een volledige page reload, waardoor **al ingevulde formuliergegevens verloren gaan**. Dat is inherent aan hoe de toggle werkt (het schema wordt bij het bouwen gekozen, vandaar de reload) en onschuldig op Edit/View waar de data al opgeslagen is — maar bij aanmaken is er niets om uit te herladen. Ik heb het bestaande mechanisme aangehouden en de scope niet opgerekt; als dit onwenselijk is, is de oplossing het bewaren van de formulierstaat over de redirect heen.

Los hiervan: `CreateAvgResponsibleProcessingRecordTest > it can not create an entry with tags of another organisation` faalt ook op een schone checkout (achtergebleven rijen laten `assertDatabaseEmpty` er 3 vinden). Dat staat los van deze PR.