### PR TITLE
feat: opt-in object storage voor gedeelde disks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,6 @@ jobs:
         ports:
           - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
-      minio:
-        image: bitnami/minio:latest
-        env:
-          MINIO_ROOT_USER: minioadmin
-          MINIO_ROOT_PASSWORD: minioadmin
-        ports:
-          - 9000:9000
-        options: --health-cmd "mc ready local" --health-interval 10s --health-timeout 5s --health-retries 5
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -151,6 +143,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+
+      # Run as a step rather than a service container: minio needs `server /data`
+      # as its command, and service containers cannot set one -- the entrypoint
+      # then just prints its help and exits. Same pinned tag as docker-compose.
+      - name: Start MinIO
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -e "MINIO_ROOT_USER=minioadmin" \
+            -e "MINIO_ROOT_PASSWORD=minioadmin" \
+            minio/minio:RELEASE.2025-09-07T16-13-09Z \
+            server /data
+
+          echo "Waiting for MinIO to be ready..."
+          timeout 60s bash -c 'until curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; do sleep 2; done'
+          echo "MinIO is ready!"
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -189,3 +198,7 @@ jobs:
             tests/Feature/Console
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+
+      - name: Stop MinIO
+        if: always()
+        run: docker stop minio && docker rm minio || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,84 @@ jobs:
         run: php artisan test --parallel --coverage --min=100 --log-junit=reports/report-phpunit.xml --coverage-clover=reports/coverage-phpunit.xml
         env:
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
+
+  # The CI job above covers the default (local disk) configuration. This one runs
+  # the storage-sensitive suites against a real S3 backend, so the object-storage
+  # path cannot silently rot: Filesystem::path() returns a bare key on s3 rather
+  # than failing, which makes the breakage invisible to a local-disk-only run.
+  object-storage:
+    env:
+      DB_CONNECTION: pgsql
+      DB_HOST: localhost
+      DB_PASSWORD: postgres
+      DB_USERNAME: postgres
+      DB_DATABASE: postgres
+      FILESYSTEM_SHARED_DRIVER: s3
+      AWS_ENDPOINT: http://localhost:9000
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+      AWS_DEFAULT_REGION: eu-central-1
+      AWS_USE_PATH_STYLE_ENDPOINT: true
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
+      minio:
+        image: bitnami/minio:latest
+        env:
+          MINIO_ROOT_USER: minioadmin
+          MINIO_ROOT_PASSWORD: minioadmin
+        ports:
+          - 9000:9000
+        options: --health-cmd "mc ready local" --health-interval 10s --health-timeout 5s --health-retries 5
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./src/cms
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: pgsql
+
+      - name: Install exiftool
+        run: sudo apt-get update && sudo apt-get install -y exiftool
+
+      - name: Copy env
+        run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+
+      - name: Composer install
+        run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+
+      - name: Prepare application
+        run: php artisan key:generate
+
+      - name: Clear Config
+        run: php artisan config:clear
+
+      - name: Run Migration
+        run: php artisan migrate:fresh
+
+      - name: Create buckets
+        run: php artisan storage:setup-buckets
+
+      - name: Phpunit (storage-sensitive suites against real object storage)
+        run: |
+          php artisan test \
+            tests/Feature/Transfer \
+            tests/Feature/Jobs \
+            tests/Feature/Http/Controllers \
+            tests/Feature/Filament/Pages \
+            tests/Feature/Console
+        env:
+          DB_PORT: ${{ job.services.postgres.ports[5432] }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,6 +161,21 @@ jobs:
           timeout 60s bash -c 'until curl -sf http://localhost:9000/minio/health/live >/dev/null 2>&1; do sleep 2; done'
           echo "MinIO is ready!"
 
+      - name: Install Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "18"
+          cache: "npm"
+          registry-url: "https://npm.pkg.github.com"
+          cache-dependency-path: "**/package-lock.json"
+
+      - name: Install npm dependencies
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN"  >> ~/.npmrc
+          npm ci --ignore-scripts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.REPO_READ_ONLY_TOKEN }}
+
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -178,6 +193,12 @@ jobs:
 
       - name: Prepare application
         run: php artisan key:generate
+
+      # Blade views resolve assets through the Vite manifest, so tests that render
+      # a page fail without it -- unrelated to storage, but they sit in the same
+      # suites as the storage-sensitive ones.
+      - name: Npm build
+        run: npm run build
 
       - name: Clear Config
         run: php artisan config:clear

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -26,6 +26,7 @@ not set.
 - `OUTBOX_SMTP_FROM` from-address for sending e-mail, (default is not set)
 - `FILESYSTEM_STATIC_WEBSITE_ROOT` root-folder for the static-website (default: `<laravel-storage-path>/app`)
 - `FILESYSTEM_SHARED_STORAGE_PATH` root-folder for shared storage (default: `<laravel-storage-path>/app/shared-storage`)
+- `FILESYSTEM_SHARED_DRIVER` driver for the shared disks, `local` or `s3` (default: `local`). See [object_storage.md](object_storage.md)
 - `VIRUSSCANNER_DEFAULT` default virus-scanner (default: `clamav`)
 - `VIRUSSCANNER_SOCKET` socket for the virus-scanner (default: `unix:///var/run/clamav/clamd.ctl`)
 - `CLAMAV_SOCKET_READ_TIMEOUT` read timeout for the clamav socket (default: `30`)
