### PR TITLE
feat(auth): maak authenticatie verwisselbaar via een strategy

### DIFF
--- a/src/cms/.env.example
+++ b/src/cms/.env.example
@@ -22,6 +22,12 @@ QUEUE_CONNECTION=sync
 IP_WHITELIST_DEFAULTS=*.*.*.*
 ONE_TIME_PASSWORD_DRIVER=fake
 
+# How identity is established:
+#   builtin  passwordless magic link + TOTP (the default; what production uses)
+#   dev      pick a user from a dropdown, no credentials — local/testing ONLY,
+#            and the app refuses to boot with it in any other environment
+AUTH_DRIVER=builtin
+
 # Static Website Configuration
 # Base URL where the static website will be accessible
 STATIC_WEBSITE_BASE_URL=http://localhost:8080

--- a/src/cms/app/Filament/Pages/DevLogin.php
+++ b/src/cms/app/Filament/Pages/DevLogin.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Pages;
+
+use App\Models\User;
+use App\Services\Authentication\AuthenticationStrategyFactory;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Http\Responses\Auth\Contracts\LoginResponse as LoginResponseContract;
+use Filament\Http\Responses\Auth\LoginResponse;
+use Filament\Pages\Auth\Login as FilamentLogin;
+use Illuminate\Support\Facades\Auth;
+use RuntimeException;
+use Webmozart\Assert\Assert;
+
+use function __;
+use function app;
+use function session;
+use function sprintf;
+
+/**
+ * Credential-free login for local development: pick a user, press the button.
+ *
+ * Exists so the app has two working auth strategies from the moment the seam is
+ * introduced — an interface with a single implementation proves nothing. It also
+ * makes local work considerably less tedious: no mail round-trip, no authenticator
+ * app, and switching between the eight roles is a dropdown.
+ *
+ * SAFETY: this bypasses authentication entirely. It is only registered when the
+ * dev driver is active (see FilamentServiceProvider), the driver itself refuses
+ * to build outside local/testing (AuthenticationStrategyFactory), and the guard
+ * below is a third, independent check at the point of use.
+ */
+class DevLogin extends FilamentLogin
+{
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            Select::make('userId')
+                ->label(__('auth.dev_login_user'))
+                ->options(self::userOptions())
+                ->searchable()
+                ->required(),
+        ]);
+    }
+
+    public function authenticate(): ?LoginResponse
+    {
+        $this->assertDevLoginAllowed();
+
+        $data = $this->form->getState();
+        $userId = $data['userId'];
+        Assert::string($userId);
+
+        // The option list is presentation only — Livewire takes the submitted
+        // value from the client. Re-check membership here so a crafted request
+        // cannot log in as a user the picker never offered (one without an
+        // organisation would 403 on arrival anyway, but this keeps the rule in
+        // one place rather than relying on the select).
+        $user = User::query()
+            ->has('organisations')
+            ->findOrFail($userId);
+
+        Auth::login($user);
+        session()->regenerate();
+
+        return app(LoginResponseContract::class);
+    }
+
+    public function getHeading(): string
+    {
+        return __('auth.dev_login_heading');
+    }
+
+    /**
+     * Users that can actually be logged in as. Mirrors the builtin strategy's
+     * rule that a user without an organisation cannot reach the panel, so the
+     * picker never offers an account that would 403 on arrival.
+     *
+     * @return array<string, string>
+     */
+    private static function userOptions(): array
+    {
+        $users = User::query()
+            ->has('organisations')
+            ->get()
+            ->sortBy('name');
+
+        return $users
+            ->mapWithKeys(static fn (User $user): array => [
+                $user->id->toString() => sprintf('%s (%s)', $user->name, $user->email),
+            ])
+            ->all();
+    }
+
+    /**
+     * Defence in depth: the factory already refuses to build the dev strategy
+     * outside local/testing, but this page must not authenticate anyone if it is
+     * ever reached by another route.
+     *
+     * @throws RuntimeException
+     */
+    private function assertDevLoginAllowed(): void
+    {
+        $environment = app()->environment();
+
+        if (!AuthenticationStrategyFactory::devAllowedIn($environment)) {
+            throw new RuntimeException(
+                sprintf('Dev login is not available in the "%s" environment.', $environment),
+            );
+        }
+    }
+}

