### PR TITLE
fix(deps): bump guzzle naar 7.15.3 (CVE-2026-69245/69246)

### DIFF
--- a/src/cms/composer.lock
+++ b/src/cms/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "623dd7d576352fc123d2d4a5d8ae52bb",
+    "content-hash": "d9b1e9cc1da264dde30a90867f7d8f9d",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2506,21 +2506,21 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.15.1",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
-                "reference": "61443dfb33c62f308ee8add20f45b4d6e4bf8d2f",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.5.1",
+                "guzzlehttp/promises": "^2.5.2",
                 "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
@@ -2614,7 +2614,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.15.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -2630,20 +2630,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-18T11:23:11+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.5.1",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/9ad1e4fc607446a055b95870c7f668e93b5cff29",
-                "reference": "9ad1e4fc607446a055b95870c7f668e93b5cff29",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
@@ -2698,7 +2698,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.5.1"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -2714,7 +2714,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-08T15:48:39+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",


### PR DESCRIPTION
`composer audit` blokkeert op dit moment **alle** CI, ook op `main` zelf
([run](https://github.com/sourcehaven-bv/openvwr/actions/runs/31013117989)). De
audit-stap draait vóór de tests, dus geen enkele PR kan groen worden tot dit is
opgelost.

Twee advisories op `guzzlehttp/guzzle` 7.15.1, gepubliceerd op 3 augustus:

| CVE | Severity | Titel |
| --- | --- | --- |
| CVE-2026-69246 | high | Noncanonical host can bypass host-based checks |
| CVE-2026-69245 | medium | Noncanonical cookie domain keeps subdomain scope |

Beide zijn verholpen in 7.15.2.

## Wijziging

Alleen `composer.lock` — de constraint (`^7.2`) stond de update al toe:

- `guzzlehttp/guzzle` 7.15.1 → 7.15.3
- `guzzlehttp/promises` 2.5.1 → 2.5.2 (meegekomen als eigen dependency)

`composer.json` is ongewijzigd.

## Verificatie

- `composer audit --no-interaction --locked` (exact het CI-commando) → exit 0,
  "No security vulnerability advisories found"
- Volledige suite: 1892 tests groen

De 4 falende `HugoStaticWebsiteGeneratorTest`-tests falen ook op een schone `main`
in deze omgeving en staan los van deze wijziging.

## Waarom Dependabot dit niet zelf heeft opgepakt

Twee onafhankelijke oorzaken, allebei instellingen op repo-niveau:

1. **Dependabot security updates staan uit** — `automated-security-fixes` geeft
   `{"enabled": false}`. Dat is precies het mechanisme dat bij een advisory
   *direct* een PR aanmaakt.
2. **De scheduled run is wekelijks, op maandag.** De laatste run was 3 augustus
   (de dag dat de advisories verschenen); de eerstvolgende is maandag 10 augustus.

De `dependabot.yml` in dit project regelt alleen de *scheduled* version-updates.
Security-updates zijn een aparte schakelaar in Settings → Code security. Aanzetten
is de moeite waard: dan komt dit soort bump binnen enkele uren binnen in plaats van
bij de volgende wekelijkse run. Dat valt buiten deze PR, dus ik heb er niets aan
veranderd.

## Volgorde

Deze eerst mergen; daarna kan #92 (auth strategy) opnieuw draaien en groen worden.