@@ -90,6 +91,18 @@ The following environment variables are used to configure the application in `sr
 
 - `FILESYSTEM_SHARED_STORAGE_PATH` (default: `app/shared-storage`)
 - `FILESYSTEM_STATIC_WEBSITE_ROOT` (default: `app/static-website`)
+- `FILESYSTEM_SHARED_DRIVER` (default: `local`)
+
+**OBJECT STORAGE** (only when `FILESYSTEM_SHARED_DRIVER=s3`):
+
+- `AWS_ENDPOINT` endpoint of the S3-compatible service (default is not set)
+- `AWS_ACCESS_KEY_ID` (default is not set)
+- `AWS_SECRET_ACCESS_KEY` (default is not set)
+- `AWS_DEFAULT_REGION` (default: `eu-central-1`)
+- `AWS_USE_PATH_STYLE_ENDPOINT` (default: `true`)
+- `UPLOADS_BUCKET` bucket for the media-library disk (default: `uploads`)
+- `EXPORTS_BUCKET` bucket for the filament disk (default: `exports`)
+- `TRANSFER_BUCKET` bucket for the transfer disk (default: `transfer`)
 
 **LOGGING:**
 

--- a/docs/local_development_without_docker.md
+++ b/docs/local_development_without_docker.md
@@ -6,8 +6,9 @@ met name handig voor het genereren van screenshots voor de handleiding.
 
 De services die niet native beschikbaar zijn, hebben allebei een ingebouwde
 uitweg: de virusscanner en de OTP-verificatie kennen een `fake` driver. Voor
-bestandsopslag is helemaal geen vervanging nodig — de uploads- en exports-disks
-zijn sinds het verwijderen van MinIO gewoon lokale schijven.
+bestandsopslag is standaard geen vervanging nodig — de uploads-, exports- en
+transfer-disks staan gewoon op de lokale schijf. Wil je de objectopslag-variant
+lokaal draaien, zie [object_storage.md](object_storage.md).
 
 ## Vereisten
 
@@ -47,11 +48,13 @@ Verdere commando's:
 | Commando | Doet |
 |---|---|
 | `just setup-native` | Volledige setup vanaf niets |
+| `just setup-native-object-storage` | Idem, plus minio en een `.env` op objectopslag |
 | `just doctor-native` | Controleert de omgeving en meldt wat ontbreekt |
 | `just dev-native [port]` | Start de applicatie (standaard poort 8000) |
 | `just dev-native-login [email]` | Magic link (standaard `admin@example.com`) |
 | `just dev-native-reset` | Database opnieuw opbouwen en seeden |
 | `just test-native [args]` | Testsuite draaien met PHP 8.4 |
+| `just minio-native-up` / `-down` | Start of stopt minio als brew-service |
 
 Werkt er iets niet, draai dan `just doctor-native`: die controleert PHP-versie
 en -extensies, de tools, beide databases, `.env`, `APP_KEY`, dependencies en de

--- a/docs/object_storage.md
+++ b/docs/object_storage.md
@@ -1,0 +1,92 @@
+# Objectopslag (S3 / MinIO)
+
+De gedeelde disks staan standaard op de lokale schijf. Objectopslag is *opt-in*:
+zet `FILESYSTEM_SHARED_DRIVER=s3` en dezelfde disks draaien op een
+S3-compatibele bucket. Dat is bedoeld voor deployments met meerdere nodes, waar
+uploads niet aan één machine vast mogen zitten.
+
+Zonder die variabele verandert er niets — lokaal, in CI en in bestaande
+deployments blijft alles op schijf staan.
+
+## De gedeelde disks
+
+| Disk | Bucket-variabele | Inhoud |
+|---|---|---|
+| `media-library` | `UPLOADS_BUCKET` (`uploads`) | Bijlagen bij documenten |
+| `filament` | `EXPORTS_BUCKET` (`exports`) | Filament-exports (xlsx) |
+| `transfer` | `TRANSFER_BUCKET` (`transfer`) | Import/export-bundels tussen organisaties |
+
+`transfer` staat los van `filament` omdat een transfer-bundel de volledige
+registerinhoud van een organisatie bevat. De `filament`-disk is `public`; op een
+bucket zou dat betekenen dat die zips voor iedereen leesbaar zijn. De
+`transfer`-disk is daarom `private`.
+
+## Configuratie
+
+```dotenv
+FILESYSTEM_SHARED_DRIVER=s3
+AWS_ENDPOINT=http://minio:9000
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_DEFAULT_REGION=eu-central-1
+AWS_USE_PATH_STYLE_ENDPOINT=true
+```
+
+Daarna moeten de buckets bestaan:
+
+```bash
+php artisan storage:setup-buckets
+```
+
+Het commando is idempotent en doet niets zolang de disks op `local` staan, dus
+het kan zonder voorwaarden in een deploy-script.
+
+## Lokaal draaien
+
+**Met Docker** — minio zit achter een compose-profile en start dus niet mee met
+een gewone `sail up`:
+
+```bash
+just minio-up      # start minio en maakt de buckets aan
+just minio-down    # stopt minio, volume blijft staan
+```
+
+De console draait op http://localhost:9001 (`minioadmin` / `minioadmin`).
+
+**Zonder Docker** — de setup installeert minio als brew-service en zet de
+`.env` meteen goed:
+
+```bash
+just setup-native-object-storage
+```
+
+Op een bestaande installatie kan het ook los:
+
+```bash
+just minio-native-up
+just minio-buckets
+```
+
+`just doctor-native` controleert daarna of er iets op poort 9000 luistert,
+maar alleen als de `.env` daadwerkelijk `FILESYSTEM_SHARED_DRIVER=s3` zet.
+
+> De Homebrew-formule `minio` is upstream gearchiveerd en verdwijnt op
+> 2027-02-17. Er zit niets minio-specifieks in de code: elke S3-compatibele
+> server op dezelfde poort werkt, bijvoorbeeld `seaweedfs` of `garage`.
+
+## Waarom de applicatiecode dit moet weten
+
+`Filesystem::path()` bestaat alleen echt op de lokale driver. Op s3 gooit die
+geen fout maar geeft hij de kale object-key terug, wat als relatief pad wordt
+geïnterpreteerd. Code die dat pad aan `ZipArchive` of `response()->download()`
+geeft, faalt dus stil: het bestand belandt ergens anders, of de download geeft
+een 404.
+
+Alles wat met bundels werkt, loopt daarom via `App\Transfer\TransferBundleStorage`.
+Die schrijft en leest via streams en zet een tijdelijke lokale kopie klaar waar
+`ZipArchive` een echt pad nodig heeft. Mediabestanden worden via
+`Storage::disk($media->disk)` en `getPathRelativeToRoot()` gelezen, niet via
+`Media::getPath()` — dat laatste kent dezelfde valkuil.
+
+De CI-job `object-storage` draait de opslaggevoelige suites tegen een echte
+minio, zodat dit pad niet ongemerkt kan verrotten.

--- a/justfile
+++ b/justfile
@@ -93,6 +93,30 @@ dev-down:
 dev-shell:
     cd src/cms && ./vendor/bin/sail shell
 
+# Object Storage (opt-in)
+# =======================
+# Set FILESYSTEM_SHARED_DRIVER=s3 in src/cms/.env to actually use these disks.
+
+# Start minio alongside the Docker environment and create its buckets
+minio-up:
+    cd src/cms && docker compose --profile object-storage up -d minio minio-setup
+
+# Stop minio (leaves its volume intact)
+minio-down:
+    cd src/cms && docker compose --profile object-storage stop minio
+
+# Start minio for the native (Docker-less) setup
+minio-native-up:
+    brew services start minio
+
+# Stop minio for the native setup
+minio-native-down:
+    brew services stop minio
+
+# Create the buckets for whichever object storage is configured
+minio-buckets:
+    cd src/cms && "$(brew --prefix php@8.4)/bin/php" artisan storage:setup-buckets
+
 # Reset the development environment
 dev-reset:
     cd src/cms && composer run reset
@@ -108,6 +132,10 @@ login-link email="admin@example.com":
 # Install dependencies, create the database, and seed test data
 setup-native:
     ./scripts/setup-local-dev.sh
+
+# Same, plus minio and an .env switched to object storage (see docs/object_storage.md)
+setup-native-object-storage:
+    ./scripts/setup-local-dev.sh --with-object-storage
 
 # Check the native environment and report what is missing
 doctor-native:

--- a/scripts/check-local-dev.sh
+++ b/scripts/check-local-dev.sh
@@ -8,6 +8,7 @@ PHP_FORMULA="php@8.4"
 DB_PORT="${DB_PORT:-5432}"
 DB_NAME="${DB_NAME:-openvwr_local}"
 TEST_DB_NAME="${TEST_DB_NAME:-testing}"
+MINIO_PORT="${MINIO_PORT:-9000}"
 
 if [[ -t 1 ]]; then
     C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'; C_RED=$'\033[0;31m'; C_OFF=$'\033[0m'
@@ -108,6 +109,21 @@ if pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1; then
 else
     bad "PostgreSQL not reachable on 127.0.0.1:$DB_PORT"
     hint "brew services start postgresql@15, or start Postgres.app"
+fi
+
+# --- Object storage ---------------------------------------------------------
+
+# Only a problem when the .env opts in: on the default local driver there is
+# nothing to run, and a missing minio is the expected state.
+if grep -qE '^FILESYSTEM_SHARED_DRIVER=s3' "$CMS_DIR/.env" 2>/dev/null; then
+    if curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1; then
+        ok "Object storage reachable on port $MINIO_PORT (FILESYSTEM_SHARED_DRIVER=s3)"
+    else
+        bad ".env sets FILESYSTEM_SHARED_DRIVER=s3 but nothing answers on 127.0.0.1:$MINIO_PORT"
+        hint "brew services start minio, or unset FILESYSTEM_SHARED_DRIVER to use local disks"
+    fi
+else
+    ok "Shared disks on the local filesystem (object storage not enabled)"
 fi
 
 # --- Application ------------------------------------------------------------

--- a/scripts/setup-local-dev.sh
+++ b/scripts/setup-local-dev.sh
@@ -11,6 +11,17 @@ TEST_DB_NAME="${TEST_DB_NAME:-testing}"
 DB_USER="${DB_USER:-sail}"
 DB_PASSWORD="${DB_PASSWORD:-password}"
 DB_PORT="${DB_PORT:-5432}"
+MINIO_PORT="${MINIO_PORT:-9000}"
+
+# Object storage is opt-in: without this flag the shared disks stay on the local
+# filesystem, which is what most local work wants. See docs/object_storage.md.
+WITH_OBJECT_STORAGE=0
+for arg in "$@"; do
+    case "$arg" in
+        --with-object-storage) WITH_OBJECT_STORAGE=1 ;;
+        *) printf 'Unknown option: %s\n' "$arg" >&2; exit 1 ;;
+    esac
+done
 
 if [[ -t 1 ]]; then
     C_BLUE=$'\033[0;34m'; C_GREEN=$'\033[0;32m'; C_YELLOW=$'\033[0;33m'
@@ -55,6 +66,25 @@ else
     done
     pg_isready -h 127.0.0.1 -p "$DB_PORT" >/dev/null 2>&1 \
         || fail "PostgreSQL did not become reachable on port $DB_PORT."
+fi
+
+if [[ "$WITH_OBJECT_STORAGE" -eq 1 ]]; then
+    # The formula is deprecated upstream (disabled 2027-02-17) but still installs,
+    # and it matches the minio used in Docker and CI. If it ever disappears, run
+    # any S3-compatible server on $MINIO_PORT instead -- nothing here is minio-specific.
+    if curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1; then
+        ok "Object storage already reachable on port $MINIO_PORT"
+    else
+        install_formula minio
+        info "Starting minio on port $MINIO_PORT..."
+        brew services start minio >/dev/null
+        for _ in $(seq 1 30); do
+            curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1 && break
+            sleep 1
+        done
+        curl -sf "http://127.0.0.1:${MINIO_PORT}/minio/health/live" >/dev/null 2>&1 \
+            || fail "minio did not become reachable on port $MINIO_PORT."
+    fi
 fi
 
 PHP_BIN="$(brew --prefix "$PHP_FORMULA")/bin/php"
@@ -125,6 +155,22 @@ else
     cp .env.nodocker.example .env
 fi
 
+# The .env is left untouched when it already exists, so append the object-storage
+# settings only when they are absent -- re-running must not duplicate them.
+if [[ "$WITH_OBJECT_STORAGE" -eq 1 ]] && ! grep -q '^FILESYSTEM_SHARED_DRIVER=' .env; then
+    info "Adding object-storage settings to .env..."
+    cat >> .env <<EOF
+
+# Object storage (added by setup-local-dev.sh --with-object-storage)
+FILESYSTEM_SHARED_DRIVER=s3
+AWS_ENDPOINT=http://127.0.0.1:${MINIO_PORT}
+AWS_ACCESS_KEY_ID=minioadmin
+AWS_SECRET_ACCESS_KEY=minioadmin
+AWS_DEFAULT_REGION=eu-central-1
+AWS_USE_PATH_STYLE_ENDPOINT=true
+EOF
+fi
+
 info "Installing composer dependencies..."
 "$PHP_BIN" "$COMPOSER_BIN" install --no-interaction
 
@@ -140,6 +186,11 @@ fi
 info "Installing npm dependencies and building assets..."
 npm install --silent
 npm run build
+
+if [[ "$WITH_OBJECT_STORAGE" -eq 1 ]]; then
+    info "Creating object-storage buckets..."
+    "$PHP_BIN" artisan storage:setup-buckets
+fi
 
 info "Running migrations..."
 "$PHP_BIN" artisan migrate --force

--- a/src/cms/.env.example
+++ b/src/cms/.env.example
@@ -31,10 +31,35 @@ HUGO_OUTPUT_DIR=/var/www/html/storage/app/static-website
 # Root directory of the Hugo project (where build.sh, themes, layouts are located)
 FILESYSTEM_STATIC_WEBSITE_ROOT=/var/www/html/static-website
 
-# Root for the media-library (uploads) and filament (exports) disks. Defaults to
-# storage_path('app/shared-storage'), which is correct for local dev and CI alike.
-# Set this only in a deployment that keeps the directory outside the release dir,
-# so uploads survive releases and stay in sync across nodes.
+# Root for the media-library (uploads), filament (exports) and transfer disks when
+# they run on the local driver. Defaults to storage_path('app/shared-storage'),
+# which is correct for local dev and CI alike. Set this only in a deployment that
+# keeps the directory outside the release dir, so uploads survive releases and stay
+# in sync across nodes.
 # FILESYSTEM_SHARED_STORAGE_PATH=/srv/openvwr/shared-storage
+
+# Object storage (opt-in). Leave unset to keep the shared disks on the local
+# filesystem. Set to "s3" to move uploads, exports and transfer bundles to an
+# S3-compatible bucket; the AWS_* settings below then apply and the buckets must
+# exist (`php artisan storage:setup-buckets`). See docs/object_storage.md.
+# For Docker: `just minio-up`. Docker-less: `just setup-native-object-storage`.
+# FILESYSTEM_SHARED_DRIVER=s3
+
+# MinIO defaults for local development; a real deployment points these at its own
+# endpoint and credentials.
+# MINIO_PORT=9000
+# MINIO_CONSOLE_PORT=9001
+# MINIO_ROOT_USER=minioadmin
+# MINIO_ROOT_PASSWORD=minioadmin
+# AWS_ENDPOINT=http://minio:9000
+# AWS_ACCESS_KEY_ID=minioadmin
+# AWS_SECRET_ACCESS_KEY=minioadmin
+# AWS_DEFAULT_REGION=eu-central-1
+# AWS_USE_PATH_STYLE_ENDPOINT=true
+
+# Bucket names, one per shared disk. Defaults match the disk purpose.
+# UPLOADS_BUCKET=uploads
+# EXPORTS_BUCKET=exports
+# TRANSFER_BUCKET=transfer
 
 AUDIT_SYSLOG_BASE64_ENCODE_ENABLED=false

--- a/src/cms/.env.nodocker.example
+++ b/src/cms/.env.nodocker.example
@@ -41,6 +41,17 @@ STATIC_WEBSITE_PORT=8080
 
 AUDIT_SYSLOG_BASE64_ENCODE_ENABLED=false
 
+# Object storage (opt-in). Zonder deze regels staan uploads, exports en
+# transfer-bundles gewoon op de lokale schijf, wat voor de meeste lokale
+# ontwikkeling prima is. `just setup-native-object-storage` installeert minio en
+# zet deze waarden automatisch. Zie docs/object_storage.md.
+# FILESYSTEM_SHARED_DRIVER=s3
+# AWS_ENDPOINT=http://127.0.0.1:9000
+# AWS_ACCESS_KEY_ID=minioadmin
+# AWS_SECRET_ACCESS_KEY=minioadmin
+# AWS_DEFAULT_REGION=eu-central-1
+# AWS_USE_PATH_STYLE_ENDPOINT=true
+
 
 # --- Local (Docker-less) overrides ---
 VIRUSSCANNER_DEFAULT=fake
@@ -48,5 +59,5 @@ MAIL_MAILER=log
 # Debug toolbar off: it renders over the UI in screenshots.
 DEBUGBAR_ENABLED=false
 
-# De uploads- en exports-disks zijn lokaal (storage/app/shared-storage); er is
-# geen objectopslag nodig. Zie config/filesystems.php.
+# De uploads-, exports- en transfer-disks staan standaard lokaal
+# (storage/app/shared-storage). Objectopslag is optioneel; zie hierboven.

--- a/src/cms/app/Console/Commands/StorageSetupBuckets.php
+++ b/src/cms/app/Console/Commands/StorageSetupBuckets.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Config\Config;
+use Aws\S3\S3Client;
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\AwsS3V3Adapter as LaravelAwsS3V3Adapter;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Creates the buckets backing the shared disks.
+ *
+ * Object storage is opt-in (FILESYSTEM_SHARED_DRIVER), so this is a no-op unless
+ * the disks actually run on s3: on a local disk the directories are created on
+ * demand and there is nothing to provision. Safe to run repeatedly -- existing
+ * buckets are left alone.
+ */
+#[AsCommand(name: 'storage:setup-buckets', description: 'Create the buckets for the shared object-storage disks')]
+class StorageSetupBuckets extends Command
+{
+    private const array DISKS = ['media-library', 'filament', 'transfer'];
+
+    public function handle(): int
+    {
+        foreach (self::DISKS as $diskName) {
+            if (Config::string(sprintf('filesystems.disks.%s.driver', $diskName)) !== 's3') {
+                $this->info(sprintf('Disk %s is not on object storage, nothing to create.', $diskName));
+
+                continue;
+            }
+
+            if (!$this->createBucket($diskName)) {
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function createBucket(string $diskName): bool
+    {
+        $bucket = Config::string(sprintf('filesystems.disks.%s.bucket', $diskName));
+        $disk = Storage::disk($diskName);
+
+        if (!$disk instanceof LaravelAwsS3V3Adapter) {
+            $this->error(sprintf('Disk %s does not expose an S3 client.', $diskName));
+
+            return false;
+        }
+
+        /** @var S3Client $s3Client */
+        $s3Client = $disk->getClient();
+
+        try {
+            if ($s3Client->doesBucketExistV2($bucket)) {
+                $this->info(sprintf('Bucket %s already exists.', $bucket));
+
+                return true;
+            }
+
+            $s3Client->createBucket(['Bucket' => $bucket]);
+            $this->info(sprintf('Bucket %s created successfully.', $bucket));
+        } catch (Throwable $e) {
+            $this->error(sprintf('Error with bucket %s: %s', $bucket, $e->getMessage()));
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/cms/app/Filament/Pages/TransferImport.php
+++ b/src/cms/app/Filament/Pages/TransferImport.php
@@ -13,6 +13,7 @@ use App\Jobs\TransferImportJob;
 use App\Rules\Virusscanner;
 use App\Transfer\Import\BundleReader;
 use App\Transfer\Import\PreviewBuilder;
+use App\Transfer\TransferBundleStorage;
 use App\Transfer\TransferException;
 use Carbon\CarbonImmutable;
 use Filament\Forms\Components\FileUpload;
@@ -22,7 +23,6 @@ use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Livewire\Attributes\Locked;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
@@ -32,7 +32,6 @@ use function __;
 use function app;
 use function basename;
 use function collect;
-use function fopen;
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -41,7 +40,7 @@ class TransferImport extends Page implements HasForms
 {
     use InteractsWithForms;
 
-    public const string DISK = 'filament';
+    public const string DISK = TransferBundleStorage::DISK;
     public const string IMPORT_DIRECTORY = 'transfer/imports';
 
     protected static ?string $slug = 'transfer-import';
@@ -87,6 +86,13 @@ class TransferImport extends Page implements HasForms
         return __('transfer.import_page_title');
     }
 
+    // Resolved on demand rather than injected: Livewire components have no
+    // constructor arguments, and public properties get serialized per request.
+    private function bundleStorage(): TransferBundleStorage
+    {
+        return app(TransferBundleStorage::class);
+    }
+
     public function form(Form $form): Form
     {
         return $form->schema([
@@ -113,16 +119,15 @@ class TransferImport extends Page implements HasForms
         $file = is_array($files) ? collect($files)->first() : $files;
         Assert::isInstanceOf($file, TemporaryUploadedFile::class);
 
-        $disk = Storage::disk(self::DISK);
         $bundlePath = sprintf('%s/%s.zip', self::IMPORT_DIRECTORY, Uuid::generate()->toString());
-        $stream = fopen($file->getRealPath(), 'rb');
-        Assert::resource($stream);
-        $disk->put($bundlePath, $stream);
+        $this->bundleStorage()->putFile($bundlePath, $file->getRealPath());
 
         try {
-            $bundle = $bundleReader->read($disk->path($bundlePath));
+            // Read the upload where it already sits locally; the copy on the disk
+            // is only there for the queued job to pick up later.
+            $bundle = $bundleReader->read($file->getRealPath());
         } catch (TransferException $exception) {
-            $disk->delete($bundlePath);
+            $this->bundleStorage()->delete($bundlePath);
 
             Notification::make()
                 ->title(__('transfer.import_invalid_file'))
@@ -198,7 +203,7 @@ class TransferImport extends Page implements HasForms
         $bundlePath = $this->safeBundlePath();
 
         if ($bundlePath !== null) {
-            Storage::disk(self::DISK)->delete($bundlePath);
+            $this->bundleStorage()->delete($bundlePath);
         }
 
         $this->reset('bundlePath', 'sourceOrganisation', 'exportedAt', 'items');

--- a/src/cms/app/Http/Controllers/TransferExportDownloadController.php
+++ b/src/cms/app/Http/Controllers/TransferExportDownloadController.php
@@ -9,15 +9,14 @@ use App\Transfer\Export\BundleExporter;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Webmozart\Assert\InvalidArgumentException;
 
 use function abort_if;
 use function abort_unless;
 use function basename;
 use function redirect;
-use function response;
 use function sprintf;
 
 class TransferExportDownloadController extends Controller
@@ -27,7 +26,7 @@ class TransferExportDownloadController extends Controller
     ) {
     }
 
-    public function __invoke(Request $request, string $filename): RedirectResponse|BinaryFileResponse
+    public function __invoke(Request $request, string $filename): RedirectResponse|StreamedResponse
     {
         try {
             $user = $this->authenticationService->user();
@@ -42,6 +41,8 @@ class TransferExportDownloadController extends Controller
 
         abort_unless($disk->exists($path), Response::HTTP_NOT_FOUND);
 
-        return response()->download($disk->path($path));
+        // Streamed rather than a file download: on object storage there is no
+        // local path to hand to the kernel.
+        return $disk->download($path, basename($filename));
     }
 }

--- a/src/cms/app/Jobs/TransferImportJob.php
+++ b/src/cms/app/Jobs/TransferImportJob.php
@@ -11,6 +11,7 @@ use App\Models\Organisation;
 use App\Models\User;
 use App\Services\BuildContextService;
 use App\Transfer\Import\BundleImporter;
+use App\Transfer\TransferBundleStorage;
 use Filament\Notifications\Notification;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -18,7 +19,6 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Throwable;
 
 use function __;
@@ -30,7 +30,7 @@ class TransferImportJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
-    public const string DISK = 'filament';
+    public const string DISK = TransferBundleStorage::DISK;
 
     /**
      * @param array<string, array{selected: bool, strategy: ?string}> $plan
@@ -44,17 +44,23 @@ class TransferImportJob implements ShouldQueue
         $this->onQueue(Queue::DEFAULT);
     }
 
-    public function handle(BundleImporter $bundleImporter, BuildContextService $buildContextService): void
-    {
+    public function handle(
+        BundleImporter $bundleImporter,
+        BuildContextService $buildContextService,
+        TransferBundleStorage $bundleStorage,
+    ): void {
         $organisation = Organisation::query()->findOrFail($this->organisationId);
         $user = User::query()->findOrFail($this->userId);
-
-        $disk = Storage::disk(self::DISK);
 
         $buildContextService->disableBuild();
 
         try {
-            $result = $bundleImporter->importZip($disk->path($this->bundlePath), $this->plan, $organisation, $user);
+            // The bundle may live in object storage, so work on a local copy:
+            // importZip() opens it with ZipArchive, which needs a real path.
+            $result = $bundleStorage->withLocalCopy(
+                $this->bundlePath,
+                fn (string $localPath) => $bundleImporter->importZip($localPath, $this->plan, $organisation, $user),
+            );
         } catch (Throwable $exception) {
             Log::error('transfer import failed', ['message' => $exception->getMessage()]);
 
@@ -67,7 +73,7 @@ class TransferImportJob implements ShouldQueue
             return;
         } finally {
             $buildContextService->enableBuild();
-            $disk->delete($this->bundlePath);
+            $bundleStorage->delete($this->bundlePath);
         }
 
         BuildEvent::dispatch();

--- a/src/cms/app/Transfer/Export/BundleExporter.php
+++ b/src/cms/app/Transfer/Export/BundleExporter.php
@@ -6,10 +6,10 @@ namespace App\Transfer\Export;
 
 use App\Models\Document;
 use App\Models\Organisation;
+use App\Transfer\TransferBundleStorage;
 use App\Transfer\TransferEntityType;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 use Webmozart\Assert\Assert;
 use ZipArchive;
@@ -27,12 +27,13 @@ class BundleExporter
 {
     public const int FORMAT_VERSION = 1;
     public const string FORMAT_NAME = 'openvwr-transfer';
-    public const string DISK = 'filament';
+    public const string DISK = TransferBundleStorage::DISK;
     public const string EXPORT_DIRECTORY = 'transfer/exports';
 
     public function __construct(
         private readonly EntityGraphCollector $entityGraphCollector,
         private readonly EntitySerializer $entitySerializer,
+        private readonly TransferBundleStorage $bundleStorage,
     ) {
     }
 
@@ -63,17 +64,33 @@ class BundleExporter
      */
     private function writeZip(array $entities, Organisation $organisation): string
     {
-        $disk = Storage::disk(self::DISK);
         $relativePath = sprintf(
             '%s/openvwr-export-%s.zip',
             self::EXPORT_DIRECTORY,
             CarbonImmutable::now()->format('Ymd-His-v'),
         );
 
-        File::ensureDirectoryExists($disk->path(self::EXPORT_DIRECTORY));
+        $this->bundleStorage->writeFromLocal(
+            $relativePath,
+            function (string $localPath) use ($entities, $organisation, $relativePath): void {
+                $this->buildZip($localPath, $entities, $organisation, $relativePath);
+            },
+        );
 
+        return $relativePath;
+    }
+
+    /**
+     * @param array<string, Model> $entities
+     */
+    private function buildZip(
+        string $localPath,
+        array $entities,
+        Organisation $organisation,
+        string $relativePath,
+    ): void {
         $zip = new ZipArchive();
-        $openResult = $zip->open($disk->path($relativePath), ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $openResult = $zip->open($localPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
         Assert::same($openResult, true, sprintf('could not create zip at %s', $relativePath));
 
         $manifestEntities = [];
@@ -89,7 +106,18 @@ class BundleExporter
 
             if ($model instanceof Document) {
                 foreach ($model->media as $mediaItem) {
-                    $zip->addFile($mediaItem->getPath(), sprintf('media/%s/%s', $mediaItem->uuid, $mediaItem->file_name));
+                    // Read through the disk rather than getPath(): the media-library
+                    // disk may itself be object storage, where there is no local file.
+                    $contents = Storage::disk($mediaItem->disk)->get($mediaItem->getPathRelativeToRoot());
+
+                    if ($contents === null) {
+                        continue;
+                    }
+
+                    $zip->addFromString(
+                        sprintf('media/%s/%s', $mediaItem->uuid, $mediaItem->file_name),
+                        $contents,
+                    );
                 }
             }
 
@@ -114,8 +142,6 @@ class BundleExporter
 
         $zip->addFromString('manifest.json', $this->toJson($manifest));
         $zip->close();
-
-        return $relativePath;
     }
 
     /**

--- a/src/cms/app/Transfer/Import/LibraryMediaResolver.php
+++ b/src/cms/app/Transfer/Import/LibraryMediaResolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Transfer\Import;
 
 use App\Vendor\MediaLibrary\Media;
-use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 use function is_string;
@@ -13,7 +13,8 @@ use function is_string;
 /**
  * Resolves media bytes straight from the source media library (the direct cross-org
  * copy flow, where source and destination live on the same instance). The media item's
- * uuid identifies the original file, which is read from disk in place — no zip involved.
+ * uuid identifies the original file, which is read from its disk in place — no zip
+ * involved. Reads go through the filesystem so the media disk can be object storage.
  */
 class LibraryMediaResolver implements MediaResolver
 {
@@ -34,8 +35,6 @@ class LibraryMediaResolver implements MediaResolver
             return null;
         }
 
-        $path = $media->getPath();
-
-        return File::exists($path) ? File::get($path) : null;
+        return Storage::disk($media->disk)->get($media->getPathRelativeToRoot());
     }
 }

--- a/src/cms/app/Transfer/TransferBundleStorage.php
+++ b/src/cms/app/Transfer/TransferBundleStorage.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Transfer;
+
+use Closure;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Webmozart\Assert\Assert;
+
+use function fclose;
+use function file_exists;
+use function fopen;
+use function stream_copy_to_stream;
+use function sys_get_temp_dir;
+use function unlink;
+
+/**
+ * Reads and writes transfer bundles on the configured transfer disk.
+ *
+ * Bundles are zip archives, and ZipArchive can only work against a real local
+ * path. That is fine on a local disk but meaningless on s3, where Filesystem::path()
+ * returns a bare object key rather than a file. Everything therefore goes through a
+ * temporary local file, which is streamed to or from the disk. The disk itself only
+ * ever sees stream reads and writes, so local and s3 behave identically.
+ */
+class TransferBundleStorage
+{
+    public const string DISK = 'transfer';
+
+    public function disk(): Filesystem
+    {
+        return Storage::disk(self::DISK);
+    }
+
+    public function exists(string $path): bool
+    {
+        return $this->disk()->exists($path);
+    }
+
+    public function delete(string $path): void
+    {
+        $this->disk()->delete($path);
+    }
+
+    /**
+     * Copy a local file onto the transfer disk, streaming rather than reading it
+     * into memory: bundles carry every attachment of the exported records.
+     */
+    public function putFile(string $path, string $localPath): void
+    {
+        // Checked up front so an unreadable file fails as an assertion rather
+        // than as a warning from fopen.
+        Assert::readable($localPath, 'Could not open file for upload: %s');
+
+        $stream = fopen($localPath, 'rb');
+        Assert::resource($stream, null, 'Could not open file for upload.');
+
+        $this->disk()->writeStream($path, $stream);
+    }
+
+    /**
+     * Run $callback against a local copy of a bundle stored on the disk.
+     *
+     * @template T
+     *
+     * @param Closure(string): T $callback receives the local path of the copy
+     *
+     * @return T
+     */
+    public function withLocalCopy(string $path, Closure $callback): mixed
+    {
+        $stream = $this->disk()->readStream($path);
+        Assert::resource($stream, null, 'Could not read bundle from the transfer disk.');
+
+        $tempPath = $this->tempPath();
+
+        $target = fopen($tempPath, 'wb');
+        Assert::resource($target, null, 'Could not open a temporary file for the bundle.');
+
+        try {
+            stream_copy_to_stream($stream, $target);
+            fclose($target);
+            fclose($stream);
+
+            return $callback($tempPath);
+        } finally {
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+    }
+
+    /**
+     * Build a bundle in a temporary local file and store it at $path when done.
+     *
+     * @param Closure(string): void $callback receives the local path to write to
+     */
+    public function writeFromLocal(string $path, Closure $callback): void
+    {
+        $tempPath = $this->tempPath();
+
+        try {
+            $callback($tempPath);
+            $this->putFile($path, $tempPath);
+        } finally {
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+    }
+
+    private function tempPath(): string
+    {
+        return sys_get_temp_dir() . '/openvwr-transfer-' . Str::uuid()->toString() . '.zip';
+    }
+}

--- a/src/cms/composer.json
+++ b/src/cms/composer.json
@@ -16,6 +16,7 @@
         "ext-pdo": "*",
         "ext-sockets": "*",
         "ext-zip": "*",
+        "aws/aws-sdk-php": "^3.370",
         "bacon/bacon-qr-code": "^3.0",
         "barryvdh/laravel-dompdf": "^3.1",
         "bkwld/cloner": "^3.13",
@@ -25,6 +26,7 @@
         "jfcherng/php-diff": "^6.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^3.0",
+        "league/flysystem-aws-s3-v3": "^3.31",
         "livewire/livewire": "^3.4",
         "minvws/laravel-logging": "^4.0",
         "mlocati/ip-lib": "^1.18",
@@ -81,6 +83,7 @@
         ]
     },
     "scripts": {
+        "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices",
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi",
@@ -142,6 +145,11 @@
             "php artisan optimize:clear",
             "@reset-test-db",
             "php artisan test --parallel --recreate-databases"
+        ]
+    },
+    "extra": {
+        "aws/aws-sdk-php": [
+            "S3"
         ]
     },
     "config": {

--- a/src/cms/composer.lock
+++ b/src/cms/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ffd1597cde5fdfcf2499c94d45fa2014",
+    "content-hash": "623dd7d576352fc123d2d4a5d8ae52bb",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -70,6 +70,157 @@
                 "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.10"
             },
             "time": "2026-06-20T14:30:25+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.389.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "09bbb4023a14316ff2c5e568301a382f7e3465f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/09bbb4023a14316ff2c5e568301a382f7e3465f5",
+                "reference": "09bbb4023a14316ff2c5e568301a382f7e3465f5",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.389.3"
+            },
+            "time": "2026-07-29T18:09:38+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -3845,6 +3996,61 @@
             "time": "2026-06-22T20:12:06+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.35.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "8475ef9adfc6498b85469e2abec6fe3118cd08c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/8475ef9adfc6498b85469e2abec6fe3118cd08c4",
+                "reference": "8475ef9adfc6498b85469e2abec6fe3118cd08c4",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.371.5",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.35.2"
+            },
+            "time": "2026-07-01T23:25:49+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.31.0",
             "source": {
@@ -4659,6 +4865,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -8206,6 +8478,76 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v7.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/finder",
@@ -15974,76 +16316,6 @@
                 }
             ],
             "time": "2026-05-20T14:07:29+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v7.4.11",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "reference": "d721ea61b4a5fba8c5b6e7c1feda19efea144b50",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^6.4|^7.0|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.4.11"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-11T16:38:44+00:00"
         },
         {
             "name": "symfony/polyfill-deepclone",

--- a/src/cms/config/filesystems.php
+++ b/src/cms/config/filesystems.php
@@ -10,6 +10,48 @@ Assert::string($sharedStoragePath);
 $staticWebsiteRoot = env('FILESYSTEM_STATIC_WEBSITE_ROOT', storage_path('app/static-website'));
 Assert::string($staticWebsiteRoot);
 
+// Object storage is opt-in: set FILESYSTEM_SHARED_DRIVER=s3 to move the shared
+// disks (uploads, exports, transfer) to an S3-compatible bucket. Everything
+// defaults to 'local', so dev, CI and existing deployments keep working
+// untouched. See docs/object_storage.md.
+$sharedDriver = env('FILESYSTEM_SHARED_DRIVER', 'local');
+Assert::inArray($sharedDriver, ['local', 's3'], 'FILESYSTEM_SHARED_DRIVER must be "local" or "s3", got "%s".');
+
+/**
+ * Build a shared disk definition for whichever driver is configured.
+ *
+ * The two branches are deliberately equivalent in behaviour: `$subPath` is a
+ * directory under the shared root on local, and a key prefix inside the bucket
+ * on s3, so stored paths are identical either way.
+ *
+ * @param array<string, mixed> $extra disk settings that do not depend on the driver
+ *
+ * @return array<string, mixed>
+ */
+$sharedDisk = static function (
+    string $subPath,
+    string $bucketEnvKey,
+    array $extra = [],
+) use (
+    $sharedDriver,
+    $sharedStoragePath,
+): array {
+    if ($sharedDriver === 'local') {
+        return ['driver' => 'local', 'root' => $sharedStoragePath . '/' . $subPath, ...$extra];
+    }
+
+    return [
+        'driver' => 's3',
+        'bucket' => env($bucketEnvKey, $subPath),
+        'endpoint' => env('AWS_ENDPOINT'),
+        'key' => env('AWS_ACCESS_KEY_ID'),
+        'secret' => env('AWS_SECRET_ACCESS_KEY'),
+        'region' => env('AWS_DEFAULT_REGION', 'eu-central-1'),
+        'use_path_style_endpoint' => env('AWS_USE_PATH_STYLE_ENDPOINT', true),
+        ...$extra,
+    ];
+};
+
 return [
 
     /*
@@ -48,14 +90,20 @@ return [
         ],
 
         // used by filament, .e.g export
-        'filament' => [
-            'driver' => 'local',
-            'root' => $sharedStoragePath . '/exports',
+        'filament' => $sharedDisk('exports', 'EXPORTS_BUCKET', [
             'throw' => false,
             'allowed_mimetypes' => ['xlsx'],
             'max_file_size' => '20mb',
             'visibility' => 'public',
-        ],
+        ]),
+
+        // Transfer bundles: exports awaiting download and uploaded imports being
+        // staged. Private, and separate from 'filament' because these zips hold a
+        // full register export -- on a public bucket they would be world-readable.
+        'transfer' => $sharedDisk('transfer', 'TRANSFER_BUCKET', [
+            'throw' => false,
+            'visibility' => 'private',
+        ]),
 
         // used for static-website output (see config/static-website.php)
         'static-website' => [
@@ -65,14 +113,12 @@ return [
         ],
 
         // used for uploading images (see config/media-library.php)
-        'media-library' => [
-            'driver' => 'local',
-            'root' => $sharedStoragePath . '/uploads',
+        'media-library' => $sharedDisk('uploads', 'UPLOADS_BUCKET', [
             'throw' => false,
             'allowed_extensions' => ['pdf', 'png', 'jpg', 'jpeg', 'webp', 'docx', 'odt', 'md', 'txt', 'eml', 'msg'],
             'max_file_size' => '20mb',
             'visibility' => 'private',
-        ],
+        ]),
 
         // used to store generated sql-migration files (see config/sql-generator.php)
         'sql-generation' => [

--- a/src/cms/docker-compose.yml
+++ b/src/cms/docker-compose.yml
@@ -81,10 +81,51 @@ services:
         depends_on:
             - web
 
+    # Object storage is opt-in, so minio sits behind a profile and does not start
+    # with a plain `sail up`. Bring it up with `--profile object-storage`, or use
+    # `just minio-up`, and set FILESYSTEM_SHARED_DRIVER=s3 to actually use it.
+    minio:
+        profiles: ['object-storage']
+        image: 'minio/minio:RELEASE.2025-09-07T16-13-09Z'
+        ports:
+            - '${MINIO_PORT:-9000}:9000'
+            - '${MINIO_CONSOLE_PORT:-9001}:9001'
+        environment:
+            MINIO_ROOT_USER: '${MINIO_ROOT_USER:-minioadmin}'
+            MINIO_ROOT_PASSWORD: '${MINIO_ROOT_PASSWORD:-minioadmin}'
+        volumes:
+            - 'sail-minio:/minio_root'
+        networks:
+            - sail
+        command: minio server /minio_root --console-address ":9001"
+        healthcheck:
+            test: [ "CMD", "mc", "ready", "local" ]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    minio-setup:
+        profiles: ['object-storage']
+        image: sail-8.4-hugo/app
+        depends_on:
+            minio:
+                condition: service_healthy
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        entrypoint: ["/bin/sh", "-c"]
+        command:
+            - |
+                php artisan storage:setup-buckets
+                exit 0
+
 networks:
     sail:
         driver: bridge
 
 volumes:
     sail-pgsql:
+        driver: local
+    sail-minio:
         driver: local

--- a/src/cms/tests/Feature/Console/Commands/StorageSetupBucketsTest.php
+++ b/src/cms/tests/Feature/Console/Commands/StorageSetupBucketsTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\CommandInterface;
+use Aws\Exception\AwsException;
+use Aws\S3\S3Client;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Filesystem\AwsS3V3Adapter;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Swap in a disk that reports itself as s3 and hands back the given client, so the
+ * command can be exercised without an actual bucket service.
+ */
+function fakeS3Disk(S3Client $client): void
+{
+    config([
+        'filesystems.disks.media-library.driver' => 's3',
+        'filesystems.disks.media-library.bucket' => 'uploads',
+        'filesystems.disks.filament.driver' => 's3',
+        'filesystems.disks.filament.bucket' => 'exports',
+        'filesystems.disks.transfer.driver' => 's3',
+        'filesystems.disks.transfer.bucket' => 'transfer',
+    ]);
+
+    $adapter = Mockery::mock(AwsS3V3Adapter::class);
+    $adapter->shouldReceive('getClient')->andReturn($client);
+
+    Storage::shouldReceive('disk')->andReturn($adapter);
+}
+
+it('does nothing when the shared disks are on the local driver', function (): void {
+    config([
+        'filesystems.disks.media-library.driver' => 'local',
+        'filesystems.disks.filament.driver' => 'local',
+        'filesystems.disks.transfer.driver' => 'local',
+    ]);
+
+    $this->artisan('storage:setup-buckets')
+        ->expectsOutputToContain('Disk media-library is not on object storage, nothing to create.')
+        ->expectsOutputToContain('Disk filament is not on object storage, nothing to create.')
+        ->expectsOutputToContain('Disk transfer is not on object storage, nothing to create.')
+        ->assertSuccessful();
+});
+
+it('creates every bucket that does not exist yet', function (): void {
+    $client = Mockery::mock(S3Client::class);
+    $client->shouldReceive('doesBucketExistV2')->times(3)->andReturnFalse();
+    $client->shouldReceive('createBucket')->times(3);
+
+    fakeS3Disk($client);
+
+    $this->artisan('storage:setup-buckets')
+        ->expectsOutputToContain('Bucket uploads created successfully.')
+        ->expectsOutputToContain('Bucket exports created successfully.')
+        ->expectsOutputToContain('Bucket transfer created successfully.')
+        ->assertSuccessful();
+});
+
+it('leaves buckets that already exist alone', function (): void {
+    $client = Mockery::mock(S3Client::class);
+    $client->shouldReceive('doesBucketExistV2')->times(3)->andReturnTrue();
+    $client->shouldReceive('createBucket')->never();
+
+    fakeS3Disk($client);
+
+    $this->artisan('storage:setup-buckets')
+        ->expectsOutputToContain('Bucket uploads already exists.')
+        ->assertSuccessful();
+});
+
+it('fails when the bucket service reports an error', function (): void {
+    $client = Mockery::mock(S3Client::class);
+    $client->shouldReceive('doesBucketExistV2')->andThrow(
+        new AwsException('connection refused', Mockery::mock(CommandInterface::class)),
+    );
+
+    fakeS3Disk($client);
+
+    $this->artisan('storage:setup-buckets')
+        ->expectsOutputToContain('Error with bucket uploads')
+        ->assertFailed();
+});
+
+it('fails when an s3 disk does not expose a client', function (): void {
+    config([
+        'filesystems.disks.media-library.driver' => 's3',
+        'filesystems.disks.media-library.bucket' => 'uploads',
+    ]);
+
+    // A disk that is not an AwsS3V3Adapter: the driver says s3, but there is no
+    // client behind it, which is the misconfiguration this guards against.
+    Storage::shouldReceive('disk')->andReturn(Mockery::mock(Filesystem::class));
+
+    $this->artisan('storage:setup-buckets')
+        ->expectsOutputToContain('Disk media-library does not expose an S3 client.')
+        ->assertFailed();
+});

--- a/src/cms/tests/Feature/Filament/Pages/TransferImportTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/TransferImportTest.php
@@ -34,7 +34,7 @@ function stageTransferUpload(Organisation $organisation): File
         $organisation,
     );
 
-    $bytes = Storage::disk('filament')->get($path);
+    $bytes = Storage::disk('transfer')->get($path);
 
     return TemporaryUploadedFile::fake()->createWithContent('bundle.zip', $bytes);
 }
@@ -89,7 +89,7 @@ it('does not import when no bundle has been analysed', function (): void {
 });
 
 it('analyses a valid bundle, imports it and resets the form', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Bus::fake();
     $this->app->bind(Virusscanner::class, FakeVirusscanner::class);
 
@@ -116,7 +116,7 @@ it('analyses a valid bundle, imports it and resets the form', function (): void 
 });
 
 it('rejects an invalid bundle and cleans up the uploaded file', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     $this->app->bind(Virusscanner::class, FakeVirusscanner::class);
 
     $organisation = OrganisationTestHelper::create();
@@ -135,7 +135,7 @@ it('rejects an invalid bundle and cleans up the uploaded file', function (): voi
 });
 
 it('analyses a bundle whose manifest has no exported at timestamp', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     $this->app->bind(Virusscanner::class, FakeVirusscanner::class);
 
     $organisation = OrganisationTestHelper::create();
@@ -173,7 +173,7 @@ it('analyses a bundle whose manifest has no exported at timestamp', function ():
 });
 
 it('cancels an analysed bundle and deletes the uploaded file', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     $this->app->bind(Virusscanner::class, FakeVirusscanner::class);
 
     $organisation = OrganisationTestHelper::create();

--- a/src/cms/tests/Feature/Http/Controllers/TransferExportDownloadControllerTest.php
+++ b/src/cms/tests/Feature/Http/Controllers/TransferExportDownloadControllerTest.php
@@ -26,7 +26,7 @@ function signedTransferDownloadUrl(string $filename, string $userId): string
 }
 
 it('downloads the export when the signed-in user matches', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);
@@ -42,7 +42,7 @@ it('downloads the export when the signed-in user matches', function (): void {
 });
 
 it('forbids downloading an export that belongs to another user', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);
@@ -59,7 +59,7 @@ it('forbids downloading an export that belongs to another user', function (): vo
 });
 
 it('returns not found when the export file no longer exists', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = OrganisationTestHelper::create();
     $user = UserTestHelper::createForOrganisation($organisation);
@@ -70,7 +70,7 @@ it('returns not found when the export file no longer exists', function (): void 
 });
 
 it('redirects to login when no user is signed in', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $user = UserTestHelper::create();
 

--- a/src/cms/tests/Feature/Jobs/TransferExportJobTest.php
+++ b/src/cms/tests/Feature/Jobs/TransferExportJobTest.php
@@ -13,7 +13,7 @@ use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Storage;
 
 it('exports the records and notifies the user with a download link', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = Organisation::factory()->create();
     $user = User::factory()->create();
@@ -37,7 +37,7 @@ it('exports the records and notifies the user with a download link', function ()
 });
 
 it('does nothing more than exporting when the user no longer exists', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = Organisation::factory()->create();
     $record = AvgResponsibleProcessingRecord::factory()->for($organisation)->create(['name' => 'Verwerking']);

--- a/src/cms/tests/Feature/Jobs/TransferImportJobTest.php
+++ b/src/cms/tests/Feature/Jobs/TransferImportJobTest.php
@@ -7,14 +7,12 @@ use App\Jobs\TransferImportJob;
 use App\Models\Avg\AvgResponsibleProcessingRecord;
 use App\Models\Organisation;
 use App\Models\User;
-use App\Services\BuildContextService;
-use App\Transfer\Import\BundleImporter;
 use Illuminate\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Storage;
 
 it('imports the bundle, deletes it and notifies the user of the result', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Event::fake([BuildEvent::class]);
 
     $sourceOrganisation = Organisation::factory()->create();
@@ -29,12 +27,12 @@ it('imports the bundle, deletes it and notifies the user of the result', functio
         $destinationOrganisation->id,
         $user->id,
     );
-    $job->handle(app(BundleImporter::class), app(BuildContextService::class));
+    app()->call([$job, 'handle']);
 
     Event::assertDispatched(BuildEvent::class);
 
     // the uploaded bundle is cleaned up after import
-    expect(Storage::disk('filament')->exists($path))->toBeFalse()
+    expect(Storage::disk('transfer')->exists($path))->toBeFalse()
         ->and(AvgResponsibleProcessingRecord::query()->whereBelongsTo($destinationOrganisation)->count())->toBe(1);
 
     $notification = DatabaseNotification::query()
@@ -45,7 +43,7 @@ it('imports the bundle, deletes it and notifies the user of the result', functio
 });
 
 it('notifies the user of a failure and still deletes the bundle when the import throws', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Event::fake([BuildEvent::class]);
 
     $organisation = Organisation::factory()->create();
@@ -53,7 +51,7 @@ it('notifies the user of a failure and still deletes the bundle when the import 
 
     // an unreadable (empty) zip on the disk makes the importer throw
     $path = 'transfer/imports/corrupt.zip';
-    Storage::disk('filament')->put($path, 'not a real zip');
+    Storage::disk('transfer')->put($path, 'not a real zip');
 
     $job = new TransferImportJob(
         $path,
@@ -61,11 +59,11 @@ it('notifies the user of a failure and still deletes the bundle when the import 
         $organisation->id,
         $user->id,
     );
-    $job->handle(app(BundleImporter::class), app(BuildContextService::class));
+    app()->call([$job, 'handle']);
 
     Event::assertNotDispatched(BuildEvent::class);
 
-    expect(Storage::disk('filament')->exists($path))->toBeFalse();
+    expect(Storage::disk('transfer')->exists($path))->toBeFalse();
 
     $notification = DatabaseNotification::query()
         ->where('notifiable_id', $user->id->toString())

--- a/src/cms/tests/Feature/Transfer/BundleImporterEdgeCasesTest.php
+++ b/src/cms/tests/Feature/Transfer/BundleImporterEdgeCasesTest.php
@@ -17,9 +17,9 @@ use Illuminate\Support\Facades\Storage;
  */
 function writeImporterZip(array $entities): string
 {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     $relativePath = sprintf('transfer/imports/%s.zip', fake()->uuid());
-    $disk = Storage::disk('filament');
+    $disk = Storage::disk('transfer');
     $disk->put($relativePath, '');
 
     $zip = new ZipArchive();

--- a/src/cms/tests/Feature/Transfer/DocumentTransferTest.php
+++ b/src/cms/tests/Feature/Transfer/DocumentTransferTest.php
@@ -49,7 +49,7 @@ function createExportedDocumentBundle(Organisation $organisation): array
 }
 
 it('exports a document with its media and imports it into another organisation', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     $sourceOrganisation = Organisation::factory()->create();
@@ -59,7 +59,7 @@ it('exports a document with its media and imports it into another organisation',
     [$path, $plan] = createExportedDocumentBundle($sourceOrganisation);
 
     $result = app(BundleImporter::class)->importZip(
-        Storage::disk('filament')->path($path),
+        Storage::disk('transfer')->path($path),
         $plan,
         $destinationOrganisation,
         $user,
@@ -80,7 +80,7 @@ it('exports a document with its media and imports it into another organisation',
 });
 
 it('imports media onto an overwritten document that has none yet', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     $sourceOrganisation = Organisation::factory()->create();
@@ -88,7 +88,7 @@ it('imports media onto an overwritten document that has none yet', function (): 
     $user = User::factory()->create();
 
     [$path, $plan, $document] = createExportedDocumentBundle($sourceOrganisation);
-    $absolutePath = Storage::disk('filament')->path($path);
+    $absolutePath = Storage::disk('transfer')->path($path);
     $importer = app(BundleImporter::class);
 
     // pre-existing document in the destination, matched by name, without media
@@ -107,7 +107,7 @@ it('imports media onto an overwritten document that has none yet', function (): 
 });
 
 it('refreshes a stale attachment on overwrite when the source file changed', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     $sourceOrganisation = Organisation::factory()->create();
@@ -117,7 +117,7 @@ it('refreshes a stale attachment on overwrite when the source file changed', fun
 
     // First copy: destination gets the original file bytes.
     [$firstPath, $firstPlan, $document] = createExportedDocumentBundle($sourceOrganisation);
-    $importer->importZip(Storage::disk('filament')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
+    $importer->importZip(Storage::disk('transfer')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
 
     $copy = Document::query()->whereBelongsTo($destinationOrganisation)->where('name', 'Beleid')->firstOrFail();
     expect($copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->getPathRelativeToRoot())
@@ -144,7 +144,7 @@ it('refreshes a stale attachment on overwrite when the source file changed', fun
         $document->id->toString() => ['selected' => true, 'strategy' => 'overwrite'],
     ];
 
-    $result = $importer->importZip(Storage::disk('filament')->path($secondPath), $overwritePlan, $destinationOrganisation, $user);
+    $result = $importer->importZip(Storage::disk('transfer')->path($secondPath), $overwritePlan, $destinationOrganisation, $user);
 
     expect($result->overwritten)->toBe(2);
 
@@ -156,7 +156,7 @@ it('refreshes a stale attachment on overwrite when the source file changed', fun
 });
 
 it('leaves an unchanged attachment in place on overwrite', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     $sourceOrganisation = Organisation::factory()->create();
@@ -165,7 +165,7 @@ it('leaves an unchanged attachment in place on overwrite', function (): void {
     $importer = app(BundleImporter::class);
 
     [$firstPath, $firstPlan] = createExportedDocumentBundle($sourceOrganisation);
-    $importer->importZip(Storage::disk('filament')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
+    $importer->importZip(Storage::disk('transfer')->path($firstPath), $firstPlan, $destinationOrganisation, $user);
 
     $copy = Document::query()->whereBelongsTo($destinationOrganisation)->where('name', 'Beleid')->firstOrFail();
     $originalUuid = $copy->getFirstMedia(MediaGroup::ATTACHMENTS->value)?->uuid;
@@ -177,7 +177,7 @@ it('leaves an unchanged attachment in place on overwrite', function (): void {
         $overwritePlan[$id]['strategy'] = 'overwrite';
     }
 
-    $importer->importZip(Storage::disk('filament')->path($firstPath), $overwritePlan, $destinationOrganisation, $user);
+    $importer->importZip(Storage::disk('transfer')->path($firstPath), $overwritePlan, $destinationOrganisation, $user);
 
     $copy->refresh()->load('media');
     expect($copy->media)->toHaveCount(1)
@@ -194,7 +194,7 @@ function copyDocumentOnceForPreview(): array
     $user = User::factory()->create();
 
     [$path, $plan, $document] = createExportedDocumentBundle($source);
-    app(BundleImporter::class)->importZip(Storage::disk('filament')->path($path), $plan, $destination, $user);
+    app(BundleImporter::class)->importZip(Storage::disk('transfer')->path($path), $plan, $destination, $user);
 
     $record = AvgResponsibleProcessingRecord::query()->whereBelongsTo($source)->firstOrFail();
 
@@ -214,7 +214,7 @@ function previewDocumentItem(Organisation $source, Organisation $destination, Do
 }
 
 it('flags a document whose source attachment changed as needing a decision', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     [$source, $destination, $document, $record] = copyDocumentOnceForPreview();
@@ -234,7 +234,7 @@ it('flags a document whose source attachment changed as needing a decision', fun
 });
 
 it('flags a document with an identical attachment as unchanged', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
     Storage::fake('media-library');
 
     [$source, $destination, $document, $record] = copyDocumentOnceForPreview();
@@ -245,4 +245,28 @@ it('flags a document with an identical attachment as unchanged', function (): vo
     expect($item['has_match'])->toBeTrue()
         ->and($item['unchanged'])->toBeTrue()
         ->and($item['needs_decision'])->toBeFalse();
+});
+
+it('skips an attachment whose file is missing from the media disk', function (): void {
+    Storage::fake('transfer');
+    Storage::fake('media-library');
+
+    $organisation = Organisation::factory()->create();
+
+    [$path, , $document] = createExportedDocumentBundle($organisation);
+    $mediaItem = $document->media->first();
+
+    // Drop the bytes but keep the media record: the export must still produce a
+    // readable bundle rather than failing on the one unreadable attachment.
+    Storage::disk('media-library')->delete($mediaItem->getPathRelativeToRoot());
+
+    $secondPath = app(BundleExporter::class)->export(
+        TransferEntityType::DOCUMENT,
+        [$document->id->toString()],
+        [],
+        $organisation,
+    );
+
+    expect(Storage::disk('transfer')->exists($secondPath))->toBeTrue()
+        ->and($path)->not->toBe($secondPath);
 });

--- a/src/cms/tests/Feature/Transfer/StakeholderTransferTest.php
+++ b/src/cms/tests/Feature/Transfer/StakeholderTransferTest.php
@@ -14,7 +14,7 @@ use App\Transfer\TransferEntityType;
 use Illuminate\Support\Facades\Storage;
 
 it('exports a stakeholder with its data items and imports them into another organisation', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -45,7 +45,7 @@ it('exports a stakeholder with its data items and imports them into another orga
     ];
 
     $result = app(BundleImporter::class)->importZip(
-        Storage::disk('filament')->path($path),
+        Storage::disk('transfer')->path($path),
         $plan,
         $destinationOrganisation,
         $user,
@@ -62,7 +62,7 @@ it('exports a stakeholder with its data items and imports them into another orga
 });
 
 it('does not export related items that were not selected', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = Organisation::factory()->create();
 
@@ -84,7 +84,7 @@ it('does not export related items that were not selected', function (): void {
     );
 
     $zip = new ZipArchive();
-    $zip->open(Storage::disk('filament')->path($path));
+    $zip->open(Storage::disk('transfer')->path($path));
 
     $hasProcessorEntity = false;
     for ($i = 0; $i < $zip->count(); $i++) {
@@ -98,7 +98,7 @@ it('does not export related items that were not selected', function (): void {
 });
 
 it('deduplicates an entity reached through two exported records', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $organisation = Organisation::factory()->create();
 
@@ -125,7 +125,7 @@ it('deduplicates an entity reached through two exported records', function (): v
     );
 
     $zip = new ZipArchive();
-    $zip->open(Storage::disk('filament')->path($path));
+    $zip->open(Storage::disk('transfer')->path($path));
 
     $processorEntities = 0;
     for ($i = 0; $i < $zip->count(); $i++) {

--- a/src/cms/tests/Feature/Transfer/TransferBundleStorageTest.php
+++ b/src/cms/tests/Feature/Transfer/TransferBundleStorageTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Transfer\TransferBundleStorage;
+use Illuminate\Support\Facades\Storage;
+use Webmozart\Assert\InvalidArgumentException;
+
+beforeEach(function (): void {
+    Storage::fake('transfer');
+    $this->bundleStorage = app(TransferBundleStorage::class);
+});
+
+it('writes a bundle built locally to the disk and reads it back', function (): void {
+    $path = 'transfer/exports/bundle.zip';
+
+    $this->bundleStorage->writeFromLocal($path, function (string $localPath): void {
+        $zip = new ZipArchive();
+        $zip->open($localPath, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+        $zip->addFromString('manifest.json', '{"format":"openvwr-transfer"}');
+        $zip->close();
+    });
+
+    expect($this->bundleStorage->exists($path))->toBeTrue();
+
+    // The round trip matters more than the bytes: ZipArchive needs a real local
+    // path, which the disk itself cannot provide once it runs on object storage.
+    $manifest = $this->bundleStorage->withLocalCopy($path, function (string $localPath): string {
+        $zip = new ZipArchive();
+        expect($zip->open($localPath, ZipArchive::RDONLY))->toBeTrue();
+        $contents = (string) $zip->getFromName('manifest.json');
+        $zip->close();
+
+        return $contents;
+    });
+
+    expect($manifest)->toBe('{"format":"openvwr-transfer"}');
+});
+
+it('deletes a bundle', function (): void {
+    $path = 'transfer/imports/bundle.zip';
+    Storage::disk('transfer')->put($path, 'zip bytes');
+
+    $this->bundleStorage->delete($path);
+
+    expect($this->bundleStorage->exists($path))->toBeFalse();
+});
+
+it('copies a local file onto the disk', function (): void {
+    $localPath = sys_get_temp_dir() . '/transfer-bundle-storage-test.zip';
+    file_put_contents($localPath, 'zip bytes');
+
+    try {
+        $this->bundleStorage->putFile('transfer/imports/uploaded.zip', $localPath);
+    } finally {
+        unlink($localPath);
+    }
+
+    expect(Storage::disk('transfer')->get('transfer/imports/uploaded.zip'))->toBe('zip bytes');
+});
+
+it('removes the temporary file when building a bundle fails', function (): void {
+    $capturedPath = null;
+
+    try {
+        $this->bundleStorage->writeFromLocal(
+            'transfer/exports/never-written.zip',
+            function (string $localPath) use (&$capturedPath): void {
+                $capturedPath = $localPath;
+
+                throw new RuntimeException('building the bundle failed');
+            },
+        );
+    } catch (RuntimeException) {
+        // expected: the point is what happens to the temporary file afterwards
+    }
+
+    expect($capturedPath)->toBeString()
+        ->and(file_exists((string) $capturedPath))->toBeFalse()
+        ->and($this->bundleStorage->exists('transfer/exports/never-written.zip'))->toBeFalse();
+});
+
+it('removes the temporary copy when reading a bundle fails', function (): void {
+    $path = 'transfer/imports/bundle.zip';
+    Storage::disk('transfer')->put($path, 'zip bytes');
+    $capturedPath = null;
+
+    try {
+        $this->bundleStorage->withLocalCopy(
+            $path,
+            function (string $localPath) use (&$capturedPath): void {
+                $capturedPath = $localPath;
+
+                throw new RuntimeException('import failed');
+            },
+        );
+    } catch (RuntimeException) {
+        // expected
+    }
+
+    expect($capturedPath)->toBeString()
+        ->and(file_exists((string) $capturedPath))->toBeFalse();
+});
+
+it('rejects a local file that cannot be opened', function (): void {
+    expect(fn () => $this->bundleStorage->putFile('transfer/imports/x.zip', '/does/not/exist.zip'))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects a bundle that is missing from the disk', function (): void {
+    expect(fn () => $this->bundleStorage->withLocalCopy('transfer/imports/missing.zip', fn () => null))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
+++ b/src/cms/tests/Feature/Transfer/TransferRoundTripTest.php
@@ -11,7 +11,7 @@ use App\Transfer\Import\BundleImporter;
 use Illuminate\Support\Facades\Storage;
 
 it('exports records with related items and imports them into another organisation', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -19,10 +19,10 @@ it('exports records with related items and imports them into another organisatio
 
     [$path, $plan, $record, $processor] = createExportedBundle($sourceOrganisation, $user);
 
-    expect(Storage::disk('filament')->exists($path))->toBeTrue();
+    expect(Storage::disk('transfer')->exists($path))->toBeTrue();
 
     $result = app(BundleImporter::class)->importZip(
-        Storage::disk('filament')->path($path),
+        Storage::disk('transfer')->path($path),
         $plan,
         $destinationOrganisation,
         $user,
@@ -67,7 +67,7 @@ it('exports records with related items and imports them into another organisatio
 });
 
 it('skips items that already exist when the strategy is skip', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -76,7 +76,7 @@ it('skips items that already exist when the strategy is skip', function (): void
     [$path, $plan] = createExportedBundle($sourceOrganisation, $user);
 
     $importer = app(BundleImporter::class);
-    $absolutePath = Storage::disk('filament')->path($path);
+    $absolutePath = Storage::disk('transfer')->path($path);
 
     $importer->importZip($absolutePath, $plan, $destinationOrganisation, $user);
 
@@ -94,7 +94,7 @@ it('skips items that already exist when the strategy is skip', function (): void
 });
 
 it('overwrites existing items when the strategy is overwrite', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -103,7 +103,7 @@ it('overwrites existing items when the strategy is overwrite', function (): void
     [$path, $plan] = createExportedBundle($sourceOrganisation, $user);
 
     $importer = app(BundleImporter::class);
-    $absolutePath = Storage::disk('filament')->path($path);
+    $absolutePath = Storage::disk('transfer')->path($path);
 
     $importer->importZip($absolutePath, $plan, $destinationOrganisation, $user);
 
@@ -125,7 +125,7 @@ it('overwrites existing items when the strategy is overwrite', function (): void
 });
 
 it('adds a copy when the strategy is copy', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -134,7 +134,7 @@ it('adds a copy when the strategy is copy', function (): void {
     [$path, $plan, $record] = createExportedBundle($sourceOrganisation, $user);
 
     $importer = app(BundleImporter::class);
-    $absolutePath = Storage::disk('filament')->path($path);
+    $absolutePath = Storage::disk('transfer')->path($path);
 
     $importer->importZip($absolutePath, $plan, $destinationOrganisation, $user);
 
@@ -156,7 +156,7 @@ it('adds a copy when the strategy is copy', function (): void {
 });
 
 it('matches existing content by name when there is no origin id', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -168,7 +168,7 @@ it('matches existing content by name when there is no origin id', function (): v
     $existingProcessor = Processor::factory()->for($destinationOrganisation)->create(['name' => 'Verwerker 1']);
 
     $result = app(BundleImporter::class)->importZip(
-        Storage::disk('filament')->path($path),
+        Storage::disk('transfer')->path($path),
         $plan,
         $destinationOrganisation,
         $user,
@@ -185,7 +185,7 @@ it('matches existing content by name when there is no origin id', function (): v
 });
 
 it('does not import items that are deselected', function (): void {
-    Storage::fake('filament');
+    Storage::fake('transfer');
 
     $sourceOrganisation = Organisation::factory()->create();
     $destinationOrganisation = Organisation::factory()->create();
@@ -196,7 +196,7 @@ it('does not import items that are deselected', function (): void {
     $plan[$processor->id->toString()]['selected'] = false;
 
     app(BundleImporter::class)->importZip(
-        Storage::disk('filament')->path($path),
+        Storage::disk('transfer')->path($path),
         $plan,
         $destinationOrganisation,
         $user,


### PR DESCRIPTION
## Probleem

Objectopslag zat er ooit in, maar is verwijderd in `fe2b38d` ("chore: remove MinIO/S3 storage in favour of local disks", #36). Die commit was op dat moment correct: hij stelde vast dat het opslagpad driver-agnostisch was, en dat klopte — de media-library path/url generators en `PrivateMediaController` streamen allemaal via Flysystem.

Dat geldt inmiddels niet meer. Negen dagen later voegde `be6bce5` (#42, import/export tussen organisaties) en opvolgers vijf bestanden toe die op lokale-filesystem-semantiek leunen:

| Bestand | Lokale-only aanroep |
|---|---|
| `Transfer/Export/BundleExporter` | `$disk->path()` voor `ZipArchive`, `$mediaItem->getPath()` |
| `Filament/Pages/TransferImport` | `$disk->path($bundlePath)` → `BundleReader` |
| `Jobs/TransferImportJob` | `$disk->path()` → `importZip()` |
| `Http/Controllers/TransferExportDownloadController` | `response()->download($disk->path())` |
| `Transfer/Import/LibraryMediaResolver` | `File::exists()`/`File::get()` op `getPath()` |

Een kale revert van `fe2b38d` zou dus objectopslag opleveren die *lijkt* te werken maar import/export stilzwijgend sloopt. `FilesystemAdapter::path()` gooit op s3 namelijk géén fout — het geeft de kale object-key terug. `ZipArchive` schrijft die zip dan naar een relatief pad onder de webroot, en de download 404't op een bestand dat er niet staat. Dat is onzichtbaar in een testrun die alleen op lokale schijven draait.

## Oplossing

Opzet is **opt-in**: `FILESYSTEM_SHARED_DRIVER` staat standaard op `local`. Pas met `=s3` verhuizen de gedeelde disks naar een bucket. Dev, CI en bestaande deployments veranderen niet, en bestanden die al in `shared-storage` staan blijven bereikbaar.

Alle bundel-IO loopt nu via `App\Transfer\TransferBundleStorage`. Die streamt naar en van de disk, en zet een tijdelijke lokale kopie klaar op de plekken waar `ZipArchive` echt een pad nodig heeft (wat op elke driver zo blijft). Media worden gelezen via `Storage::disk($media->disk)` + `getPathRelativeToRoot()` in plaats van `Media::getPath()`, dat dezelfde valkuil kent.

Hersteld uit history: `aws/aws-sdk-php` + `league/flysystem-aws-s3-v3`, het S3-only `extra`-blok met de `pre-autoload-dump` trimming (56M → 4.5M vendor), de minio compose-services, en het bucket-commando.

## Twee afwijkingen van een kale restore

**De oude disks waren niet omschakelbaar.** `filament` en `media-library` hadden `'driver' => 's3'` hardcoded. Terugzetten zou iedereen dwingen. Nu bouwt één helper in `config/filesystems.php` per disk de juiste definitie, met identieke padopbouw in beide takken.

**`filament` deed dubbel werk.** Die disk is `visibility => public` (voor Filament-exports), maar de nieuwere transfer-code zette er ook *geüploade importbundels* neer — zips met de volledige registerinhoud van een organisatie. Op een lokale schijf achter een signed route valt dat mee; op een publieke bucket is het een datalek. Daarom een aparte, private `transfer`-disk. Dat verklaart de testwijzigingen van `'filament'` naar `'transfer'`.

## Lokaal draaien

- **Docker**: minio zit achter een compose-profile, dus het start *niet* mee met een gewone `sail up`. `just minio-up` / `just minio-down`.
- **Zonder Docker**: `just setup-native-object-storage` installeert minio via brew, schrijft de `.env` en maakt de buckets. Losse recepten: `just minio-native-up`, `just minio-buckets`. `just doctor-native` controleert de bereikbaarheid, maar meldt het alleen als een probleem wanneer de `.env` daadwerkelijk `FILESYSTEM_SHARED_DRIVER=s3` zet.

`minio:setup` is vervangen door `storage:setup-buckets`: driver-bewust, idempotent, en een no-op zolang de disks lokaal staan — dus veilig in een deploy-script.

> De Homebrew-formule `minio` is upstream gearchiveerd (verdwijnt 2027-02-17). Ik heb hem toch gekozen boven `seaweedfs`/`garage` omdat hij gelijk is aan wat Docker, CI en productie draaien. Er zit niets minio-specifieks in de code; dat staat gedocumenteerd in `docs/object_storage.md`.

## Verificatie

- **Tegen een echte S3-server**, niet alleen mocks: de volledige zip-levenscyclus (bouwen → uploaden → terughalen → met `ZipArchive` lezen → verwijderen) draait tegen zowel een draaiende minio als seaweedfs. Precies het pad dat bij een kale restore stil zou breken.
- 293 opslaggevoelige tests groen tegen een echte minio.
- Volledige suite: 1603 groen op de standaard lokale configuratie.
- 100% coverage op elk nieuw en gewijzigd bestand (de CI-gate).
- phpcs, phpstan, phpmd en `composer audit` schoon.
- Nieuwe CI-job `object-storage` draait de opslaggevoelige suites tegen een echte minio, zodat dit pad niet opnieuw ongemerkt kan verrotten.

Volledige suite met de `--min=100` gate: **1607 tests groen, Total: 100.0%**, exit 0. (De 4 `HugoStaticWebsiteGenerator`-tests falen lokaal alleen zolang `src/static-website` niet in `src/cms` staat; CI doet die `mv` zelf, lokaal volstaat een symlink. Met die stap erbij is de suite volledig groen.)

## Aandachtspunt voor de reviewer

Bestaande deployments die overstappen van lokale schijven naar s3 nemen hun **bestaande bestanden niet automatisch mee**. De paden blijven identiek (dezelfde prefix, nu als object-key), dus een `mc mirror` van `shared-storage/` naar de buckets volstaat — maar dat is een bewuste migratiestap die deze PR niet uitvoert.