--- a/src/cms/app/Filament/Pages/DevLogin.php
+++ b/src/cms/app/Filament/Pages/DevLogin.php
@@ -35,6 +35,21 @@ use function sprintf;
  */
 class DevLogin extends FilamentLogin
 {
+    /**
+     * Filament discovers every class under app/Filament/Pages and registers it as
+     * a Livewire component, regardless of which login page the panel is using. So
+     * this component is addressable in production even though the panel never
+     * links to it — which means mounting it must be refused before anything else
+     * runs, not just before it authenticates. Without this, rendering the form
+     * would list every user's name and email to an unauthenticated caller.
+     */
+    public function mount(): void
+    {
+        $this->assertDevLoginAllowed();
+
+        parent::mount();
+    }
+
     public function form(Form $form): Form
     {
         return $form->schema([

--- a/src/cms/app/Filament/Pages/Profile.php
+++ b/src/cms/app/Filament/Pages/Profile.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Filament\Pages;
 
+use App\Config\Config;
 use App\Livewire\User\Profile\OneTimePassword;
 use App\Livewire\User\Profile\PersonalInfo;
 use App\Livewire\User\Profile\Settings;
+use App\Services\Authentication\AuthenticationStrategyFactory;
 use App\Services\AuthenticationService;
 use Filament\Pages\Page;
 use Illuminate\Contracts\View\View;
@@ -56,11 +58,19 @@ class Profile extends Page
      */
     public function getRegisteredMyProfileComponents(): array
     {
-        return [
+        $components = [
             'personal_info' => PersonalInfo::class,
             'settings' => Settings::class,
-            'one_time_password' => OneTimePassword::class,
         ];
+
+        // OTP enrolment belongs to the builtin strategy. Under the dev driver the
+        // OTP gate is not in the middleware stack, so offering enrolment here
+        // would let a developer set up a factor that is never challenged.
+        if (Config::string('auth.driver', AuthenticationStrategyFactory::DRIVER_BUILTIN) !== AuthenticationStrategyFactory::DRIVER_DEV) {
+            $components['one_time_password'] = OneTimePassword::class;
+        }
+
+        return $components;
     }
 
     public function render(): View

--- a/src/cms/app/Providers/AuthServiceProvider.php
+++ b/src/cms/app/Providers/AuthServiceProvider.php
@@ -41,6 +41,8 @@ use App\Policies\ResponsibleLegalEntityPolicy;
 use App\Policies\ResponsiblePolicy;
 use App\Policies\TagPolicy;
 use App\Policies\UserPolicy;
+use App\Services\Authentication\AuthenticationStrategy;
+use App\Services\Authentication\AuthenticationStrategyFactory;
 use App\Services\AuthorizationService;
 use App\Services\CrossOrgAuthorization;
 use App\Services\OneTimePassword\OneTimePassword;
@@ -106,6 +108,17 @@ class AuthServiceProvider extends IlluminateAuthServiceProvider
     public function register(): void
     {
         parent::register();
+
+        // Resolve the auth driver once, at boot: an unknown driver (or `dev`
+        // outside local/testing) must fail startup rather than silently
+        // authenticate requests some other way.
+        $this->app->singleton(
+            AuthenticationStrategy::class,
+            fn (): AuthenticationStrategy => AuthenticationStrategyFactory::make(
+                Config::string('auth.driver', AuthenticationStrategyFactory::DRIVER_BUILTIN),
+                $this->app->environment(),
+            ),
+        );
 
         $this->app->when(AuthorizationService::class)
             ->needs('$rolesAndPermissions')

--- a/src/cms/app/Providers/FilamentServiceProvider.php
+++ b/src/cms/app/Providers/FilamentServiceProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Config\Config;
 use App\Facades\Authentication;
 use App\Filament\NavigationGroups\NavigationGroup;
 use App\Filament\OnePageLayoutRenderHooks;
+use App\Filament\Pages\DevLogin;
 use App\Filament\Pages\Login;
 use App\Filament\Pages\Profile;
 use App\Filament\SimpleAvatarProvider;
@@ -14,6 +16,7 @@ use App\Http\Controllers\HealthController;
 use App\Http\Middleware\EnforceOneTimePassword;
 use App\Http\Middleware\IPAllowFilter;
 use App\Models\Organisation;
+use App\Services\Authentication\AuthenticationStrategyFactory;
 use Exception;
 use Filament\Facades\Filament;
 use Filament\FontProviders\LocalFontProvider;
@@ -89,6 +92,45 @@ class FilamentServiceProvider extends PanelProvider
     }
 
     /**
+     * The login page for the active auth driver. Under `dev` this is the
+     * credential-free user picker, which is why it is selected here rather than
+     * registered unconditionally — a page that bypasses authentication should not
+     * exist on the panel at all unless that driver is deliberately in use.
+     *
+     * @return class-string
+     */
+    private function loginPage(): string
+    {
+        return $this->authDriver() === AuthenticationStrategyFactory::DRIVER_DEV
+            ? DevLogin::class
+            : Login::class;
+    }
+
+    /**
+     * Auth middleware for the active driver. The dev driver skips the OTP gate:
+     * it is a credential-free login, so a second factor on top would be theatre,
+     * and enrolling one would block every local login behind an authenticator app.
+     *
+     * @return array<int, class-string>
+     */
+    private function authMiddleware(): array
+    {
+        if ($this->authDriver() === AuthenticationStrategyFactory::DRIVER_DEV) {
+            return [Authenticate::class];
+        }
+
+        return [
+            Authenticate::class,
+            EnforceOneTimePassword::class,
+        ];
+    }
+
+    private function authDriver(): string
+    {
+        return Config::string('auth.driver', AuthenticationStrategyFactory::DRIVER_BUILTIN);
+    }
+
+    /**
      * @throws Exception
      */
     public function panel(Panel $panel): Panel
@@ -98,7 +140,7 @@ class FilamentServiceProvider extends PanelProvider
             ->id('admin')
             ->path('/')
             ->font('Inter', asset('fonts/inter.css'), LocalFontProvider::class)
-            ->login(Login::class)
+            ->login($this->loginPage())
             ->profile(Profile::class)
             ->routes(static function (): void {
                 RouteFacade::get('/health', HealthController::class);
@@ -151,10 +193,7 @@ class FilamentServiceProvider extends PanelProvider
                 DispatchServingFilamentEvent::class,
                 AddCspHeaders::class,
             ])
-            ->authMiddleware([
-                Authenticate::class,
-                EnforceOneTimePassword::class,
-            ])
+            ->authMiddleware($this->authMiddleware())
             ->tenantMiddleware([
                 IPAllowFilter::class,
             ], isPersistent: true)

--- a/src/cms/app/Services/Authentication/AuthenticationStrategy.php
+++ b/src/cms/app/Services/Authentication/AuthenticationStrategy.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Authentication;
+
+use App\Models\Organisation;
+use App\Models\Principal;
+use App\Models\User;
+
+/**
+ * How the application answers "who is acting, and in which organisation".
+ *
+ * This is the seam between the app and whatever establishes identity. Everything
+ * above it — the ~50 callers of the Authentication facade, AuthorizationService,
+ * and all policies — is written against these three questions and never learns
+ * which strategy answered them.
+ *
+ * Implementations are selected by the `auth.driver` config value.
+ */
+interface AuthenticationStrategy
+{
+    /**
+     * The authenticated user. Implementations throw when there is none — callers
+     * treat "no user" as a programming error, not a branch, because every path
+     * reaching them is already behind auth middleware.
+     */
+    public function user(): User;
+
+    /** The organisation the current request acts in (the active tenant). */
+    public function organisation(): Organisation;
+
+    /**
+     * The roles in effect for this request: global roles plus the roles held in
+     * the current organisation.
+     */
+    public function principal(): Principal;
+}

--- a/src/cms/app/Services/Authentication/AuthenticationStrategyFactory.php
+++ b/src/cms/app/Services/Authentication/AuthenticationStrategyFactory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Authentication;
+
+use RuntimeException;
+
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * Resolves the configured auth driver to a strategy, once, at boot.
+ *
+ * Resolution fails loudly: an unknown driver is a startup error rather than a
+ * silent fallback, because "quietly authenticated some other way" is exactly the
+ * failure mode worth making impossible.
+ */
+final class AuthenticationStrategyFactory
+{
+    public const DRIVER_BUILTIN = 'builtin';
+    public const DRIVER_DEV = 'dev';
+
+    /** Environments in which the credential-free dev driver may run. */
+    private const DEV_ENVIRONMENTS = ['local', 'testing'];
+
+    /**
+     * @throws RuntimeException on an unknown driver, or on `dev` outside local/testing
+     */
+    public static function make(string $driver, string $environment): AuthenticationStrategy
+    {
+        return match ($driver) {
+            self::DRIVER_BUILTIN => new BuiltinAuthenticationStrategy(),
+            self::DRIVER_DEV => self::makeDev($environment),
+            default => throw new RuntimeException(sprintf(
+                'Unknown auth driver "%s". Valid drivers: %s.',
+                $driver,
+                implode(', ', [self::DRIVER_BUILTIN, self::DRIVER_DEV]),
+            )),
+        };
+    }
+
+    /** Whether the dev driver is permitted to run in this environment. */
+    public static function devAllowedIn(string $environment): bool
+    {
+        return in_array($environment, self::DEV_ENVIRONMENTS, true);
+    }
+
+    /**
+     * The dev driver logs anyone in without credentials, so reaching production
+     * with it enabled would be a full authentication bypass. Refuse to boot
+     * rather than serve a single request that way.
+     *
+     * @throws RuntimeException
+     */
+    private static function makeDev(string $environment): AuthenticationStrategy
+    {
+        if (!self::devAllowedIn($environment)) {
+            throw new RuntimeException(sprintf(
+                'The "%s" auth driver is a credential-free login and cannot run in the "%s" environment. '
+                . 'It is permitted only in: %s.',
+                self::DRIVER_DEV,
+                $environment,
+                implode(', ', self::DEV_ENVIRONMENTS),
+            ));
+        }
+
+        return new DevAuthenticationStrategy();
+    }
+}

--- a/src/cms/app/Services/Authentication/BuiltinAuthenticationStrategy.php
+++ b/src/cms/app/Services/Authentication/BuiltinAuthenticationStrategy.php
@@ -13,6 +13,8 @@ use Filament\Facades\Filament;
 use Webmozart\Assert\Assert;
 use Webmozart\Assert\InvalidArgumentException;
 
+use function array_key_exists;
+
 /**
  * The application's own auth: passwordless magic link + TOTP, on Laravel's
  * session guard, with the active tenant resolved from the URL by Filament.
@@ -22,7 +24,19 @@ use Webmozart\Assert\InvalidArgumentException;
  */
 class BuiltinAuthenticationStrategy implements AuthenticationStrategy
 {
-    private ?Principal $principal = null;
+    /**
+     * Memoised roles, keyed by "<user>:<organisation>".
+     *
+     * Roles are scoped to the ACTIVE organisation, and both the user and that
+     * organisation can change within a single request (a tenant switch, or the
+     * test helper re-authenticating). This object is a container singleton, so an
+     * unkeyed cache would let a role held in one organisation apply in another —
+     * a privilege escalation, not just a stale read. The key makes that
+     * impossible while keeping the per-question caching the roles lookup needs.
+     *
+     * @var array<string, Principal>
+     */
+    private array $principals = [];
 
     /**
      * @throws InvalidArgumentException
@@ -37,7 +51,9 @@ class BuiltinAuthenticationStrategy implements AuthenticationStrategy
 
     public function principal(): Principal
     {
-        if ($this->principal === null) {
+        $key = $this->principalCacheKey();
+
+        if (!array_key_exists($key, $this->principals)) {
             $roles = [];
 
             foreach ($this->getGlobalRoles() as $globalRole) {
@@ -48,10 +64,32 @@ class BuiltinAuthenticationStrategy implements AuthenticationStrategy
                 $roles[] = $organisationRole->role;
             }
 
-            $this->principal = new Principal($roles);
+            $this->principals[$key] = new Principal($roles);
         }
 
-        return $this->principal;
+        return $this->principals[$key];
+    }
+
+    /**
+     * Identifies whose roles, in which organisation, a cached Principal describes.
+     * Either side being absent is its own distinct key, so an unauthenticated or
+     * tenant-less lookup can never read a populated entry.
+     */
+    private function principalCacheKey(): string
+    {
+        try {
+            $userKey = $this->user()->id->toString();
+        } catch (InvalidArgumentException) {
+            $userKey = 'no-user';
+        }
+
+        try {
+            $organisationKey = $this->organisation()->id->toString();
+        } catch (InvalidArgumentException) {
+            $organisationKey = 'no-organisation';
+        }
+
+        return $userKey . ':' . $organisationKey;
     }
 
     /**

--- a/src/cms/app/Services/Authentication/BuiltinAuthenticationStrategy.php
+++ b/src/cms/app/Services/Authentication/BuiltinAuthenticationStrategy.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Authentication;
+
+use App\Collections\OrganisationUserRoleCollection;
+use App\Collections\UserGlobalRoleCollection;
+use App\Models\Organisation;
+use App\Models\Principal;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Webmozart\Assert\Assert;
+use Webmozart\Assert\InvalidArgumentException;
+
+/**
+ * The application's own auth: passwordless magic link + TOTP, on Laravel's
+ * session guard, with the active tenant resolved from the URL by Filament.
+ *
+ * This is the historical behaviour, moved here unchanged when the strategy seam
+ * was extracted.
+ */
+class BuiltinAuthenticationStrategy implements AuthenticationStrategy
+{
+    private ?Principal $principal = null;
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function organisation(): Organisation
+    {
+        $organisation = Filament::getTenant();
+        Assert::isInstanceOf($organisation, Organisation::class);
+
+        return $organisation;
+    }
+
+    public function principal(): Principal
+    {
+        if ($this->principal === null) {
+            $roles = [];
+
+            foreach ($this->getGlobalRoles() as $globalRole) {
+                $roles[] = $globalRole->role;
+            }
+
+            foreach ($this->getOrganisationRoles() as $organisationRole) {
+                $roles[] = $organisationRole->role;
+            }
+
+            $this->principal = new Principal($roles);
+        }
+
+        return $this->principal;
+    }
+
+    /**
+     * @throws InvalidArgumentException
+     */
+    public function user(): User
+    {
+        $user = Filament::auth()->user();
+        Assert::isInstanceOf($user, User::class);
+
+        return $user;
+    }
+
+    private function getGlobalRoles(): UserGlobalRoleCollection
+    {
+        try {
+            return $this->user()->globalRoles;
+        } catch (InvalidArgumentException) {
+            return new UserGlobalRoleCollection();
+        }
+    }
+
+    private function getOrganisationRoles(): OrganisationUserRoleCollection
+    {
+        try {
+            $organisationUserRoles = $this->user()
+                ->organisationRoles()
+                ->where(['organisation_id' => $this->organisation()->id])
+                ->get();
+            Assert::isInstanceOf($organisationUserRoles, OrganisationUserRoleCollection::class);
+        } catch (InvalidArgumentException) {
+            $organisationUserRoles = new OrganisationUserRoleCollection();
+        }
+
+        return $organisationUserRoles;
+    }
+}

--- a/src/cms/app/Services/Authentication/DevAuthenticationStrategy.php
+++ b/src/cms/app/Services/Authentication/DevAuthenticationStrategy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Authentication;
+
+/**
+ * Local-development identity: pick a user from a dropdown, no credentials.
+ *
+ * Once a session exists it resolves exactly like the builtin strategy — it
+ * differs only in how that session is *established* (see the DevLogin page).
+ * That is deliberate: it exercises the strategy seam without duplicating the
+ * resolution logic under test, so a leak in the seam shows up here rather than
+ * being masked by a parallel implementation.
+ *
+ * This is an authentication bypass. It must never be reachable in production;
+ * AuthenticationStrategyFactory refuses to build it outside local/testing, and
+ * the Filament page is only registered for the same environments.
+ */
+class DevAuthenticationStrategy extends BuiltinAuthenticationStrategy
+{
+}

--- a/src/cms/app/Services/AuthenticationService.php
+++ b/src/cms/app/Services/AuthenticationService.php
@@ -4,47 +4,38 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Collections\OrganisationUserRoleCollection;
-use App\Collections\UserGlobalRoleCollection;
 use App\Models\Organisation;
 use App\Models\Principal;
 use App\Models\User;
-use Filament\Facades\Filament;
-use Webmozart\Assert\Assert;
+use App\Services\Authentication\AuthenticationStrategy;
 use Webmozart\Assert\InvalidArgumentException;
 
+/**
+ * Answers "who is acting, and where" by delegating to the configured
+ * AuthenticationStrategy.
+ *
+ * The public surface here is unchanged from when this class held the logic
+ * directly — the Authentication facade and its ~50 callers are deliberately
+ * untouched by the strategy extraction.
+ */
 class AuthenticationService
 {
-    private ?Principal $principal = null;
+    public function __construct(
+        private readonly AuthenticationStrategy $strategy,
+    ) {
+    }
 
     /**
      * @throws InvalidArgumentException
      */
     public function organisation(): Organisation
     {
-        $organisation = Filament::getTenant();
-        Assert::isInstanceOf($organisation, Organisation::class);
-
-        return $organisation;
+        return $this->strategy->organisation();
     }
 
     public function principal(): Principal
     {
-        if ($this->principal === null) {
-            $roles = [];
-
-            foreach ($this->getGlobalRoles() as $globalRole) {
-                $roles[] = $globalRole->role;
-            }
-
-            foreach ($this->getOrganisationRoles() as $organisationRole) {
-                $roles[] = $organisationRole->role;
-            }
-
-            $this->principal = new Principal($roles);
-        }
-
-        return $this->principal;
+        return $this->strategy->principal();
     }
 
     /**
@@ -52,33 +43,6 @@ class AuthenticationService
      */
     public function user(): User
     {
-        $user = Filament::auth()->user();
-        Assert::isInstanceOf($user, User::class);
-
-        return $user;
-    }
-
-    private function getGlobalRoles(): UserGlobalRoleCollection
-    {
-        try {
-            return $this->user()->globalRoles;
-        } catch (InvalidArgumentException) {
-            return new UserGlobalRoleCollection();
-        }
-    }
-
-    private function getOrganisationRoles(): OrganisationUserRoleCollection
-    {
-        try {
-            $organisationUserRoles = $this->user()
-                ->organisationRoles()
-                ->where(['organisation_id' => $this->organisation()->id])
-                ->get();
-            Assert::isInstanceOf($organisationUserRoles, OrganisationUserRoleCollection::class);
-        } catch (InvalidArgumentException) {
-            $organisationUserRoles = new OrganisationUserRoleCollection();
-        }
-
-        return $organisationUserRoles;
+        return $this->strategy->user();
     }
 }

--- a/src/cms/config/auth.php
+++ b/src/cms/config/auth.php
@@ -24,6 +24,23 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Authentication Driver (strategy)
+    |--------------------------------------------------------------------------
+    |
+    | Selects how identity is established:
+    |
+    |   builtin  passwordless magic link + TOTP on the session guard (default)
+    |   dev      pick a user from a dropdown, no credentials — local/testing ONLY
+    |
+    | An unknown value is a startup error, and "dev" refuses to boot outside the
+    | local and testing environments: it is a deliberate authentication bypass.
+    |
+    */
+
+    'driver' => env('AUTH_DRIVER', 'builtin'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Authentication Guards
     |--------------------------------------------------------------------------
     |

--- a/src/cms/resources/lang/nl/auth.php
+++ b/src/cms/resources/lang/nl/auth.php
@@ -20,4 +20,8 @@ return [
     'snapshot_sign_confirm_message' => 'Hallo :userName, klik hieronder om het authenticatieproces te starten',
     'snapshot_sign_confirm_login' => 'Stuur login email',
     'snapshot_sign_confirm_help_text' => 'De login email is om te bepalen of u op dit moment werkelijk toegang heeft tot het email adres dat bij ons bekend is.',
+
+    // Ontwikkelomgeving: inloggen zonder wachtwoord of tweede factor.
+    'dev_login_heading' => 'Inloggen (ontwikkelomgeving)',
+    'dev_login_user' => 'Gebruiker',
 ];

--- a/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
@@ -10,6 +10,15 @@ use Illuminate\Support\Facades\Auth;
 
 use function Pest\Livewire\livewire;
 
+/*
+ * detectEnvironment() mutates the application for the rest of the process, so
+ * anything that pretends to be production has to put it back — otherwise every
+ * later test in the same worker silently runs in the wrong environment.
+ */
+afterEach(function (): void {
+    app()->detectEnvironment(static fn (): string => 'testing');
+});
+
 it('logs in the selected user without any credential', function (): void {
     $organisation = Organisation::factory()->create();
     $user = User::factory()->create();

--- a/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
@@ -30,11 +30,6 @@ it('logs in the selected user without any credential', function (): void {
 });
 
 /*
- * The picker mirrors the builtin strategy's rule that a user without an
- * organisation cannot reach the panel, so it must not offer an account that
- * would 403 immediately on arrival.
- */
-/*
  * A user without an organisation cannot reach the panel (the builtin strategy
  * enforces that at login, and canAccessTenant would reject them anyway), so the
  * picker must not offer an account that would 403 on arrival.
@@ -70,6 +65,41 @@ it('requires a user to be selected', function (): void {
         ->assertHasFormErrors(['userId' => 'required']);
 
     expect(Auth::check())->toBeFalse();
+});
+
+/*
+ * Filament registers every class under app/Filament/Pages as a Livewire
+ * component, whichever login page the panel actually uses — so this component is
+ * addressable in production even though nothing links to it. Mounting must be
+ * refused before the form is built, because building it queries every user and
+ * renders their name and email. Guarding only authenticate() would leave the
+ * whole user directory readable by an unauthenticated caller.
+ */
+it('refuses to render outside local and testing', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    app()->detectEnvironment(static fn (): string => 'production');
+
+    // Livewire wraps a mount-time throw, so walk the chain: what matters is that
+    // the guard fired before the form was built and no user data was rendered.
+    $thrown = null;
+
+    try {
+        livewire(DevLogin::class);
+    } catch (Throwable $exception) {
+        $thrown = $exception;
+    }
+
+    expect($thrown)->not->toBeNull('mounting dev login in production should fail');
+
+    $messages = [];
+    for ($e = $thrown; $e !== null; $e = $e->getPrevious()) {
+        $messages[] = $e->getMessage();
+    }
+
+    expect(implode(' | ', $messages))->toContain('Dev login is not available');
 });
 
 /*

--- a/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
@@ -71,3 +71,24 @@ it('requires a user to be selected', function (): void {
 
     expect(Auth::check())->toBeFalse();
 });
+
+/*
+ * The page's own environment guard, independent of the factory's. If dev login
+ * is ever reachable in a deployed environment it must refuse to authenticate
+ * anyone — so this is the single most important assertion in this file.
+ */
+it('refuses to authenticate anyone outside local and testing', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    $component = livewire(DevLogin::class)
+        ->fillForm(['userId' => $user->id->toString()]);
+
+    app()->detectEnvironment(static fn (): string => 'production');
+
+    expect(static fn () => $component->call('authenticate'))
+        ->toThrow(RuntimeException::class, 'Dev login is not available');
+
+    expect(Auth::check())->toBeFalse();
+});

--- a/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
+++ b/src/cms/tests/Feature/Filament/Pages/DevLoginTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\DevLogin;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\Auth;
+
+use function Pest\Livewire\livewire;
+
+it('logs in the selected user without any credential', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    expect(Auth::check())->toBeFalse();
+
+    livewire(DevLogin::class)
+        ->fillForm(['userId' => $user->id->toString()])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(Auth::check())->toBeTrue();
+
+    $authenticated = Auth::user();
+    expect($authenticated)->toBeInstanceOf(User::class);
+    expect($authenticated->id->toString())->toBe($user->id->toString());
+});
+
+/*
+ * The picker mirrors the builtin strategy's rule that a user without an
+ * organisation cannot reach the panel, so it must not offer an account that
+ * would 403 immediately on arrival.
+ */
+/*
+ * A user without an organisation cannot reach the panel (the builtin strategy
+ * enforces that at login, and canAccessTenant would reject them anyway), so the
+ * picker must not offer an account that would 403 on arrival.
+ */
+it('only offers users that belong to an organisation', function (): void {
+    $organisation = Organisation::factory()->create();
+    $withOrganisation = User::factory()->create();
+    $withOrganisation->organisations()->attach($organisation);
+    $withoutOrganisation = User::factory()->create();
+
+    // The option list is presentation only — Livewire takes the submitted value
+    // from the client — so assert the server refuses an orgless user outright
+    // rather than merely hiding them from the dropdown.
+    expect(static function () use ($withoutOrganisation): void {
+        livewire(DevLogin::class)
+            ->fillForm(['userId' => $withoutOrganisation->id->toString()])
+            ->call('authenticate');
+    })->toThrow(ModelNotFoundException::class);
+
+    expect(Auth::check())->toBeFalse();
+
+    livewire(DevLogin::class)
+        ->fillForm(['userId' => $withOrganisation->id->toString()])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(Auth::check())->toBeTrue();
+});
+
+it('requires a user to be selected', function (): void {
+    livewire(DevLogin::class)
+        ->call('authenticate')
+        ->assertHasFormErrors(['userId' => 'required']);
+
+    expect(Auth::check())->toBeFalse();
+});

--- a/src/cms/tests/Feature/Providers/FilamentServiceProviderTest.php
+++ b/src/cms/tests/Feature/Providers/FilamentServiceProviderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Filament\Pages\DevLogin;
+use App\Filament\Pages\Login;
+use App\Http\Middleware\EnforceOneTimePassword;
+use App\Providers\FilamentServiceProvider;
+use Filament\Http\Middleware\Authenticate;
+use Filament\Panel;
+
+/*
+ * The panel's login page and auth middleware depend on the active driver, and
+ * those branches only run at panel-build time. Building the panel directly is
+ * what exercises them — the test environment itself stays on `builtin`.
+ */
+
+function buildPanel(string $driver): Panel
+{
+    config(['auth.driver' => $driver]);
+
+    $provider = new FilamentServiceProvider(app());
+
+    return $provider->panel(Panel::make());
+}
+
+it('uses the passwordless login page under the builtin driver', function (): void {
+    $panel = buildPanel('builtin');
+
+    expect($panel->getLoginRouteAction())->toBe(Login::class);
+});
+
+it('uses the user picker under the dev driver', function (): void {
+    $panel = buildPanel('dev');
+
+    expect($panel->getLoginRouteAction())->toBe(DevLogin::class);
+});
+
+it('enforces the one-time password gate under the builtin driver', function (): void {
+    $panel = buildPanel('builtin');
+
+    expect($panel->getAuthMiddleware())
+        ->toContain(Authenticate::class)
+        ->toContain(EnforceOneTimePassword::class);
+});
+
+/*
+ * The dev driver is a credential-free login, so a second factor on top of it
+ * would be theatre — and enrolling one would put every local login behind an
+ * authenticator app.
+ */
+it('skips the one-time password gate under the dev driver', function (): void {
+    $panel = buildPanel('dev');
+
+    expect($panel->getAuthMiddleware())
+        ->toContain(Authenticate::class)
+        ->not->toContain(EnforceOneTimePassword::class);
+});

--- a/src/cms/tests/Feature/Services/Authentication/AuthenticationStrategyFactoryTest.php
+++ b/src/cms/tests/Feature/Services/Authentication/AuthenticationStrategyFactoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Authentication\AuthenticationStrategyFactory;
+use App\Services\Authentication\BuiltinAuthenticationStrategy;
+use App\Services\Authentication\DevAuthenticationStrategy;
+
+it('builds the builtin strategy', function (): void {
+    expect(AuthenticationStrategyFactory::make('builtin', 'production'))
+        ->toBeInstanceOf(BuiltinAuthenticationStrategy::class);
+});
+
+it('builds the dev strategy in permitted environments', function (string $environment): void {
+    expect(AuthenticationStrategyFactory::make('dev', $environment))
+        ->toBeInstanceOf(DevAuthenticationStrategy::class);
+})->with(['local', 'testing']);
+
+/*
+ * The dev strategy logs anyone in without credentials, so reaching a deployed
+ * environment with it configured would be a full authentication bypass. These
+ * are the tests that make that impossible, so they are the point of this file.
+ */
+it('refuses to build the dev strategy outside local and testing', function (string $environment): void {
+    AuthenticationStrategyFactory::make('dev', $environment);
+})->with([
+    'production',
+    'staging',
+    'acceptance',
+])->throws(RuntimeException::class, 'cannot run in the');
+
+it('reports whether dev is allowed per environment', function (): void {
+    expect(AuthenticationStrategyFactory::devAllowedIn('local'))->toBeTrue()
+        ->and(AuthenticationStrategyFactory::devAllowedIn('testing'))->toBeTrue()
+        ->and(AuthenticationStrategyFactory::devAllowedIn('production'))->toBeFalse()
+        ->and(AuthenticationStrategyFactory::devAllowedIn('staging'))->toBeFalse();
+});
+
+/*
+ * An unknown driver must stop the app rather than quietly falling back to some
+ * default — a typo in AUTH_DRIVER should never silently change how requests are
+ * authenticated.
+ */
+it('rejects an unknown driver', function (): void {
+    AuthenticationStrategyFactory::make('nope', 'local');
+})->throws(RuntimeException::class, 'Unknown auth driver');

--- a/src/cms/tests/Feature/Services/Authentication/StrategyParityTest.php
+++ b/src/cms/tests/Feature/Services/Authentication/StrategyParityTest.php
@@ -87,6 +87,39 @@ it('resolves the same roles under every strategy', function (): void {
 });
 
 /*
+ * With no authenticated user, role lookup must degrade to "no roles" rather than
+ * blowing up — every policy then denies, which is the safe direction. Both role
+ * sources (global and per-organisation) have to fail that way independently.
+ */
+it('yields no roles when there is no authenticated user', function (): void {
+    foreach (strategies() as $name => $strategy) {
+        expect($strategy->principal()->roles)
+            ->toBe([], sprintf('strategy "%s" leaked roles without an authenticated user', $name));
+    }
+});
+
+it('yields no organisation roles when authenticated without a tenant', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+    $user->assignOrganisationRole(Role::PRIVACY_OFFICER, $organisation);
+    $user->assignGlobalRole(Role::FUNCTIONAL_MANAGER);
+
+    $this->be($user);
+    Filament::setTenant(null);
+
+    // Global roles still resolve; organisation roles cannot, because there is no
+    // active tenant to scope them to.
+    foreach (strategies() as $strategy) {
+        $roles = array_map(static fn (Role $role): string => $role->value, $strategy->principal()->roles);
+
+        expect($roles)
+            ->toContain(Role::FUNCTIONAL_MANAGER->value)
+            ->not->toContain(Role::PRIVACY_OFFICER->value);
+    }
+});
+
+/*
  * The facade is the contract ~50 files depend on. It must keep answering through
  * whichever strategy is bound, without those callers knowing which one.
  */

--- a/src/cms/tests/Feature/Services/Authentication/StrategyParityTest.php
+++ b/src/cms/tests/Feature/Services/Authentication/StrategyParityTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Role;
+use App\Models\Organisation;
+use App\Models\Principal;
+use App\Models\User;
+use App\Services\Authentication\AuthenticationStrategy;
+use App\Services\Authentication\BuiltinAuthenticationStrategy;
+use App\Services\Authentication\DevAuthenticationStrategy;
+use App\Services\AuthenticationService;
+use Filament\Facades\Filament;
+
+/*
+ * The strategy seam is only worth anything if two implementations genuinely
+ * answer the same questions the same way. These tests run the same fixture
+ * through each strategy and assert the answers match — that is what stops the
+ * interface from being indirection that happens to compile.
+ *
+ * When the Pratique strategy lands it becomes a third case here rather than new
+ * scaffolding.
+ */
+
+/** @return array<string, AuthenticationStrategy> */
+function strategies(): array
+{
+    return [
+        'builtin' => new BuiltinAuthenticationStrategy(),
+        'dev' => new DevAuthenticationStrategy(),
+    ];
+}
+
+it('resolves the same user under every strategy', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    $this->be($user);
+    Filament::setTenant($organisation);
+
+    foreach (strategies() as $name => $strategy) {
+        expect($strategy->user()->id->toString())
+            ->toBe($user->id->toString(), sprintf('strategy "%s" resolved a different user', $name));
+    }
+});
+
+it('resolves the same organisation under every strategy', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    $this->be($user);
+    Filament::setTenant($organisation);
+
+    foreach (strategies() as $name => $strategy) {
+        expect($strategy->organisation()->id->toString())
+            ->toBe($organisation->id->toString(), sprintf('strategy "%s" resolved a different organisation', $name));
+    }
+});
+
+it('resolves the same roles under every strategy', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+    $user->assignOrganisationRole(Role::PRIVACY_OFFICER, $organisation);
+    $user->assignGlobalRole(Role::FUNCTIONAL_MANAGER);
+
+    $this->be($user);
+    Filament::setTenant($organisation);
+
+    $roleSets = [];
+    foreach (strategies() as $name => $strategy) {
+        $principal = $strategy->principal();
+        expect($principal)->toBeInstanceOf(Principal::class);
+
+        $roles = array_map(static fn (Role $role): string => $role->value, $principal->roles);
+        sort($roles);
+        $roleSets[$name] = $roles;
+    }
+
+    // Global and organisation roles both present, and identical across strategies.
+    expect($roleSets['builtin'])
+        ->toContain(Role::PRIVACY_OFFICER->value)
+        ->toContain(Role::FUNCTIONAL_MANAGER->value)
+        ->and($roleSets['dev'])->toBe($roleSets['builtin']);
+});
+
+/*
+ * The facade is the contract ~50 files depend on. It must keep answering through
+ * whichever strategy is bound, without those callers knowing which one.
+ */
+it('serves the facade through the bound strategy', function (): void {
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->create();
+    $user->organisations()->attach($organisation);
+
+    $this->be($user);
+    Filament::setTenant($organisation);
+
+    $this->app->instance(AuthenticationStrategy::class, new DevAuthenticationStrategy());
+
+    $service = new AuthenticationService($this->app->get(AuthenticationStrategy::class));
+
+    expect($service->user()->id->toString())->toBe($user->id->toString())
+        ->and($service->organisation()->id->toString())->toBe($organisation->id->toString());
+});

--- a/src/cms/tests/Feature/Services/Authentication/TenantIsolationTest.php
+++ b/src/cms/tests/Feature/Services/Authentication/TenantIsolationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Authorization\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Services\Authentication\AuthenticationStrategy;
+use Filament\Facades\Filament;
+
+/*
+ * The strategy is a container singleton, so anything it caches outlives a single
+ * question. Roles are scoped to the ACTIVE organisation, which changes within a
+ * request whenever the user switches tenant — so a cached Principal must not
+ * survive that switch, or a role held in one org silently applies in another.
+ */
+
+it('does not carry roles across a tenant switch', function (): void {
+    $orgA = Organisation::factory()->create();
+    $orgB = Organisation::factory()->create();
+
+    $user = User::factory()->create();
+    $user->organisations()->attach($orgA);
+    $user->organisations()->attach($orgB);
+
+    // Privileged in A, no roles at all in B.
+    $user->assignOrganisationRole(Role::PRIVACY_OFFICER, $orgA);
+
+    $this->be($user);
+
+    $strategy = $this->app->get(AuthenticationStrategy::class);
+
+    Filament::setTenant($orgA);
+    expect($strategy->principal()->roles)->toContain(Role::PRIVACY_OFFICER);
+
+    Filament::setTenant($orgB);
+    expect($strategy->principal()->roles)
+        ->toBe([], 'a role held in one organisation leaked into another');
+});
+
+it('does not carry roles across a change of user', function (): void {
+    $organisation = Organisation::factory()->create();
+
+    $privileged = User::factory()->create();
+    $privileged->organisations()->attach($organisation);
+    $privileged->assignOrganisationRole(Role::PRIVACY_OFFICER, $organisation);
+
+    $unprivileged = User::factory()->create();
+    $unprivileged->organisations()->attach($organisation);
+
+    $strategy = $this->app->get(AuthenticationStrategy::class);
+
+    $this->be($privileged);
+    Filament::setTenant($organisation);
+    expect($strategy->principal()->roles)->toContain(Role::PRIVACY_OFFICER);
+
+    $this->be($unprivileged);
+    expect($strategy->principal()->roles)
+        ->toBe([], 'one user inherited another user\'s roles');
+});


### PR DESCRIPTION
Eerste stap richting de Pratique-proxy: maakt *hoe* iemand wordt geauthenticeerd
verwisselbaar, zonder dat de rest van de applicatie daar iets van merkt.

## Wat er verandert

`AuthenticationStrategy` (`user()` / `organisation()` / `principal()`) achter de
bestaande `Authentication` facade. Twee implementaties, vanaf nu allebei werkend:

- **`builtin`** — de huidige magic link + TOTP, ongewijzigd overgezet (default)
- **`dev`** — kies een gebruiker uit een dropdown, zonder inloggegevens

`AUTH_DRIVER` bepaalt welke actief is. Een onbekende waarde is een startup-fout,
en `dev` weigert te starten buiten `local`/`testing`.

De facade-signatuur is ongewijzigd, dus de ~50 aanroepende bestanden,
`AuthorizationService` en alle policies blijven onaangeroerd.

## Waarom `dev` nu al meegaat

Een interface met één implementatie bewijst niets: elk lek in de naad blijft
onzichtbaar tot de tweede implementatie er is. Door `dev` meteen mee te bouwen is
de naad aantoonbaar goed *voordat* de security-kritische Pratique-strategie erop
gebouwd wordt. En het scheelt lokaal veel: geen mail-rondje, geen authenticator,
en wisselen tussen de acht rollen is een dropdown.

## Twee bugs gevonden en gedicht tijdens review

**Cross-tenant privilege escalation.** De `Principal`-memoisatie was veilig zolang
`AuthenticationService` per aanroep werd geresolved, maar de strategy is een
singleton — waardoor de cache de vraag overleefde die hij beantwoordde. Een rol in
organisatie A gold daardoor ook in B, en een gebruiker erfde de rollen van een
ander. Geverifieerd tegen `main` met dezelfde fixture: een echte regressie, niet
alleen een Octane-risico, omdat Filament binnen één request van tenant wisselt.
Opgelost door de memo te sleutelen op gebruiker + organisatie.

**User enumeration.** Filament registreert élke klasse onder `Filament/Pages` als
Livewire-component, ongeacht welke login-pagina het panel gebruikt. `DevLogin` was
dus in productie adresseerbaar terwijl niets ernaar linkt. `authenticate()` was
afgeschermd, `mount()` niet — en het opbouwen van het formulier haalt naam en
e-mail van alle gebruikers op. `mount()` weigert nu vóór er iets wordt opgevraagd.

Beide fixes zijn mutation-getest: het terugdraaien van een fix laat de bijbehorende
test falen.

## Verificatie

- 1615 tests groen (was 1590 op `main`; +25 nieuw)
- 100% line coverage op alle nieuwe/gewijzigde bestanden
- phpstan, phpcs, phpmd schoon
- De bestaande suite draaide **ongewijzigd** — geen enkele test hoefde aangepast,
  wat het bewijs is dat de extractie niets heeft laten lekken

Lokaal falen 4 Hugo-tests (`HugoStaticWebsiteGeneratorTest`); die falen ook op een
schone `main` in deze omgeving en staan los van deze wijziging.

## Nog te doen (volgende PR)

De Pratique-strategie zelf: JWT-verificatie, JWKS-caching en JIT-provisioning.
