### PR TITLE
test: maak de CalendarDate-vergelijking deterministisch

### DIFF
--- a/src/cms/tests/Feature/ValueObjects/CalendarDateTest.php
+++ b/src/cms/tests/Feature/ValueObjects/CalendarDateTest.php
@@ -53,8 +53,12 @@ it('can compare equal dates', function (): void {
 });
 
 it('can compare equal dates of not equal', function (): void {
-    $date1 = CalendarDate::createFromFormat('Y-m-d', fake()->date());
-    $date2 = CalendarDate::createFromFormat('Y-m-d', fake()->unique()->date());
+    // Vaste, gegarandeerd verschillende datums. Eerder stond hier
+    // fake()->date() naast fake()->unique()->date(); unique() ontdubbelt alleen
+    // binnen zijn eigen reeks en kent de waarde van de eerste generator niet, dus
+    // die twee konden dezelfde datum opleveren en de test viel willekeurig om.
+    $date1 = CalendarDate::createFromFormat('Y-m-d', '2020-01-01');
+    $date2 = CalendarDate::createFromFormat('Y-m-d', '2021-06-15');
 
     $this->assertFalse($date1->equalTo($date2));
 });


### PR DESCRIPTION
`CalendarDateTest > it can compare equal dates of not equal` valt willekeurig om.
Geen probleem met de code — de test zelf is niet deterministisch:

```php
$date1 = CalendarDate::createFromFormat('Y-m-d', fake()->date());
$date2 = CalendarDate::createFromFormat('Y-m-d', fake()->unique()->date());

$this->assertFalse($date1->equalTo($date2));
```

`unique()` ontdubbelt alleen binnen zijn **eigen** reeks; het kent de waarde die de
eerste (niet-unique) generator al getrokken heeft niet. Beide kunnen dus dezelfde
datum opleveren, waarna de assertie "deze twee zijn níet gelijk" faalt.

## Wijziging

Twee vaste, gegarandeerd verschillende datums. Dat test precies hetzelfde gedrag,
maar zonder dobbelsteen.

## Verificatie

- Het hele bestand groen (18 tests)
- De betreffende test 15 keer op rij gedraaid: 0 failures

## Context

Dit kwam boven tijdens #92, waar het één keer rood werd en me op een verkeerd
spoor zette. De test staat los van die PR — vandaar apart, zodat het merge-baar is
zonder op #92 te wachten.

Ik heb de rest van de suite gecontroleerd op hetzelfde patroon: de overige
`unique()`-aanroepen gebruiken één verse waarde en vergelijken die niet met een
tweede generator, dus die zijn in orde.
