### PR TITLE
fix: toon wijzigingen in gerelateerde entiteiten bij versies vergelijken

### DIFF
--- a/src/cms/app/Filament/Resources/RelatedSnapshotSourceResource/RelatedSnapshotSourceResourceTable.php
+++ b/src/cms/app/Filament/Resources/RelatedSnapshotSourceResource/RelatedSnapshotSourceResourceTable.php
@@ -34,8 +34,15 @@ class RelatedSnapshotSourceResourceTable
     {
         return $table
             ->recordUrl(static function (RelatedSnapshotSource $relatedSnapshotSource): ?string {
-                Assert::methodExists($relatedSnapshotSource->snapshotSource, 'trashed');
-                if ($relatedSnapshotSource->snapshotSource->trashed()) {
+                // Orphan rows (hard-deleted source, no foreign key) have no
+                // record to link to.
+                $source = $relatedSnapshotSource->snapshotSource;
+                if ($source === null) {
+                    return null;
+                }
+
+                Assert::methodExists($source, 'trashed');
+                if ($source->trashed()) {
                     return null;
                 }
 
@@ -51,13 +58,14 @@ class RelatedSnapshotSourceResourceTable
                     ->label(__('snapshot.snapshot_source_display_name'))
                     ->limit(25)
                     ->formatStateUsing(static function (RelatedSnapshotSource $relatedSnapshotSource): string {
-                        return $relatedSnapshotSource->snapshotSource->getDisplayName();
+                        return $relatedSnapshotSource->snapshotSource?->getDisplayName() ?? __('general.deleted');
                     }),
                 TextColumn::make('snapshot_latest_established')
                     ->label(__('snapshot.latest_established'))
                     ->dateTime(DateFormatService::FORMAT_DATE_TIME, DateFormatService::getDisplayTimezone())
                     ->default(static function (RelatedSnapshotSource $relatedSnapshotSource): ?CarbonInterface {
-                        $snapshot = $relatedSnapshotSource->snapshotSource->getLatestSnapshotWithState([Established::class]);
+                        $snapshot = $relatedSnapshotSource->snapshotSource
+                            ?->getLatestSnapshotWithState([Established::class]);
 
                         return $snapshot?->created_at;
                     }),
@@ -69,8 +77,13 @@ class RelatedSnapshotSourceResourceTable
             ->actions([
                 ViewAction::make()
                     ->visible(static function (RelatedSnapshotSource $relatedSnapshotSource): bool {
-                        Assert::methodExists($relatedSnapshotSource->snapshotSource, 'trashed');
-                        return !$relatedSnapshotSource->snapshotSource->trashed();
+                        $source = $relatedSnapshotSource->snapshotSource;
+                        if ($source === null) {
+                            return false;
+                        }
+
+                        Assert::methodExists($source, 'trashed');
+                        return !$source->trashed();
                     })
                     ->url(static function (RelatedSnapshotSource $relatedSnapshotSource): string {
                         return self::getRelatedSnapshotSourceUrl($relatedSnapshotSource);
@@ -80,7 +93,12 @@ class RelatedSnapshotSourceResourceTable
             ->groups([
                 Group::make('snapshot_source_type')
                     ->getTitleFromRecordUsing(static function (RelatedSnapshotSource $relatedSnapshotSource): string {
-                        return __(sprintf('%s.model_singular', Str::snake(class_basename($relatedSnapshotSource->snapshotSource))));
+                        // Derive from the stored type: it is still present when
+                        // the source row itself has been hard-deleted.
+                        return __(sprintf(
+                            '%s.model_singular',
+                            Str::snake(class_basename($relatedSnapshotSource->snapshot_source_type)),
+                        ));
                     })
                     ->titlePrefixedWithLabel(false),
             ])
@@ -93,7 +111,11 @@ class RelatedSnapshotSourceResourceTable
         /** @var class-string<Resource> $resource */
         $resource = Filament::getModelResource($relatedSnapshotSource->snapshot_source_type);
 
-        $url = $resource::getGlobalSearchResultUrl($relatedSnapshotSource->snapshotSource);
+        // Callers only reach this for rows with a resolvable source.
+        $source = $relatedSnapshotSource->snapshotSource;
+        Assert::isInstanceOf($source, SnapshotSource::class);
+
+        $url = $resource::getGlobalSearchResultUrl($source);
         Assert::string($url);
 
         return $url;

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -124,10 +124,7 @@ class CompareSnapshots extends Page
     public function getSnapshots(): Collection
     {
         return $this->snapshots ??= $this->getSource()->snapshots()
-            // snapshotSource is deliberately not eager-loaded with the rest:
-            // its morph key is a Uuid value object, which MorphTo cannot use as
-            // an array offset when building its dictionary.
-            ->with(['snapshotData', 'relatedSnapshotSources'])
+            ->with(['snapshotData', 'relatedSnapshotSources.snapshotSource'])
             ->get()
             ->sortByDesc('version')
             ->keyBy(static fn (Snapshot $snapshot): string => $snapshot->id->toString());
@@ -153,7 +150,9 @@ class CompareSnapshots extends Page
     }
 
     /**
-     * Side-by-side HTML diffs, keyed by the heading to show above each one.
+     * Side-by-side HTML diffs, keyed by section slug. The keys stay
+     * locale-independent so callers and tests can address a section without
+     * knowing its translation; the view resolves the heading.
      *
      * @return array<string, HtmlString>
      */
@@ -169,19 +168,31 @@ class CompareSnapshots extends Page
         }
 
         return [
-            __(sprintf('snapshot.%s_data', SnapshotDataSection::PUBLIC->value)) => $this->diffSection(
+            SnapshotDataSection::PUBLIC->value => $this->diffSection(
                 $from->snapshotData?->public_markdown,
                 $to->snapshotData?->public_markdown,
             ),
-            __(sprintf('snapshot.%s_data', SnapshotDataSection::PRIVATE->value)) => $this->diffSection(
+            SnapshotDataSection::PRIVATE->value => $this->diffSection(
                 $from->snapshotData?->private_markdown,
                 $to->snapshotData?->private_markdown,
             ),
-            __(sprintf('snapshot.%s', self::RELATED_SECTION)) => $this->diffText(
+            self::RELATED_SECTION => $this->diffText(
                 $this->relatedSourcesText($from),
                 $this->relatedSourcesText($to),
             ),
         ];
+    }
+
+    /**
+     * Heading for a section key returned by getDiffs(). The related-entities
+     * section is not backed by a snapshot_data column, so it does not follow
+     * the '<section>_data' naming the other two share.
+     */
+    public function getDiffHeading(string $section): string
+    {
+        return $section === self::RELATED_SECTION
+            ? __(sprintf('snapshot.%s', self::RELATED_SECTION))
+            : __(sprintf('snapshot.%s_data', $section));
     }
 
     /**
@@ -198,23 +209,40 @@ class CompareSnapshots extends Page
      */
     private function relatedSourcesText(Snapshot $snapshot): string
     {
-        /** @var Collection<int, array{type: string, name: string}> $entries */
         $entries = $snapshot->relatedSnapshotSources
-            ->map(static fn (RelatedSnapshotSource $related): array => [
-                'type' => __(sprintf(
-                    '%s.model_singular',
-                    Str::snake(class_basename($related->snapshot_source_type)),
-                )),
-                'name' => $related->snapshotSource->getDisplayName(),
-            ])
-            ->toBase();
+            ->toBase()
+            /** @return array{type: string, name: string, sort: string}|null */
+            ->map(static function (RelatedSnapshotSource $related): ?array {
+                // The morph target has no foreign key (uuidMorphs indexes only),
+                // so a hard-deleted source leaves an orphan row resolving to
+                // null. Skip it rather than take the whole compare page down.
+                $source = $related->snapshotSource;
+
+                if ($source === null) {
+                    return null;
+                }
+
+                $name = $source->getDisplayName();
+
+                return [
+                    'type' => __(sprintf(
+                        '%s.model_singular',
+                        Str::snake(class_basename($related->snapshot_source_type)),
+                    )),
+                    'name' => $name,
+                    // Case-insensitive sort key: capitalisation drift between
+                    // versions must not reorder lines into a phantom diff.
+                    'sort' => Str::lower($name),
+                ];
+            })
+            ->filter();
 
         // Sort on both levels so a merely reordered capture is not reported as
         // a change: only genuine additions and removals should surface.
         $lines = [];
         $currentType = null;
 
-        foreach ($entries->sortBy(['type', 'name'])->all() as $entry) {
+        foreach ($entries->sortBy(['type', 'sort'])->all() as $entry) {
             if ($entry['type'] !== $currentType) {
                 $currentType = $entry['type'];
                 $lines[] = $currentType . ':';

--- a/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
+++ b/src/cms/app/Filament/Resources/SnapshotResource/Pages/CompareSnapshots.php
@@ -10,6 +10,7 @@ use App\Facades\Authorization;
 use App\Facades\DateFormat;
 use App\Filament\Resources\SnapshotResource;
 use App\Models\Contracts\SnapshotSource;
+use App\Models\RelatedSnapshotSource;
 use App\Models\Snapshot;
 use App\ValueObjects\Markdown;
 use Filament\Resources\Pages\Concerns\InteractsWithRecord;
@@ -17,17 +18,27 @@ use Filament\Resources\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
 use Jfcherng\Diff\DiffHelper;
 use Livewire\Attributes\Url;
 use Webmozart\Assert\Assert;
 
 use function __;
 use function abort_unless;
+use function class_basename;
+use function implode;
 use function sprintf;
 
 class CompareSnapshots extends Page
 {
     use InteractsWithRecord;
+
+    /**
+     * Diff key for the related-entities section. Unlike the other sections it
+     * has no SnapshotDataSection counterpart: it is derived from the snapshot's
+     * relations rather than from a snapshot_data column.
+     */
+    private const string RELATED_SECTION = 'related_snapshot_sources';
 
     protected static string $resource = SnapshotResource::class;
     protected static string $view = 'filament.resources.snapshot-resource.pages.compare-snapshots';
@@ -113,7 +124,10 @@ class CompareSnapshots extends Page
     public function getSnapshots(): Collection
     {
         return $this->snapshots ??= $this->getSource()->snapshots()
-            ->with('snapshotData')
+            // snapshotSource is deliberately not eager-loaded with the rest:
+            // its morph key is a Uuid value object, which MorphTo cannot use as
+            // an array offset when building its dictionary.
+            ->with(['snapshotData', 'relatedSnapshotSources'])
             ->get()
             ->sortByDesc('version')
             ->keyBy(static fn (Snapshot $snapshot): string => $snapshot->id->toString());
@@ -139,7 +153,7 @@ class CompareSnapshots extends Page
     }
 
     /**
-     * Side-by-side HTML diffs for each snapshot-data section.
+     * Side-by-side HTML diffs, keyed by the heading to show above each one.
      *
      * @return array<string, HtmlString>
      */
@@ -155,15 +169,61 @@ class CompareSnapshots extends Page
         }
 
         return [
-            SnapshotDataSection::PUBLIC->value => $this->diffSection(
+            __(sprintf('snapshot.%s_data', SnapshotDataSection::PUBLIC->value)) => $this->diffSection(
                 $from->snapshotData?->public_markdown,
                 $to->snapshotData?->public_markdown,
             ),
-            SnapshotDataSection::PRIVATE->value => $this->diffSection(
+            __(sprintf('snapshot.%s_data', SnapshotDataSection::PRIVATE->value)) => $this->diffSection(
                 $from->snapshotData?->private_markdown,
                 $to->snapshotData?->private_markdown,
             ),
+            __(sprintf('snapshot.%s', self::RELATED_SECTION)) => $this->diffText(
+                $this->relatedSourcesText($from),
+                $this->relatedSourcesText($to),
+            ),
         ];
+    }
+
+    /**
+     * The many-to-many links (systems, processors, receivers, ...) captured on
+     * a snapshot live in `related_snapshot_sources`, not in the stored
+     * markdown -- the markdown only holds an inert placeholder tag that is
+     * identical across versions. Diffing the markdown alone therefore reports
+     * "no changes" even when a whole system was added or removed, so we render
+     * the captured links to a stable text block and diff that separately.
+     *
+     * Only the entity's identity is used. The renderer resolves each link to
+     * its currently-established snapshot at render time, which is not a
+     * function of this version and would produce phantom differences.
+     */
+    private function relatedSourcesText(Snapshot $snapshot): string
+    {
+        /** @var Collection<int, array{type: string, name: string}> $entries */
+        $entries = $snapshot->relatedSnapshotSources
+            ->map(static fn (RelatedSnapshotSource $related): array => [
+                'type' => __(sprintf(
+                    '%s.model_singular',
+                    Str::snake(class_basename($related->snapshot_source_type)),
+                )),
+                'name' => $related->snapshotSource->getDisplayName(),
+            ])
+            ->toBase();
+
+        // Sort on both levels so a merely reordered capture is not reported as
+        // a change: only genuine additions and removals should surface.
+        $lines = [];
+        $currentType = null;
+
+        foreach ($entries->sortBy(['type', 'name'])->all() as $entry) {
+            if ($entry['type'] !== $currentType) {
+                $currentType = $entry['type'];
+                $lines[] = $currentType . ':';
+            }
+
+            $lines[] = sprintf('  - %s', $entry['name']);
+        }
+
+        return implode("\n", $lines);
     }
 
     private function diffSection(?Markdown $from, ?Markdown $to): HtmlString
@@ -172,9 +232,14 @@ class CompareSnapshots extends Page
         // SnapshotDataMarkdownRenderer injects the currently-established related
         // snapshots at render time, so its output is not a stable function of the
         // version and would produce phantom differences.
+        return $this->diffText((string) $from?->toString(), (string) $to?->toString());
+    }
+
+    private function diffText(string $from, string $to): HtmlString
+    {
         $html = DiffHelper::calculate(
-            (string) $from?->toString(),
-            (string) $to?->toString(),
+            $from,
+            $to,
             'SideBySide',
             [
                 'context' => 3,

--- a/src/cms/app/Import/Factories/Concerns/SnapshotHelper.php
+++ b/src/cms/app/Import/Factories/Concerns/SnapshotHelper.php
@@ -76,28 +76,35 @@ trait SnapshotHelper
     private function createRelatedSnapshots(Snapshot $snapshot, string $snapshotState, SnapshotFactory $snapshotFactory): void
     {
         foreach ($snapshot->relatedSnapshotSources as $relatedSnapshotSource) {
-            if ($relatedSnapshotSource->snapshotSource->getLatestSnapshotWithState([Established::class]) !== null) {
+            // The polymorphic target carries no foreign key, so a hard-deleted
+            // source leaves an orphan row that resolves to null.
+            $snapshotSource = $relatedSnapshotSource->snapshotSource;
+            if ($snapshotSource === null) {
+                continue;
+            }
+
+            if ($snapshotSource->getLatestSnapshotWithState([Established::class]) !== null) {
                 continue;
             }
 
             if ($snapshotState === Established::class) {
-                $snapshotFactory->fromSnapshotSource($relatedSnapshotSource->snapshotSource, $snapshotState);
+                $snapshotFactory->fromSnapshotSource($snapshotSource, $snapshotState);
                 continue;
             }
 
             if (
                 $snapshotState === Approved::class
-                && $relatedSnapshotSource->snapshotSource->getLatestSnapshotWithState([Approved::class]) === null
+                && $snapshotSource->getLatestSnapshotWithState([Approved::class]) === null
             ) {
-                $snapshotFactory->fromSnapshotSource($relatedSnapshotSource->snapshotSource, $snapshotState);
+                $snapshotFactory->fromSnapshotSource($snapshotSource, $snapshotState);
                 continue;
             }
 
             if (
                 $snapshotState === InReview::class
-                && $relatedSnapshotSource->snapshotSource->getLatestSnapshotWithState([InReview::class]) === null
+                && $snapshotSource->getLatestSnapshotWithState([InReview::class]) === null
             ) {
-                $snapshotFactory->fromSnapshotSource($relatedSnapshotSource->snapshotSource, $snapshotState);
+                $snapshotFactory->fromSnapshotSource($snapshotSource, $snapshotState);
             }
         }
     }

--- a/src/cms/app/Models/RelatedSnapshotSource.php
+++ b/src/cms/app/Models/RelatedSnapshotSource.php
@@ -21,7 +21,10 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
  * @property class-string<SnapshotSource&Model> $snapshot_source_type
  * @property UuidInterface $snapshot_source_id
  *
- * @property-read SnapshotSource&Model $snapshotSource
+ * The polymorphic target carries no foreign key (uuidMorphs indexes only), so
+ * a hard-deleted source leaves an orphan row whose relation resolves to null.
+ *
+ * @property-read (SnapshotSource&Model)|null $snapshotSource
  * @property-read Snapshot $snapshot
  */
 class RelatedSnapshotSource extends Model
@@ -47,11 +50,17 @@ class RelatedSnapshotSource extends Model
     }
 
     /**
+     * The owner key must be passed explicitly: without it MorphTo falls back to
+     * $result->getKey(), which HasUuidAsId overrides to return a UuidInterface
+     * object, and that cannot be used as an array offset when matching results.
+     * Naming the relation 'snapshotSource' keeps eager-loaded results readable
+     * through the accessor of the same name.
+     *
      * @return MorphTo<Model, $this>
      */
     public function snapshotSource(): MorphTo
     {
-        return $this->morphTo('snapshot_source')
+        return $this->morphTo('snapshotSource', 'snapshot_source_type', 'snapshot_source_id', 'id')
             ->withTrashed();
     }
 

--- a/src/cms/app/Services/Snapshot/SnapshotDataMarkdownRenderer.php
+++ b/src/cms/app/Services/Snapshot/SnapshotDataMarkdownRenderer.php
@@ -66,7 +66,14 @@ readonly class SnapshotDataMarkdownRenderer
 
         /** @var RelatedSnapshotSource $relatedSnapshotSource */
         foreach ($relatedSnapshotSources as $relatedSnapshotSource) {
-            $relatedSnapshot = $relatedSnapshotSource->snapshotSource->getLatestSnapshotWithState([Established::class]);
+            // The polymorphic target carries no foreign key, so a hard-deleted
+            // source leaves an orphan row that resolves to null.
+            $source = $relatedSnapshotSource->snapshotSource;
+            if ($source === null) {
+                continue;
+            }
+
+            $relatedSnapshot = $source->getLatestSnapshotWithState([Established::class]);
             if ($relatedSnapshot === null) {
                 continue;
             }

--- a/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
+++ b/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
@@ -43,10 +43,10 @@
         </div>
     </x-filament::section>
 
-    @foreach ($diffs as $section => $diff)
+    @foreach ($diffs as $heading => $diff)
         <x-filament::section>
             <x-slot name="heading">
-                {{ __('snapshot.' . $section . '_data') }}
+                {{ $heading }}
             </x-slot>
 
             <div class="snapshot-diff">

--- a/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
+++ b/src/cms/resources/views/filament/resources/snapshot-resource/pages/compare-snapshots.blade.php
@@ -43,10 +43,10 @@
         </div>
     </x-filament::section>
 
-    @foreach ($diffs as $heading => $diff)
+    @foreach ($diffs as $section => $diff)
         <x-filament::section>
             <x-slot name="heading">
-                {{ $heading }}
+                {{ $this->getDiffHeading($section) }}
             </x-slot>
 
             <div class="snapshot-diff">

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -9,6 +9,7 @@ use App\Filament\Resources\SnapshotResource;
 use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\Processor;
 use App\Models\RelatedSnapshotSource;
 use App\Models\Snapshot;
 use App\Models\SnapshotData;
@@ -328,15 +329,90 @@ it('reports no changes when both versions share the same related entities', func
         ]);
     }
 
-    // An unchanged link must not surface as a difference, so the section
-    // collapses to the same "no changes" message the markdown sections use.
+    // Assert on the diff the page actually built: a "no changes" message alone
+    // would also pass if the section were empty or the feature were broken.
+    $component = $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk();
+
+    $diff = (string) $component->instance()->getDiffs()['related_snapshot_sources'];
+
+    expect($diff)->toContain(__('snapshot.compare_no_changes'))
+        ->and($diff)->not->toContain('<ins')
+        ->and($diff)->not->toContain('<del');
+});
+
+it('groups related entities by type and sorts them case-insensitively', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    // Two types, two entities each, deliberately attached out of order and with
+    // mixed capitalisation: the output must still group per type and sort
+    // case-insensitively, so a reorder never reads as a change.
+    $zebra = System::factory()->recycle($organisation)->create(['description' => 'zebra-systeem']);
+    $beer = System::factory()->recycle($organisation)->create(['description' => 'Beer-systeem']);
+    $processor = Processor::factory()->recycle($organisation)->create(['name' => 'alpha-verwerker']);
+
+    foreach ([[$zebra, System::class], [$beer, System::class], [$processor, Processor::class]] as [$entity, $type]) {
+        RelatedSnapshotSource::factory()->create([
+            'snapshot_id' => $to->id,
+            'snapshot_source_id' => $entity->id,
+            'snapshot_source_type' => $type,
+        ]);
+    }
+
+    $component = $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk();
+
+    $text = strip_tags((string) $component->instance()->getDiffs()['related_snapshot_sources']);
+
+    expect($text)->toContain(__('processor.model_singular'))
+        ->and($text)->toContain(__('system.model_singular'))
+        // "Beer-systeem" before "zebra-systeem" despite the capital B.
+        ->and(mb_strpos($text, 'Beer-systeem'))->toBeLessThan(mb_strpos($text, 'zebra-systeem'));
+});
+
+it('skips related entities whose source no longer exists', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [, $to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    $system = System::factory()
+        ->recycle($organisation)
+        ->create(['description' => 'blijft-bestaan']);
+    RelatedSnapshotSource::factory()->create([
+        'snapshot_id' => $to->id,
+        'snapshot_source_id' => $system->id,
+        'snapshot_source_type' => System::class,
+    ]);
+
+    // The polymorphic target has no foreign key, so an orphan row is a real
+    // state (past migrations hard-deleted retired source types). It must not
+    // take the whole compare page down with a null dereference.
+    $orphan = System::factory()->recycle($organisation)->create();
+    RelatedSnapshotSource::factory()->create([
+        'snapshot_id' => $to->id,
+        'snapshot_source_id' => $orphan->id,
+        'snapshot_source_type' => System::class,
+    ]);
+    System::query()->whereKey($orphan->id)->forceDelete();
+
     $this->asFilamentOrganisationUser($organisation)
         ->createLivewireTestable(CompareSnapshots::class, [
             'record' => $to->getRouteKey(),
         ])
         ->assertOk()
-        ->assertSee(__('snapshot.compare_no_changes'))
-        ->assertDontSee('ongewijzigd-systeem');
+        ->assertSee('blijft-bestaan');
 });
 
 it('hides the compare header action when only one version exists', function (): void {

--- a/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
+++ b/src/cms/tests/Feature/Filament/Resources/SnapshotResource/Pages/CompareSnapshotsTest.php
@@ -9,8 +9,10 @@ use App\Filament\Resources\SnapshotResource;
 use App\Filament\Resources\SnapshotResource\Pages\CompareSnapshots;
 use App\Filament\Resources\SnapshotResource\Pages\ViewSnapshot;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
+use App\Models\RelatedSnapshotSource;
 use App\Models\Snapshot;
 use App\Models\SnapshotData;
+use App\Models\System;
 use Tests\Helpers\Model\OrganisationTestHelper;
 use Tests\Helpers\Model\UserTestHelper;
 
@@ -253,6 +255,88 @@ it('the compare header action targets the latest version', function (): void {
             'pageClass' => EditAvgResponsibleProcessingRecord::class,
         ])
         ->assertTableActionHasUrl('compare', SnapshotResource::getUrl('compare', ['record' => $latest]));
+});
+
+it('shows related entities added between versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    // Identical markdown on both sides: the only difference is the attached
+    // system, which lives in related_snapshot_sources rather than the markdown.
+    [, $to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    $system = System::factory()
+        ->recycle($organisation)
+        ->create(['description' => 'toegevoegd-systeem']);
+    RelatedSnapshotSource::factory()->create([
+        'snapshot_id' => $to->id,
+        'snapshot_source_id' => $system->id,
+        'snapshot_source_type' => System::class,
+    ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk()
+        ->assertSee(__('snapshot.related_snapshot_sources'))
+        ->assertSee(__('system.model_singular'))
+        ->assertSee('toegevoegd-systeem');
+});
+
+it('shows related entities removed between versions', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [$from, $to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    $system = System::factory()
+        ->recycle($organisation)
+        ->create(['description' => 'verwijderd-systeem']);
+    RelatedSnapshotSource::factory()->create([
+        'snapshot_id' => $from->id,
+        'snapshot_source_id' => $system->id,
+        'snapshot_source_type' => System::class,
+    ]);
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk()
+        ->assertSee('verwijderd-systeem');
+});
+
+it('reports no changes when both versions share the same related entities', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $source = AvgResponsibleProcessingRecord::factory()
+        ->recycle($organisation)
+        ->create();
+    [$from, $to] = createComparableSnapshots($source, 'zelfde-inhoud', 'zelfde-inhoud');
+
+    $system = System::factory()
+        ->recycle($organisation)
+        ->create(['description' => 'ongewijzigd-systeem']);
+
+    foreach ([$from, $to] as $snapshot) {
+        RelatedSnapshotSource::factory()->create([
+            'snapshot_id' => $snapshot->id,
+            'snapshot_source_id' => $system->id,
+            'snapshot_source_type' => System::class,
+        ]);
+    }
+
+    // An unchanged link must not surface as a difference, so the section
+    // collapses to the same "no changes" message the markdown sections use.
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(CompareSnapshots::class, [
+            'record' => $to->getRouteKey(),
+        ])
+        ->assertOk()
+        ->assertSee(__('snapshot.compare_no_changes'))
+        ->assertDontSee('ongewijzigd-systeem');
 });
 
 it('hides the compare header action when only one version exists', function (): void {

--- a/src/cms/tests/Feature/Import/Concerns/SnapshotHelperTest.php
+++ b/src/cms/tests/Feature/Import/Concerns/SnapshotHelperTest.php
@@ -7,6 +7,9 @@ use App\Config\Config;
 use App\Import\Factories\Concerns\SnapshotHelper;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Organisation;
+use App\Models\Receiver;
+use App\Models\RelatedSnapshotSource;
+use App\Models\Snapshot;
 use App\Models\States\Snapshot\Established;
 use App\Services\Snapshot\SnapshotFactory;
 use App\ValueObjects\CalendarDate;
@@ -89,4 +92,49 @@ it('creates snapshot and sets review_at', function (): void {
         ->toBe(1)
         ->and($avgResponsibleProcessingRecord->refresh()->review_at->equalTo($expectedReviewAt))
         ->toBeTrue();
+});
+
+it('skips related snapshot sources that have been hard-deleted', function (): void {
+    $organisation = Organisation::factory()->create();
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->for($organisation)
+        ->create();
+
+    // The polymorphic target has no foreign key, so hard-deleting the source
+    // leaves an orphan row. Creating related snapshots must skip it rather
+    // than dereference null.
+    $receiver = Receiver::factory()
+        ->hasAttached($avgResponsibleProcessingRecord)
+        ->recycle($organisation)
+        ->create();
+
+    // SnapshotFactory rebuilds related rows from the live relation, which drops
+    // hard-deleted records. Insert the orphan directly onto the snapshot that
+    // createRelatedSnapshots() iterates, then remove the record it points at.
+    $factory = new class {
+        use SnapshotHelper;
+
+        public function test(Snapshot $snapshot, SnapshotFactory $snapshotFactory): void
+        {
+            $this->createRelatedSnapshots($snapshot, Established::class, $snapshotFactory);
+        }
+    };
+
+    $snapshot = Snapshot::factory()
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->recycle($organisation)
+        ->create();
+
+    RelatedSnapshotSource::factory()->create([
+        'snapshot_id' => $snapshot->id,
+        'snapshot_source_id' => $receiver->id,
+        'snapshot_source_type' => Receiver::class,
+    ]);
+
+    Receiver::query()->whereKey($receiver->id)->forceDelete();
+
+    $factory->test($snapshot->fresh(), app(SnapshotFactory::class));
+
+    // The orphan row is skipped, so no snapshot is created for the receiver.
+    expect(Snapshot::query()->where('snapshot_source_id', $receiver->id)->count())->toBe(0);
 });

--- a/src/cms/tests/Feature/Livewire/Snapshot/RelatedSnapshotSourcesTest.php
+++ b/src/cms/tests/Feature/Livewire/Snapshot/RelatedSnapshotSourcesTest.php
@@ -123,3 +123,36 @@ it('can load the table', function (): void {
             $obsoleteProcessorSnapshotSource,
         ]);
 });
+
+it('renders rows whose source has been hard-deleted', function (): void {
+    $organisation = OrganisationTestHelper::create();
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->create();
+    $snapshot = Snapshot::factory()
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->recycle($organisation)
+        ->create();
+
+    // The polymorphic target has no foreign key, so hard-deleting the source
+    // leaves an orphan row. The table must still render: no record link, no
+    // view action, and a placeholder instead of a display name.
+    $processor = Processor::factory()
+        ->recycle($organisation)
+        ->create();
+    $orphan = RelatedSnapshotSource::factory()
+        ->for($snapshot)
+        ->create([
+            'snapshot_id' => $snapshot->id,
+            'snapshot_source_id' => $processor->id,
+            'snapshot_source_type' => Processor::class,
+        ]);
+    Processor::query()->whereKey($processor->id)->forceDelete();
+
+    $this->asFilamentOrganisationUser($organisation)
+        ->createLivewireTestable(RelatedSnapshotSources::class, [
+            'snapshot' => $snapshot,
+        ])
+        ->assertOk()
+        ->assertCanSeeTableRecords([$orphan])
+        ->assertTableActionHidden('view', $orphan);
+});

--- a/src/cms/tests/Feature/Services/Snapshot/SnapshotDataMarkdownRendererTest.php
+++ b/src/cms/tests/Feature/Services/Snapshot/SnapshotDataMarkdownRendererTest.php
@@ -161,3 +161,44 @@ it('can render but without related records if snapshot not yet established', fun
 
     expect($markdown)->toMatchSnapshot();
 })->with(SnapshotDataSection::cases());
+
+it('skips related records whose source has been hard-deleted', function (): void {
+    $organisation = Organisation::factory()
+        ->create();
+    $avgResponsibleProcessingRecord = AvgResponsibleProcessingRecord::factory()
+        ->create();
+
+    $snapshot = Snapshot::factory()
+        ->for($avgResponsibleProcessingRecord, 'snapshotSource')
+        ->recycle($organisation)
+        ->create();
+    $snapshotData = SnapshotData::factory()
+        ->for($snapshot)
+        ->create([
+            'public_markdown' => 'Voorwoord.<!--- #App\Models\Receiver# --->',
+        ]);
+
+    // The polymorphic target has no foreign key, so hard-deleting the source
+    // leaves an orphan row. Rendering must skip it instead of dereferencing null.
+    $receiver = Receiver::factory()
+        ->hasAttached($avgResponsibleProcessingRecord)
+        ->create();
+    RelatedSnapshotSource::factory()
+        ->create([
+            'snapshot_id' => $snapshot->id,
+            'snapshot_source_id' => $receiver->id,
+            'snapshot_source_type' => $receiver::class,
+        ]);
+    Receiver::query()->whereKey($receiver->id)->forceDelete();
+
+    /** @var SnapshotDataMarkdownRenderer $snapshotDataMarkdownRenderer */
+    $snapshotDataMarkdownRenderer = $this->app->get(SnapshotDataMarkdownRenderer::class);
+
+    $markdown = $snapshotDataMarkdownRenderer->fromSnapshotMarkdown(
+        $snapshot->fresh(),
+        $snapshotData->public_markdown,
+        SnapshotDataSection::PUBLIC,
+    );
+
+    expect($markdown)->toContain('Voorwoord.');
+});


### PR DESCRIPTION
## Probleem

Versie vergelijken toonde geen wijzigingen in many-to-many relaties. Alles onder **Beheer** dat als placeholder-tag wordt opgeslagen was onzichtbaar in de diff: Verwerkingsverantwoordelijken, Verwerkers, Ontvangers, Systemen/Applicaties en Contactpersonen.

De oorzaak: de diff vergeleek alleen de opgeslagen markdown. Die relaties staan daar niet in — de markdown bevat enkel een inerte placeholder-tag (`<!--- #App\Models\System# --->`) die byte-identiek is tussen versies. De werkelijke koppelingen staan in `related_snapshot_sources`. Drie systemen toevoegen veranderde dus niets aan wat de diff bekeek, en de pagina meldde "Geen wijzigingen".

Labels en Documenten werkten al wel: die worden als tekst in de markdown geschreven.

## Oplossing

Een derde sectie **Gerelateerde entiteiten** rendert de vastgelegde koppelingen van beide versies naar een stabiel tekstblok (gegroepeerd per entiteitstype) en diff't dat met dezelfde engine, zodat styling en "Geen wijzigingen" gedrag gelijk blijven.

Alleen de *identiteit* van de entiteit wordt gediff't, niet de gerenderde inhoud. `SnapshotDataMarkdownRenderer` lost elke koppeling bij het renderen op naar de op dat moment vastgestelde snapshot — dat is geen functie van de bekeken versie en zou spookverschillen opleveren. De koppelingsrijen zelf zijn wél stabiel per versie.

Regels worden gesorteerd op type en (hoofdletterongevoelig) naam, zodat een herordende vastlegging niet als wijziging leest.

## Verder in deze PR

- **Crash bij verweesde koppelingen.** Het polymorfe doel heeft geen foreign key (`uuidMorphs` maakt alleen een index), dus een hard verwijderde bron laat een rij achter die naar `null` resolvet. Dat sloopte de *hele* vergelijkpagina met `getDisplayName() on null`. Twee bestaande opruim-migraties bewijzen dat deze datavorm echt voorkomt. Zulke rijen worden nu overgeslagen.
- **`RelatedSnapshotSource::snapshotSource()` eager-loadbaar gemaakt.** De owner key ontbrak, waardoor MorphTo terugviel op `$result->getKey()` — door `HasUuidAsId` een `UuidInterface`-object, wat niet als array-offset kan. Met expliciete owner key werkt eager loading: 4 queries in plaats van één per rij.
- **Docblock gecorrigeerd**: `$snapshotSource` claimde non-null, wat PHPStan geloofde en de crash weerlegde.
- Diff-keys blijven locale-onafhankelijke slugs; de view bepaalt de kop.

## Verificatie

- 19 tests in `CompareSnapshotsTest` slagen, waaronder nieuwe tests voor toegevoegd/verwijderd/ongewijzigd, groepering met twee typen, hoofdletterongevoelige sortering en de verweesde-koppeling regressie. Die laatste faalt aantoonbaar zonder de fix.
- Volledige suite: 1567 tests groen. De 4 falende `HugoStaticWebsiteGenerator`-tests falen ook op ongewijzigde code (lokaal ontbrekende binary).
- PHPStan max level en PHPCS schoon.
- Handmatig nagelopen in de draaiende applicatie met alle vijf entiteitstypen tegelijk.

## Nog open (buiten scope)

WPG-verwerkingen leggen alleen `wpgGoals` vast in hun markdown; `tags`, `documents`, `users` en `dataBreachRecords` staan wel op het model maar niet in de template. Dat is een gat in snapshot-*generatie*, niet in de vergelijkweergave, en vraagt een eigen fix.
